### PR TITLE
feat: add frontend dependencies check workflow

### DIFF
--- a/.github/workflows/dependencies-frontend.yaml
+++ b/.github/workflows/dependencies-frontend.yaml
@@ -1,0 +1,88 @@
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: Check Frontend Dependencies
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ichub-frontend/package-lock.json
+      - DEPENDENCIES_ICHUB-FRONTEND
+      - .github/workflows/dependencies-frontend.yaml
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ichub-frontend/package-lock.json
+      - DEPENDENCIES_ICHUB-FRONTEND
+      - .github/workflows/dependencies-frontend.yaml
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generate Dependencies file
+        run: |
+          curl -L --output ./dash.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST'
+
+          java -jar ./dash.jar ichub-frontend/package-lock.json -project automotive.tractusx -summary DEPENDENCIES_ICHUB-FRONTEND || true
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES_ICHUB-FRONTEND)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES_ICHUB-FRONTEND || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES_ICHUB-FRONTEND file
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          path: DEPENDENCIES_ICHUB-FRONTEND
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES_ICHUB
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES_ICHUB file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->
## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Adds a workflow to run the eclipse dash license checker each time frontend dependencies are updated.

Similar to #51
Related to #2 

Based in the portal-frontend workflow: https://github.com/eclipse-tractusx/portal-frontend/blob/main/.github/workflows/dependencies.yaml
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
