### PR TITLE
feat: Add security TRG KICS

### DIFF
--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: "." # Scanning directory .
           output_path: kicsResults/ # Output path for SARIF results
-          output_formats: "sarif" # Output format
+          output_formats: "json,sarif" # Output format
           # ignore_on_exit: results # Ignore the results and return exit status code 0 unless a KICS engine error happens
           fail_on: high # If you want your pipeline to fail only on high severity results and KICS engine execution errors
           # exclude_paths: "terraform/gcp/big_data.tf,terraform/azure" # Exclude paths or files from scan

--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -1,0 +1,66 @@
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: KICS
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.txt"
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.txt"
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Run KICS Scan with SARIF result
+        uses: checkmarx/kics-github-action@v1.7.0
+        with:
+          path: "." # Scanning directory .
+          output_path: kicsResults/ # Output path for SARIF results
+          output_formats: "sarif" # Output format
+          # ignore_on_exit: results # Ignore the results and return exit status code 0 unless a KICS engine error happens
+          fail_on: high # If you want your pipeline to fail only on high severity results and KICS engine execution errors
+          # exclude_paths: "terraform/gcp/big_data.tf,terraform/azure" # Exclude paths or files from scan
+          # exclude_queries: 0437633b-daa6-4bbc-8526-c0d2443b946e # Exclude accepted queries from the build
+          disable_secrets: true # No secret scanning
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: kicsResults/results.sarif

--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run KICS Scan with SARIF result
-        uses: checkmarx/kics-github-action@v1.7.0
+        uses: checkmarx/kics-github-action@3246fb456a46d1ea8848ae18793c036718b19fe0 # v2.1.5
         with:
           path: "." # Scanning directory .
           output_path: kicsResults/ # Output path for SARIF results
@@ -61,6 +61,6 @@ jobs:
           disable_secrets: true # No secret scanning
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           sarif_file: kicsResults/results.sarif


### PR DESCRIPTION
## WHAT

Add the KICS workflow.

## WHY

[KICS](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-02/) is deployed for comprehensive scanning of Infrastructure as Code (IaC) files, ensuring secure and best-practice configurations across various IaC frameworks.

## FURTHER NOTES

Related to #2 