### PR TITLE
Chore: set dockerhub as repo in helm chart

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -70,20 +70,6 @@ jobs:
           # default value for event_name != workflow_dispatch
           node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
-      - name: Build backend image
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        with:
-          context: "{{defaultContext}}:ichub-backend"
-          push: true
-          tags: kind-registry:5000/ichub-backend:testing
-
-      - name: Build frontend image
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        with:
-          context: "{{defaultContext}}:ichub-frontend"
-          push: true
-          tags: kind-registry:5000/ichub-frontend:testing
-
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4
         with:
@@ -113,7 +99,7 @@ jobs:
           helm repo add runix https://helm.runix.net
 
       - name: Run chart-testing (install)
-        run: ct install --charts charts/industry-core-hub --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set backend.image.repository=kind-registry:5000/ichub-backend --set backend.image.tag=testing --set frontend.image.repository=kind-registry:5000/ichub-frontend --set frontend.image.tag=testing"
+        run: ct install --charts charts/industry-core-hub --target-branch ${{ github.event.repository.default_branch }}
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
         # Upgrade the released chart version with the locally available chart

--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: industry-core-hub
 type: application
 appVersion: "0.0.1"
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart for Eclipse Tractus-X - Industry Core Hub
 home: https://github.com/eclipse-tractusx/industry-core-hub
 sources:

--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: industry-core-hub
 type: application
 appVersion: "0.0.1"
-version: 0.1.2
+version: 0.1.3
 description: A Helm chart for Eclipse Tractus-X - Industry Core Hub
 home: https://github.com/eclipse-tractusx/industry-core-hub
 sources:

--- a/charts/industry-core-hub/README.md
+++ b/charts/industry-core-hub/README.md
@@ -1,6 +1,6 @@
 # A Helm chart for Eclipse Tractus-X - Industry Core Hub
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Eclipse Tractus-X - Industry Core Hub
 
@@ -35,7 +35,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| backend | object | `{"additionalVolumeMounts":[],"additionalVolumes":[],"enabled":false,"healthChecks":{"liveness":{"enabled":false,"path":"/"},"readiness":{"enabled":false,"path":"/"},"startup":{"enabled":false,"path":"/"}},"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"repository":"ichub-backend","tag":""},"ingress":{"className":"nginx","enabled":false,"hosts":[{"host":"","paths":[{"backend":{"port":8000,"service":"backend"},"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]},"name":"industry-core-hub-backend","persistence":{"data":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":"standard"},"enabled":true,"logs":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":"standard"}},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"fsGroup":3000,"runAsGroup":3000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"resources":{"limits":{"cpu":"500m","ephemeral-storage":"2Gi","memory":"512Mi"},"requests":{"cpu":"250m","ephemeral-storage":"2Gi","memory":"512Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10000},"service":{"port":80,"targetPort":8000,"type":"ClusterIP"}}` | Backend configuration |
+| backend | object | `{"additionalVolumeMounts":[],"additionalVolumes":[],"enabled":true,"healthChecks":{"liveness":{"enabled":false,"path":"/"},"readiness":{"enabled":false,"path":"/"},"startup":{"enabled":false,"path":"/"}},"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"repository":"tractusx/industry-core-hub-backend","tag":""},"ingress":{"className":"nginx","enabled":false,"hosts":[{"host":"","paths":[{"backend":{"port":8000,"service":"backend"},"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]},"name":"industry-core-hub-backend","persistence":{"data":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":"standard"},"enabled":true,"logs":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":"standard"}},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"fsGroup":3000,"runAsGroup":3000,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"resources":{"limits":{"cpu":"500m","ephemeral-storage":"2Gi","memory":"512Mi"},"requests":{"cpu":"250m","ephemeral-storage":"2Gi","memory":"512Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10000},"service":{"portContainer":8000,"portService":8000,"type":"ClusterIP"}}` | Backend configuration |
 | backend.additionalVolumeMounts | list | `[]` | specifies additional volume mounts for the backend deployment |
 | backend.additionalVolumes | list | `[]` | additional volume claims for the containers |
 | backend.image.pullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
@@ -48,7 +48,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | backend.persistence.data.size | string | `"1Gi"` | Storage size for data |
 | backend.persistence.data.storageClass | string | `"standard"` | Storage class for data volume |
 | backend.persistence.enabled | bool | `true` | Create a PVC to persist storage (if disabled, data and logs will not be persisted) |
