### PR TITLE
fix(TRG 5.04): match memory request and limit for frontend

### DIFF
--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -262,7 +262,7 @@ frontend:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
       ephemeral-storage: "128Mi"
     limits:
       cpu: 500m


### PR DESCRIPTION
## Description
Frontend deployment memory resource didn't match request and limit, so it wasn't compliant with TRG 5.04.
https://eclipse-tractusx.github.io/sig-release/
![image](https://github.com/user-attachments/assets/37b20b71-7939-4a9c-af13-6204ef9d772b)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
