### PR TITLE
chore(helm): add Postgres DSN connection string

### DIFF
--- a/charts/industry-core-hub/README.md
+++ b/charts/industry-core-hub/README.md
@@ -65,7 +65,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | backend.securityContext.runAsNonRoot | bool | `true` | Requires the container to run without root privileges |
 | backend.securityContext.runAsUser | int | `10000` | The container's process will run with the specified uid |
 | backend.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service |
-| externalDatabase | object | `{"database":"postgres","existingIchubSecretKey":"ichub-password","existingSecret":"","host":"","ichubPassword":"","ichubUser":"ichub","port":5432}` | External database configuration (used when postgresql.enabled is false) |
+| externalDatabase | object | `{"database":"postgres","existingIchubSecretKey":"ichub-password","existingSecret":"","host":"","ichubPassword":"","ichubUser":"ichub","port":5432,"sslMode":"prefer"}` | External database configuration (used when postgresql.enabled is false) |
 | externalDatabase.database | string | `"postgres"` | External PostgreSQL database name |
 | externalDatabase.existingIchubSecretKey | string | `"ichub-password"` | Key in the existing secret that contains database password for ichub user |
 | externalDatabase.existingSecret | string | `""` | Existing secret containing database password |
@@ -73,6 +73,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | externalDatabase.ichubPassword | string | `""` | External PostgreSQL password for ichub user |
 | externalDatabase.ichubUser | string | `"ichub"` | External PostgreSQL username for ichub user |
 | externalDatabase.port | int | `5432` | External PostgreSQL port |
+| externalDatabase.sslMode | string | `"prefer"` | Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server. There are [six modes](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) |
 | frontend.additionalVolumeMounts | list | `[]` | specifies additional volume mounts for the backend deployment |
 | frontend.additionalVolumes | list | `[]` | additional volume claims for the containers |
 | frontend.enabled | bool | `true` |  |
@@ -117,13 +118,14 @@ helm install industry-core-hub tractusx/industry-core-hub
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | pgadmin4 | object | `{"enabled":false,"env":{"email":"pgadmin4@txtest.org","password":"tractusxpgadmin4"},"ingress":{"enabled":false},"persistentVolume":{"enabled":false}}` | pgAdmin4 configuration |
-| postgresql | object | `{"audit":{"logLinePrefix":"%m %u %d ","pgAuditLog":"write, ddl"},"auth":{"database":"ichub-postgres","existingSecret":"ichub-postgres-secret","ichubPassword":"","ichubUser":"ichub","password":"","port":5432},"enabled":true,"fullnameOverride":"","nameOverride":"","primary":{"extendedConfiguration":"","extraEnvVars":[{"name":"ICHUB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"ichub-password","name":"{{ .Values.auth.existingSecret }}"}}}],"initdb":{"scriptsConfigMap":"{{ .Release.Name }}-cm-postgres"},"persistence":{"enabled":true,"size":"10Gi","storageClass":""}}}` | PostgreSQL chart configuration |
+| postgresql | object | `{"audit":{"logLinePrefix":"%m %u %d ","pgAuditLog":"write, ddl"},"auth":{"database":"ichub-postgres","existingSecret":"ichub-postgres-secret","ichubPassword":"","ichubUser":"ichub","password":"","port":5432,"sslMode":"prefer"},"enabled":true,"fullnameOverride":"","nameOverride":"","primary":{"extendedConfiguration":"","extraEnvVars":[{"name":"ICHUB_PASSWORD","valueFrom":{"secretKeyRef":{"key":"ichub-password","name":"{{ .Values.auth.existingSecret }}"}}}],"initdb":{"scriptsConfigMap":"{{ .Release.Name }}-cm-postgres"},"persistence":{"enabled":true,"size":"10Gi","storageClass":""}}}` | PostgreSQL chart configuration |
 | postgresql.auth.database | string | `"ichub-postgres"` | Database name |
 | postgresql.auth.existingSecret | string | `"ichub-postgres-secret"` | Secret containing the passwords for root usernames postgres and non-root usernames repl_user and ichub. |
 | postgresql.auth.ichubPassword | string | `""` | Password for the non-root username 'ichub'. Secret-key 'ichub-password'. |
 | postgresql.auth.ichubUser | string | `"ichub"` | Non-root username for ichub. |
 | postgresql.auth.password | string | `""` | Password for the root username 'postgres' (will be stored in a secret if existingSecret is not provided) |
 | postgresql.auth.port | int | `5432` | Database port number |
