### PR TITLE
chore: bump TractusX-SDK version

### DIFF
--- a/DEPENDENCIES_ICHUB-BACKEND
+++ b/DEPENDENCIES_ICHUB-BACKEND
@@ -39,6 +39,7 @@ pypi/pypi/-/pytest/8.1.1, MIT, approved, #19365
 pypi/pypi/-/python-dotenv/1.0.1, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 pypi/pypi/-/python-keycloak/4.0.1, MIT, approved, clearlydefined
 pypi/pypi/-/python-multipart/0.0.20, Apache-2.0, approved, clearlydefined
+pypi/pypi/-/requests-mock/1.12.1, Apache-2.0, approved, clearlydefined
 pypi/pypi/-/requests-toolbelt/1.0.0, Apache-2.0, approved, #15024
 pypi/pypi/-/requests/2.32.3, Apache-2.0 AND MIT AND Apache-2.0, approved, #14884
 pypi/pypi/-/rfc3986/1.5.0, Apache-2.0, approved, #19390

--- a/DEPENDENCIES_ICHUB-BACKEND
+++ b/DEPENDENCIES_ICHUB-BACKEND
@@ -49,7 +49,7 @@ pypi/pypi/-/sniffio/1.3.1, Apache-2.0 OR (Apache-2.0 AND MIT), approved, clearly
 pypi/pypi/-/sqlmodel/0.0.22, MIT, approved, clearlydefined
 pypi/pypi/-/starlette/0.40.0, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 pypi/pypi/-/tomli/2.0.1, MIT, approved, #7824
-pypi/pypi/-/tractusx_sdk/0.0.2, Apache-2.0 AND CC-BY-4.0, approved, #20505
+pypi/pypi/-/tractusx_sdk/0.0.3, Apache-2.0 AND CC-BY-4.0, approved, #20505
 pypi/pypi/-/typer/0.15.1, MIT, approved, clearlydefined
 pypi/pypi/-/typing_extensions/4.12.2, Python-2.0, approved, #19383
 pypi/pypi/-/urllib3/2.3.0, MIT AND Python-2.0 AND MPL-2.0, approved, #19863

--- a/ichub-backend/requirements.txt
+++ b/ichub-backend/requirements.txt
@@ -50,7 +50,7 @@ SQLAlchemy==2.0.38
 sqlmodel==0.0.22
 starlette==0.40.0
 tomli==2.0.1
-tractusx_sdk==0.0.2
+tractusx_sdk==0.0.3
 typer==0.15.1
 typing_extensions==4.12.2
 urllib3==2.3.0


### PR DESCRIPTION
## Description
Update the TractusX-SDK to the latest version.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
