### PR TITLE
fix: separate backend and frontend labels in Helm templates

### DIFF
--- a/charts/industry-core-hub/templates/_helpers.tpl
+++ b/charts/industry-core-hub/templates/_helpers.tpl
@@ -71,11 +71,26 @@ Common labels
 */}}
 {{- define "industry-core-hub.labels" -}}
 helm.sh/chart: {{ include "industry-core-hub.chart" . }}
-{{ include "industry-core-hub.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Backend labels (includes backend selector labels)
+*/}}
+{{- define "industry-core-hub.backend.labels" -}}
+{{ include "industry-core-hub.backend.selectorLabels" . }}
+{{ include "industry-core-hub.labels" . }}
+{{- end }}
+
+{{/*
+Frontend labels (includes frontend selector labels)
+*/}}
+{{- define "industry-core-hub.frontend.labels" -}}
+{{ include "industry-core-hub.frontend.selectorLabels" . }}
+{{ include "industry-core-hub.labels" . }}
 {{- end }}
 
 {{/*

--- a/charts/industry-core-hub/templates/deployment-backend.yaml
+++ b/charts/industry-core-hub/templates/deployment-backend.yaml
@@ -24,14 +24,14 @@ kind: Deployment
 metadata:
   name: {{ include "industry-core-hub.fullname.backend" . }}
   labels:
-    {{- include "industry-core-hub.labels" . | nindent 4 }}
+    {{- include "industry-core-hub.backend.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
-      {{- include "industry-core-hub.selectorLabels" . | nindent 6 }}
+      {{- include "industry-core-hub.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.backend.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "industry-core-hub.labels" . | nindent 8 }}
+        {{- include "industry-core-hub.backend.labels" . | nindent 8 }}
         {{- with .Values.backend.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/industry-core-hub/templates/deployment-frontend.yaml
+++ b/charts/industry-core-hub/templates/deployment-frontend.yaml
@@ -25,14 +25,14 @@ kind: Deployment
 metadata:
   name: {{ include "industry-core-hub.fullname.frontend" . }}
   labels:
-    {{- include "industry-core-hub.labels" . | nindent 4 }}
+    {{- include "industry-core-hub.frontend.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
-      {{- include "industry-core-hub.selectorLabels" . | nindent 6 }}
+      {{- include "industry-core-hub.frontend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.frontend.podAnnotations }}
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "industry-core-hub.labels" . | nindent 8 }}
+        {{- include "industry-core-hub.frontend.labels" . | nindent 8 }}
         {{- with .Values.frontend.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/industry-core-hub/templates/pvc-data-backend.yaml
+++ b/charts/industry-core-hub/templates/pvc-data-backend.yaml
@@ -25,7 +25,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-pvc-data-backend
   labels:
-    {{- include "industry-core-hub.labels" . | nindent 4 }}
+    {{- include "industry-core-hub.backend.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.backend.persistence.data.annotations }}
   annotations:
@@ -49,7 +49,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-pvc-logs-backend
   labels:
-    {{- include "industry-core-hub.labels" . | nindent 4 }}
+    {{- include "industry-core-hub.backend.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.backend.persistence.logs.annotations }}
   annotations:

--- a/charts/industry-core-hub/templates/secret-backend-postgres.yaml
+++ b/charts/industry-core-hub/templates/secret-backend-postgres.yaml
@@ -26,7 +26,7 @@ metadata:
   name: {{ .Values.postgresql.auth.existingSecret }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "industry-core-hub.labels" . | nindent 4 }}
+    {{- include "industry-core-hub.backend.labels" . | nindent 4 }}
 type: Opaque
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.postgresql.auth.existingSecret) }}
 {{ if and  $secret $secret.data -}}

--- a/charts/industry-core-hub/templates/service-backend.yaml
+++ b/charts/industry-core-hub/templates/service-backend.yaml
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "industry-core-hub.fullname.backend" . }}
-  labels: {{ include "industry-core-hub.labels" . | nindent 4 }}
+  labels: {{ include "industry-core-hub.backend.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.backend.service.type }}
   ports:
@@ -32,5 +32,5 @@ spec:
       targetPort: {{ .Values.backend.service.targetPort }}
       protocol: TCP
       name: http
-  selector: {{ include "industry-core-hub.frontend.selectorLabels" . | nindent 4 }}
+  selector: {{ include "industry-core-hub.backend.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/industry-core-hub/templates/service-frontend.yaml
+++ b/charts/industry-core-hub/templates/service-frontend.yaml
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "industry-core-hub.fullname.frontend" . }}
-  labels: {{ include "industry-core-hub.labels" . | nindent 4 }}
+  labels: {{ include "industry-core-hub.frontend.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:


### PR DESCRIPTION
## Description
This pull request includes changes to the Helm chart templates for the `industry-core-hub` to improve label management by introducing separate label definitions for backend and frontend components. 

Previously, both backend and frontend were using the same labels, which can be problematic for selector labels and could confuse Kubernetes.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
