### PR TITLE
fix: Update codeql.yml for checks in GH Action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ on:
     paths-ignore:
       - "**/*.md"
       - "**/*.txt"
+      - "**/.github/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,12 +47,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: ["python"] # Define languages here
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout repository
@@ -62,7 +56,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          languages: ${{ matrix.language }}
+          languages: "python"
           # If you wish to specify custom queries, you can do so here or in a config file
           # By default, queries listed here will override any specified in a config file
           # Prefix the list here with "+" to use these queries and those in the config file

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,13 @@ name: "CodeQL"
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.txt"
-      - "**/.github/**"
+    paths:
+      - "ichub-backend"
+      - "ichub-frontend"
   pull_request:
     paths-ignore:
-      - "**/*.md"
-      - "**/*.txt"
-      - "**/.github/**"
+      - "ichub-backend"
+      - "ichub-frontend"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
@@ -47,6 +45,12 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        language: ["python"] # Define languages here
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout repository
@@ -56,7 +60,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          languages: "python"
+          languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file
           # By default, queries listed here will override any specified in a config file
           # Prefix the list here with "+" to use these queries and those in the config file
@@ -83,4 +87,5 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          category: "/language:python"
+          category: "/language:${{matrix.language}}"
+          fail-on: error

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - "ichub-backend/**/*.py"
       - "ichub-frontend/**/*.py"
+    paths-ignore:
       - "**/*.yml"
       - "**/*.yaml"
       - "**/*.md"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,12 +23,12 @@ on:
   push:
     branches: ["main"]
     paths:
-      - "ichub-backend"
-      - "ichub-frontend"
+      - "ichub-backend/**"
+      - "ichub-frontend/**"
   pull_request:
-    paths-ignore:
-      - "ichub-backend"
-      - "ichub-frontend"
+    paths:
+      - "ichub-backend/**"
+      - "ichub-frontend/**"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,12 +23,21 @@ on:
   push:
     branches: ["main"]
     paths:
-      - "ichub-backend/**"
-      - "ichub-frontend/**"
+      - "ichub-backend/**/*.py"
+      - "ichub-frontend/**/*.py"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.md"
+      - "**/*.txt"
   pull_request:
     paths:
-      - "ichub-backend/**"
-      - "ichub-frontend/**"
+      - "ichub-backend/**/*.py"
+      - "ichub-frontend/**/*.py"
+    paths-ignore:
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.md"
+      - "**/*.txt"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,10 @@ on:
       - "**/*.txt"
       - "**/.github/**"
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["main"]
     paths-ignore:
       - "**/*.md"
       - "**/*.txt"
+      - "**/.github/**"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
@@ -85,4 +84,3 @@ jobs:
         uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           category: "/language:python"
-          fail-on: error

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,12 +69,6 @@ jobs:
           # Use +security-extended,security-and-quality for wider security and better code quality
           queries: +security-extended,security-and-quality
 
-      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift)
-      # Automates dependency installation for Python, Ruby, and JavaScript, optimizing the CodeQL analysis setup
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
-
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,15 +43,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["python"] # Define languages here
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -60,7 +51,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          languages: ${{ matrix.language }}
+          languages: python
           # If you wish to specify custom queries, you can do so here or in a config file
           # By default, queries listed here will override any specified in a config file
           # Prefix the list here with "+" to use these queries and those in the config file
@@ -81,5 +72,5 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:python"
           fail-on: error

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,5 +89,5 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:python"
           fail-on: error

--- a/ichub-backend/services/__init__.py
+++ b/ichub-backend/services/__init__.py
@@ -21,5 +21,6 @@
 #################################################################################
 
 # Package-level variables
+# Testing
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/ichub-backend/services/__init__.py
+++ b/ichub-backend/services/__init__.py
@@ -21,6 +21,5 @@
 #################################################################################
 
 # Package-level variables
-# Testing
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/ichub-backend/services/__init__.py
+++ b/ichub-backend/services/__init__.py
@@ -21,6 +21,5 @@
 #################################################################################
 
 # Package-level variables
-# Comment for test
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"

--- a/ichub-backend/services/__init__.py
+++ b/ichub-backend/services/__init__.py
@@ -21,5 +21,6 @@
 #################################################################################
 
 # Package-level variables
+# Comment for test
 __author__ = 'Eclipse Tractus-X Contributors'
 __license__ = "Apache License, Version 2.0"


### PR DESCRIPTION
I have tested this change in my repository and works fine when executes checks.

I have changed that the GH Actions only executes when there are codes changed being made, so that it doesn't gives as an error when other types of files.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
