### PR TITLE
fix(license-verification): update license header verification to exclude docker notice files

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Verify the MD footer
               run: |-
-                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md . | grep -v '^./[^/]*$'"
+                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude=docker-notice-ichub-\* . | grep -v '^./[^/]*$'"
                 violations=$(eval $cmd | wc -l)
                 if [[ $violations -ne 0 ]] ; then
                     echo "$violations files without license headers were found:";


### PR DESCRIPTION
## Description
#162 introduced docker notice files for the docker images, these files can't include license notice like other .md files, so I have added an exclusion tag in the verification workflow.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
