### PR TITLE
fix: ensure authManager is properly initialized to avoid missing 'self' error

### DIFF
--- a/ichub-backend/main.py
+++ b/ichub-backend/main.py
@@ -54,6 +54,9 @@ log_config:dict
 ## In memory storage/management services
 edc_service: edcService
 
+## In memory authentication manager service
+auth_manager: authManager
+
 urllib3.disable_warnings()
 logging.captureWarnings(True)
 
@@ -86,7 +89,7 @@ async def api_call(request: Request):
     """
     try:
         ## Check if the api key is present and if it is authenticated
-        if(not authManager.is_authenticated(request=request)):
+        if(not auth_manager.is_authenticated(request=request)):
             return httpTools.get_not_authorized()
         ## Standard way to know if user is calling or the EDC.
         calling_bpn = request.headers.get('Edc-Bpn', None)
@@ -104,11 +107,14 @@ async def api_call(request: Request):
         )
 
 def start(host:str, port:int, log_level:str="info"):
-    ## Load in memory data storages 
-    global edc_service
+    ## Load in memory data storages and authentication manager
+    global edc_service, auth_manager
     
     ## Start storage and edc communication service
     edc_service = edcService()
+
+    ## Start the authentication manager
+    auth_manager = authManager()
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")

--- a/tractusx_sdk/dataspace/main.py
+++ b/tractusx_sdk/dataspace/main.py
@@ -45,10 +45,14 @@ from tractusx_sdk.shared.managers import authManager
 from tractusx_sdk.dataspace.services import edcService
 from tractusx_sdk.shared.tools import op
 from tractusx_sdk.shared.tools import httpTools
+
 ## Declare Global Variables
 app_configuration:dict
 log_config:dict
 app = FastAPI(title="main")
+
+## In memory authentication manager service
+auth_manager: authManager
 
 ## In memory storage/management services
 edc_service: edcService
@@ -78,7 +82,7 @@ async def api_call(request: Request):
     """
     try:
         ## Check if the api key is present and if it is authenticated
-        if(not authManager.is_authenticated(request=request)):
+        if(not auth_manager.is_authenticated(request=request)):
             return httpTools.get_not_authorized()
         ## Standard way to know if user is calling or the EDC.
         calling_bpn = request.headers.get('Edc-Bpn', None)
@@ -96,11 +100,14 @@ async def api_call(request: Request):
         )
 
 def start(host:str, port:int, log_level:str="info"):
-    ## Load in memory data storages 
-    global edc_service
+    ## Load in memory data storages and authentication manager
+    global edc_service, auth_manager
     
     ## Start storage and edc communication service
     edc_service = edcService()
+
+    ## Start the authentication manager
+    auth_manager = authManager()
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")

--- a/tractusx_sdk/industry/main.py
+++ b/tractusx_sdk/industry/main.py
@@ -57,6 +57,9 @@ log_config:dict
 ## In memory storage/management services
 edc_service: edcService
 
+## In memory authentication manager service
+auth_manager: authManager
+
 urllib3.disable_warnings()
 logging.captureWarnings(True)
 
@@ -91,7 +94,7 @@ async def api_call(request: Request):
     """
     try:
         ## Check if the api key is present and if it is authenticated
-        if(not authManager.is_authenticated(request=request)):
+        if(not auth_manager.is_authenticated(request=request)):
             return httpTools.get_not_authorized()
         ## Standard way to know if user is calling or the EDC.
         calling_bpn = request.headers.get('Edc-Bpn', None)
@@ -109,11 +112,14 @@ async def api_call(request: Request):
         )
 
 def start(host:str, port:int, log_level:str="info"):
-    ## Load in memory data storages 
-    global edc_service
+    ## Load in memory data storages and authentication manager
+    global edc_service, auth_manager
     
     ## Start storage and edc communication service
     edc_service = edcService()
+
+    ## Start the authentication manager
+    auth_manager = authManager()
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")


### PR DESCRIPTION
## WHAT

Initialize the `authManager` in the `start` method in all three components: `ichub-backend`, `dataspace` and `industry`

## WHY

Without this initialization, the three components cannot perform the authentication step and will fail when querying.

## FURTHER NOTES

Closes #27 