### PR TITLE
fix: exclude .github folder from Verify MD license check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Verify the MD footer
               run: |-
-                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude=docker-notice-ichub-\* . | grep -v '^./[^/]*$'"
+                cmd="grep -riL \"SPDX-License-Identifier: CC-BY-4.0\" --include=\*.md --exclude=docker-notice-ichub-\* $(find . -mindepth 2 -type f -not -path "./.github/*")"
                 violations=$(eval $cmd | wc -l)
                 if [[ $violations -ne 0 ]] ; then
                     echo "$violations files without license headers were found:";


### PR DESCRIPTION
## WHAT

Exclude the `.github` directory from License file verification.

## WHY

The workflow currently fails due to the PR template in that directory.
