### PR TITLE
feat: Integrate pytest and httpx as a new test framework alongside unittest

### DIFF
--- a/ichub-backend/main.py
+++ b/ichub-backend/main.py
@@ -122,11 +122,16 @@ def start():
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")
-    uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))        
+
+    # Only start the Uvicorn server if not in test mode
+    if not args.test_mode:
+        uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))        
     
 def get_arguments():
     
     parser = argparse.ArgumentParser()
+
+    parser.add_argument('--test-mode', action='store_true', help="Run in test mode (skips uvicorn.run())", required=False)
     
     parser.add_argument("--debug", default=False, action="store_false", help="Enable and disable the debug", required=False)
     

--- a/ichub-backend/requirements.txt
+++ b/ichub-backend/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.6.3
 pydantic-core==2.16.3
 sqlmodel==0.0.22
 pytest==8.1.1
+httpx==0.23.1

--- a/ichub-backend/requirements.txt
+++ b/ichub-backend/requirements.txt
@@ -4,3 +4,4 @@ Requests==2.32.3
 fastapi_keycloak_middleware==1.1.0
 pydantic==2.6.3
 pydantic-core==2.16.3
+pytest==8.1.1

--- a/ichub-backend/tests/test_main.py
+++ b/ichub-backend/tests/test_main.py
@@ -1,0 +1,53 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+import pytest
+import importlib
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+from tractusx_sdk.shared.managers.auth_manager import AuthManager
+main = importlib.import_module("ichub-backend.main")
+
+app = main.app
+
+# Set test_mode to True before running tests to skip uvicorn.run
+def set_test_mode():
+    import sys
+    sys.argv = sys.argv + ['--test-mode'] 
+
+@pytest.fixture
+def client():
+    set_test_mode()
+    main.start()
+    return TestClient(app)
+
+@pytest.fixture
+def mock_auth_manager():
+    """Mock the authentication manager."""
+    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
+        yield mock_auth
+
+def test_api_call_success(client):
+    """Test API call with successful authentication."""
+    response = client.get("/example")
+    assert response.status_code == 200
+    assert response.json() is None

--- a/ichub-backend/tests/test_main.py
+++ b/ichub-backend/tests/test_main.py
@@ -23,11 +23,7 @@
 import pytest
 import importlib
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, patch
-from tractusx_sdk.shared.managers.auth_manager import AuthManager
 main = importlib.import_module("ichub-backend.main")
-
-app = main.app
 
 # Set test_mode to True before running tests to skip uvicorn.run
 def set_test_mode():
@@ -38,16 +34,19 @@ def set_test_mode():
 def client():
     set_test_mode()
     main.start()
-    return TestClient(app)
-
-@pytest.fixture
-def mock_auth_manager():
-    """Mock the authentication manager."""
-    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
-        yield mock_auth
+    return TestClient(main.app)
 
 def test_api_call_success(client):
-    """Test API call with successful authentication."""
+    """
+    Test API call with successful authentication.
+
+    Args:
+        client: A test client instance used to simulate HTTP requests.
+
+    Assertions:
+        - The response status code must be 200.
+        - The response JSON must be None.
+    """
     response = client.get("/example")
-    assert response.status_code == 200
+    assert (200 == response.status_code)
     assert response.json() is None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 pythonpath = .
+filterwarnings =
+    ignore::PendingDeprecationWarning

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+cd ichub-backend
+pytest
+cd ..
+cd tractusx_sdk
+cd dataspace
+pytest
+cd ..
+cd industry
+pytest
+cd ..
+cd shared
+pytest

--- a/tractusx_sdk/dataspace/main.py
+++ b/tractusx_sdk/dataspace/main.py
@@ -122,11 +122,16 @@ def start():
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")
-    uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))       
+
+    # Only start the Uvicorn server if not in test mode
+    if not args.test_mode:
+        uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))         
     
 def get_arguments():
     
     parser = argparse.ArgumentParser()
+
+    parser.add_argument('--test-mode', action='store_true', help="Run in test mode (skips uvicorn.run())", required=False)
     
     parser.add_argument("--debug", default=False, action="store_false", help="Enable and disable the debug", required=False)
     

--- a/tractusx_sdk/dataspace/requirements.txt
+++ b/tractusx_sdk/dataspace/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.6.3
 pydantic-core==2.16.3
 sqlmodel==0.0.22
 pytest==8.1.1
