### PR TITLE
feat: Add security TRG Trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,139 @@
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: "Trivy"
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+env:
+  IMAGE_NAMESPACE: 'tractusx'
+  ICHUB_BACKEND_IMAGE_NAME: "ichub-backend"
+  DATASPACE_SDK_IMAGE_NAME: "dataspace-sdk"
+  INDUSTRY_SDK_IMAGE_NAME: "industry-sdk"
+
+jobs:
+  analyze-ichub-backend:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build ichub-backend Docker image
+        id: build-docker-ichub-backend
+        run: |
+            cd ichub-backend
+            docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.ICHUB_BACKEND_IMAGE_NAME }}:latest .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+        with:
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.ICHUB_BACKEND_IMAGE_NAME }}:latest" # Pull image from Docker Hub and run Trivy vulnerability scanner
+          format: "sarif"
+          output: "trivy-results-ichub-backend.sarif"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
+        if: always()
+        with:
+          sarif_file: "trivy-results-ichub-backend.sarif"
+
+  analyze-dataspace-sdk:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build dataspace-sdk Docker image
+        id: build-docker-dataspace-sdk
+        run: |
+            cd tractusx_sdk/dataspace
+            docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.DATASPACE_SDK_IMAGE_NAME }}:latest .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+        with:
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.DATASPACE_SDK_IMAGE_NAME }}:latest" # Pull image from Docker Hub and run Trivy vulnerability scanner
+          format: "sarif"
+          output: "trivy-results-dataspace-sdk.sarif"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
+        if: always()
+        with:
+          sarif_file: "trivy-results-dataspace-sdk.sarif"
+
+  analyze-industry-sdk:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build industry-sdk Docker image
+        id: build-docker-industry-sdk
+        run: |
+            cd tractusx_sdk/dataspace
+            docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.INDUSTRY_SDK_IMAGE_NAME }}:latest .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+        with:
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.INDUSTRY_SDK_IMAGE_NAME }}:latest" # Pull image from Docker Hub and run Trivy vulnerability scanner
+          format: "sarif"
+          output: "trivy-results-industry-sdk.sarif"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
+        if: always()
+        with:
+          sarif_file: "trivy-results-industry-sdk.sarif"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   analyze-ichub-backend:
-    name: Analyze
+    name: Analyze ICHub Backend
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -69,7 +69,7 @@ jobs:
           sarif_file: "trivy-results-ichub-backend.sarif"
 
   analyze-dataspace-sdk:
-    name: Analyze
+    name: Analyze Dataspace SDK
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -104,7 +104,7 @@ jobs:
           sarif_file: "trivy-results-dataspace-sdk.sarif"
 
   analyze-industry-sdk:
-    name: Analyze
+    name: Analyze Industry SDK
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -118,7 +118,7 @@ jobs:
       - name: Build industry-sdk Docker image
         id: build-docker-industry-sdk
         run: |
-            cd tractusx_sdk/dataspace
+            cd tractusx_sdk/industry
             docker build -t ${{ env.IMAGE_NAMESPACE }}/${{ env.INDUSTRY_SDK_IMAGE_NAME }}:latest .
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## WHAT

Add the Trivy workflow.

## WHY

[Trivy](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-04/) scans our Docker containers to accurately identify and remediate vulnerabilities in OS packages and application dependencies, ensuring our environment remains secure.

## FURTHER NOTES

Related to #2 