### PR TITLE
fix(helm-chart): update PostgreSQL host definition to use fullname

### DIFF
--- a/charts/industry-core-hub/templates/_helpers.tpl
+++ b/charts/industry-core-hub/templates/_helpers.tpl
@@ -118,7 +118,7 @@ Get the database host
 */}}
 {{- define "industry-core-hub.postgresql.host" -}}
 {{- if .Values.postgresql.enabled }}
-{{- (include "industry-core-hub.fullname" .) -}}
+{{- (include "industry-core-hub.postgresql.fullname" .) -}}
 {{- else -}}
 {{- .Values.externalDatabase.host -}}
 {{- end -}}


### PR DESCRIPTION
## Description
This pull request includes a change to the `charts/industry-core-hub/templates/_helpers.tpl` file to correctly reference the PostgreSQL host. The modification ensures that the correct fullname template is used when PostgreSQL is enabled.

Fixed URL:
![image](https://github.com/user-attachments/assets/b9198195-3ec1-45be-b48f-ae3490f71e58)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
The bug was introduced in #150 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