+httpx==0.23.1

--- a/tractusx_sdk/dataspace/requirements.txt
+++ b/tractusx_sdk/dataspace/requirements.txt
@@ -4,3 +4,4 @@ Requests==2.32.3
 fastapi_keycloak_middleware==1.1.0
 pydantic==2.6.3
 pydantic-core==2.16.3
+pytest==8.1.1

--- a/tractusx_sdk/dataspace/tests/test_main.py
+++ b/tractusx_sdk/dataspace/tests/test_main.py
@@ -21,10 +21,7 @@
 #################################################################################
 
 import pytest
-import importlib
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, patch
-from tractusx_sdk.shared.managers.auth_manager import AuthManager
 from tractusx_sdk.dataspace import main
 
 # Set test_mode to True before running tests to skip uvicorn.run
@@ -38,14 +35,17 @@ def client():
     main.start()
     return TestClient(main.app)
 
-@pytest.fixture
-def mock_auth_manager():
-    """Mock the authentication manager."""
-    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
-        yield mock_auth
-
 def test_api_call_success(client):
-    """Test API call with successful authentication."""
+    """
+    Test API call with successful authentication.
+
+    Args:
+        client: A test client instance used to simulate HTTP requests.
+
+    Assertions:
+        - The response status code must be 200.
+        - The response JSON must be None.
+    """
     response = client.get("/example")
-    assert response.status_code == 200
+    assert (200 == response.status_code)
     assert response.json() is None

--- a/tractusx_sdk/dataspace/tests/test_main.py
+++ b/tractusx_sdk/dataspace/tests/test_main.py
@@ -1,0 +1,51 @@
+#################################################################################
+# Eclipse Tractus-X - Dataspace SDK
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+import pytest
+import importlib
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+from tractusx_sdk.shared.managers.auth_manager import AuthManager
+from tractusx_sdk.dataspace import main
+
+# Set test_mode to True before running tests to skip uvicorn.run
+def set_test_mode():
+    import sys
+    sys.argv = sys.argv + ['--test-mode'] 
+
+@pytest.fixture
+def client():
+    set_test_mode()
+    main.start()
+    return TestClient(main.app)
+
+@pytest.fixture
+def mock_auth_manager():
+    """Mock the authentication manager."""
+    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
+        yield mock_auth
+
+def test_api_call_success(client):
+    """Test API call with successful authentication."""
+    response = client.get("/example")
+    assert response.status_code == 200
+    assert response.json() is None

--- a/tractusx_sdk/industry/main.py
+++ b/tractusx_sdk/industry/main.py
@@ -129,11 +129,16 @@ def start():
     
     ## Once initial checks and configurations are done here is the place where it shall be included
     logger.info("[INIT] Application Startup Initialization Completed!")
-    uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))           
+
+    # Only start the Uvicorn server if not in test mode
+    if not args.test_mode:
+        uvicorn.run(app, host=args.host, port=args.port, log_level=("debug" if args.debug else "info"))      
     
 def get_arguments():
     
     parser = argparse.ArgumentParser()
+
+    parser.add_argument('--test-mode', action='store_true', help="Run in test mode (skips uvicorn.run())", required=False)
         
     parser.add_argument("--debug", default=False, action="store_false", help="Enable and disable the debug", required=False)
     

--- a/tractusx_sdk/industry/requirements.txt
+++ b/tractusx_sdk/industry/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.6.3
 pydantic-core==2.16.3
 sqlmodel==0.0.22
 pytest==8.1.1
+httpx==0.23.1

--- a/tractusx_sdk/industry/requirements.txt
+++ b/tractusx_sdk/industry/requirements.txt
@@ -4,3 +4,4 @@ Requests==2.32.3
 fastapi_keycloak_middleware==1.1.0
 pydantic==2.6.3
 pydantic-core==2.16.3
+pytest==8.1.1

--- a/tractusx_sdk/industry/tests/test_main.py
+++ b/tractusx_sdk/industry/tests/test_main.py
@@ -21,10 +21,7 @@
 #################################################################################
 
 import pytest
-import importlib
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, patch
-from tractusx_sdk.shared.managers.auth_manager import AuthManager
 from tractusx_sdk.industry import main
 
 # Set test_mode to True before running tests to skip uvicorn.run
@@ -38,14 +35,17 @@ def client():
     main.start()
     return TestClient(main.app)
 