-| backend.persistence.logs.accessMode | string | `"ReadWriteOnce"` | Access mode for logs volume   |
+| backend.persistence.logs.accessMode | string | `"ReadWriteOnce"` | Access mode for logs volume |
 | backend.persistence.logs.enabled | bool | `true` | Enable logs persistence |
 | backend.persistence.logs.size | string | `"1Gi"` | Storage size for logs |
 | backend.persistence.logs.storageClass | string | `"standard"` | Storage class for logs volume |
@@ -86,7 +86,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | frontend.healthChecks.startup.path | string | `"/"` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.pullSecrets | list | `[]` | Existing image pull secret to use to [obtain the container image from private registries](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) |
-| frontend.image.repository | string | `"ichub-frontend"` |  |
+| frontend.image.repository | string | `"tractusx/industry-core-hub-frontend"` |  |
 | frontend.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | frontend.ingress | object | `{"className":"nginx","enabled":false,"hosts":[{"host":"","paths":[{"backend":{"port":8080,"service":"frontend"},"path":"/","pathType":"ImplementationSpecific"}]}],"tls":[]}` | ingress declaration to expose the industry-core-hub-backend service |
 | frontend.ingress.tls | list | `[]` | Ingress TLS configuration |
@@ -98,7 +98,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | frontend.podSecurityContext.runAsGroup | int | `3000` | Processes within a pod will belong to this guid |
 | frontend.podSecurityContext.runAsUser | int | `1000` | Runs all processes within a pod with a special uid |
 | frontend.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Restrict a Container's Syscalls with seccomp |
-| frontend.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"1Gi","memory":"256Mi"},"requests":{"cpu":"100m","ephemeral-storage":"128Mi","memory":"128Mi"}}` | Review the default resource limits as this should a conscious choice. |
+| frontend.resources | object | `{"limits":{"cpu":"500m","ephemeral-storage":"1Gi","memory":"256Mi"},"requests":{"cpu":"100m","ephemeral-storage":"128Mi","memory":"256Mi"}}` | Review the default resource limits as this should a conscious choice. |
 | frontend.securityContext.allowPrivilegeEscalation | bool | `false` | Controls [Privilege Escalation](https://kubernetes.io/docs/concepts/security/pod-security-policy/#privilege-escalation) enabling setuid binaries changing the effective user ID |
 | frontend.securityContext.capabilities.add | list | `[]` | Specifies which capabilities to add to issue specialized syscalls |
 | frontend.securityContext.capabilities.drop | list | `["ALL"]` | Specifies which capabilities to drop to reduce syscall attack surface |
@@ -106,8 +106,8 @@ helm install industry-core-hub tractusx/industry-core-hub
 | frontend.securityContext.runAsGroup | int | `10001` | The owner for volumes and any files created within volumes will belong to this guid |
 | frontend.securityContext.runAsNonRoot | bool | `true` | Requires the container to run without root privileges |
 | frontend.securityContext.runAsUser | int | `10000` | The container's process will run with the specified uid |
-| frontend.service.port | int | `80` |  |
-| frontend.service.targetPort | int | `8000` |  |
+| frontend.service.portContainer | int | `8080` |  |
+| frontend.service.portService | int | `8080` |  |
 | frontend.service.type | string | `"ClusterIP"` | [Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to expose the running application on a set of Pods as a network service |
 | fullnameOverride | string | `""` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -32,7 +32,7 @@ backend:
   enabled: true
   name: "industry-core-hub-backend"
   image:
-    repository: "ichub-backend"
+    repository: "tractusx/industry-core-hub-backend"
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""
@@ -162,7 +162,7 @@ frontend:
   enabled: true
   name: "industry-core-hub-frontend"
   image:
-    repository: "ichub-frontend"
+    repository: "tractusx/industry-core-hub-frontend"
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""


### PR DESCRIPTION
## WHAT
Now that we have the 0.0.1 tag on dockerhub I have updated the chart to use the released images. This pr will publish the first helm chart version 0.1.3 with the 0.0.1 appVersion.

It also updates the helm test workflow, which was relying on manually built images. To use released images.

## WHY

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