+| postgresql.auth.sslMode | string | `"prefer"` | Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server. There are [six modes](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) |
 | postgresql.enabled | bool | `true` | Switch to enable or disable the PostgreSQL helm chart |
 | postgresql.primary.extendedConfiguration | string | `""` | Extended PostgreSQL Primary configuration (increase of max_connections recommended - default is 100) |
 | postgresql.primary.persistence.enabled | bool | `true` | Enable persistent storage |

--- a/charts/industry-core-hub/templates/_helpers.tpl
+++ b/charts/industry-core-hub/templates/_helpers.tpl
@@ -193,6 +193,17 @@ Get the database name
 {{- end -}}
 
 {{/*
+Get the sslMode
+*/}}
+{{- define "industry-core-hub.postgresql.sslMode" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.sslMode -}}
+{{- else -}}
+{{- .Values.externalDatabase.sslMode -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the database secret key
 */}}
 {{- define "industry-core-hub.postgresql.ichub.secretKey" -}}
@@ -227,4 +238,16 @@ Get the postgres configmap name
 */}}
 {{- define "industry-core-hub.postgresql.configmap" -}}
 {{- printf "%s-cm-postgres" .Release.Name -}}
+{{- end -}}
+
+{{/*
+Return the postgresql DSN URL
+*/}}
+{{- define "industry-core-hub.postgresql.dsn" -}}
+{{- $host := include "industry-core-hub.postgresql.host" . -}}
+{{- $port := include "industry-core-hub.postgresql.port" . -}}
+{{- $name := include "industry-core-hub.postgresql.databaseName" . -}}
+{{- $user := include "industry-core-hub.postgresql.ichubUser" . -}}
+{{- $sslMode := include "industry-core-hub.postgresql.sslMode" . -}}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s?sslmode=%s" $user $host $port $name $sslMode -}}
 {{- end -}}

--- a/charts/industry-core-hub/templates/deployment-backend.yaml
+++ b/charts/industry-core-hub/templates/deployment-backend.yaml
@@ -62,19 +62,13 @@ spec:
               containerPort: {{ .Values.backend.service.port }}
               protocol: TCP
           env:
-            - name: DATABASE__HOST
-              value: {{ include "industry-core-hub.postgresql.host" . }}
-            - name: DATABASE_PORT
-              value: {{ include "industry-core-hub.postgresql.port" . | quote }}
-            - name: DATABASE_NAME
-              value: {{ include "industry-core-hub.postgresql.databaseName" . }}
-            - name: DATABASE_USER
-              value: {{ include "industry-core-hub.postgresql.ichubUser" . }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "industry-core-hub.postgresql.secretName" . }}
                   key: {{ include "industry-core-hub.postgresql.ichub.secretKey" . }}
+            - name: DATABASE_CONNECTION_STRING
+              value: {{ include "industry-core-hub.postgresql.dsn" . | quote }}
           {{- if .Values.backend.healthChecks.startup.enabled }}
           startupProbe:
             httpGet:

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -288,6 +288,8 @@ postgresql:
     ichubUser: "ichub"
     # -- Password for the non-root username 'ichub'. Secret-key 'ichub-password'.
     ichubPassword: ""
+    # -- Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server. There are [six modes](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE)
+    sslMode: "prefer"
   audit:
     pgAuditLog: "write, ddl"
     logLinePrefix: "%m %u %d "
@@ -338,6 +340,8 @@ externalDatabase:
   existingSecret: ""
   # -- Key in the existing secret that contains database password for ichub user
   existingIchubSecretKey: "ichub-password"
+  # -- Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server. There are [six modes](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE)
+  sslMode: "prefer"
 
 # [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to constrain pods to nodes
 nodeSelector: {}


### PR DESCRIPTION
## Description
This pull request introduces an environment variable to the backend deployment that contains a PostgreSQL connection string. Additionally, it adds support for modifying the preferred sslMode for the PostgreSQL connection.

As part of this update, the old environment variables DATABASE_HOST, DATABASE_USER, and DATABASE_PORT have been removed, as their values are now incorporated into the connection string. This connection string will serve as the primary method for establishing a connection to the database.

It must be merged before: #132 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