-@pytest.fixture
-def mock_auth_manager():
-    """Mock the authentication manager."""
-    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
-        yield mock_auth
-
 def test_api_call_success(client):
-    """Test API call with successful authentication."""
+    """
+    Test API call with successful authentication.
+
+    Args:
+        client: A test client instance used to simulate HTTP requests.
+
+    Assertions:
+        - The response status code must be 200.
+        - The response JSON must be None.
+    """
     response = client.get("/example")
-    assert response.status_code == 200
+    assert (200 == response.status_code)
     assert response.json() is None

--- a/tractusx_sdk/industry/tests/test_main.py
+++ b/tractusx_sdk/industry/tests/test_main.py
@@ -1,0 +1,51 @@
+#################################################################################
+# Eclipse Tractus-X - Industry SDK
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+import pytest
+import importlib
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+from tractusx_sdk.shared.managers.auth_manager import AuthManager
+from tractusx_sdk.industry import main
+
+# Set test_mode to True before running tests to skip uvicorn.run
+def set_test_mode():
+    import sys
+    sys.argv = sys.argv + ['--test-mode'] 
+
+@pytest.fixture
+def client():
+    set_test_mode()
+    main.start()
+    return TestClient(main.app)
+
+@pytest.fixture
+def mock_auth_manager():
+    """Mock the authentication manager."""
+    with patch("tractusx_sdk.shared.managers.auth_.is_authenticated", new_callable=AsyncMock, return_value=True) as mock_auth:
+        yield mock_auth
+
+def test_api_call_success(client):
+    """Test API call with successful authentication."""
+    response = client.get("/example")
+    assert response.status_code == 200
+    assert response.json() is None

--- a/tractusx_sdk/shared/tests/manager/__init__.py
+++ b/tractusx_sdk/shared/tests/manager/__init__.py
@@ -1,0 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+# Package-level variables
+__author__ = 'Eclipse Tractus-X Contributors'
+__license__ = "Apache License, Version 2.0"

--- a/tractusx_sdk/shared/tests/manager/test_auth_manager.py
+++ b/tractusx_sdk/shared/tests/manager/test_auth_manager.py
@@ -1,0 +1,65 @@
+#################################################################################
+# Eclipse Tractus-X - Software Development KIT
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+import unittest
+from unittest.mock import Mock
+from fastapi import Request
+from starlette.datastructures import Headers
+from tractusx_sdk.shared.managers.auth_manager import AuthManager
+
+class TestAuthManager(unittest.TestCase):
+
+    def setUp(self):
+        """Set up default values for testing."""
+        self.auth_manager = AuthManager(
+            configured_api_key="test_key",
+            api_key_header="X-Api-Key",
+            auth_enabled=True
+        )
+
+    def test_auth_disabled_always_returns_true(self):
+        """Test when authentication is disabled, it always returns True."""
+        self.auth_manager.auth_enabled = False
+        mock_request = Mock(spec=Request)
+        self.assertTrue(self.auth_manager.is_authenticated(mock_request))
+
+    def test_missing_api_key_header_returns_false(self):
+        """Test when the API key header is missing, it returns False."""
+        mock_request = Mock(spec=Request)
+        mock_request.headers = Headers({})  # Empty headers
+        self.assertFalse(self.auth_manager.is_authenticated(mock_request))
+
+    def test_invalid_api_key_returns_false(self):
+        """Test when an incorrect API key is provided, it returns False."""
+        mock_request = Mock(spec=Request)
+        mock_request.headers = Headers({"X-Api-Key": "wrong_key"})
+        self.assertFalse(self.auth_manager.is_authenticated(mock_request))
+
+    def test_valid_api_key_returns_true(self):
+        """Test when the correct API key is provided, it returns True."""
+        mock_request = Mock(spec=Request)
+        mock_request.headers = Headers({"X-Api-Key": "test_key"})
+        self.assertTrue(self.auth_manager.is_authenticated(mock_request))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## WHAT

- Added `pytest` and `httpx` as a new testing frameworks to complement `unittest` for project testing.
- Implemented tests for `AuthManager` and the `/example` endpoints to verify that the initial configuration works as expected.

## WHY

Ensures that the new frameworks pass the `DEPENDENCY-CHECK`.

## FURTHER NOTES

![image](https://github.com/user-attachments/assets/832d180f-e35c-4b0b-9f8f-790045178380)


Refers to #29  
