### PR TITLE
Feat/share shortcut

### DIFF
--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -32,6 +32,7 @@ from fastapi import FastAPI, HTTPException
 from services.part_management_service import PartManagementService
 from services.partner_management_service import PartnerManagementService
 from services.twin_management_service import TwinManagementService
+from services.part_sharing_shortcut_service import PartSharingShortcutService
 from models.services.part_management import CatalogPartBase, CatalogPartRead, CatalogPartCreate
 from models.services.partner_management import BusinessPartnerRead, BusinessPartnerCreate, DataExchangeAgreementRead
 from models.services.twin_management import TwinRead, TwinAspectRead, TwinAspectCreate, CatalogPartTwinRead, CatalogPartTwinDetailsRead, CatalogPartTwinCreate, CatalogPartTwinShare
@@ -60,6 +61,7 @@ app = FastAPI(title="Industry Core Hub Backend API", version="0.0.1", openapi_ta
 part_management_service = PartManagementService()
 partner_management_service = PartnerManagementService()
 twin_management_service = TwinManagementService()
+part_sharing_shortcut_service = PartSharingShortcutService()
 
 @app.get("/part-management/catalog-part/{manufacturer_id}/{manufacturer_part_id}", response_model=CatalogPartRead, tags=["Part Management"])
 async def part_management_get_catalog_part(manufacturer_id: str, manufacturer_part_id: str) -> Optional[CatalogPartRead]:
@@ -114,3 +116,11 @@ async def twin_management_share_catalog_part_twin(catalog_part_twin_share: Catal
 @app.post("/twin-management/twin-aspect", response_model=TwinAspectRead, tags=["Twin Management"])
 async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreate) -> TwinAspectRead:
     return twin_management_service.create_twin_aspect(twin_aspect_create)
+
+@app.post("/twin-management/catalog-part-twin/share-shortcut", response_model=CatalogPartTwinDetailsRead, tags=["Twin Management"])
+async def twin_management_create_part_sharing_shortcut(catalog_part_twin_share: CatalogPartTwinShare,
+    auto_generate_part_type_information_submodel:bool = True) -> CatalogPartTwinDetailsRead:
+    return part_sharing_shortcut_service.create_catalog_part_sharing_shortcut(
+        catalog_part_twin_share,
+        auto_generate_part_type_information=auto_generate_part_type_information_submodel
+    )

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -107,6 +107,15 @@ class BaseRepository(Generic[ModelType]):
 
 class BusinessPartnerRepository(BaseRepository[BusinessPartner]):
 
+    def create_new(self, name: str, bpnl: str) -> BusinessPartner:
+        """Create a new BusinessPartner instance."""
+        business_partner = BusinessPartner(
+            name=name,
+            bpnl=bpnl
+        )
+        self.create(business_partner)
+        return business_partner
+
     def get_by_name(self, name: str) -> Optional[BusinessPartner]:
         stmt = select(BusinessPartner).where(
             BusinessPartner.name == name)  # type: ignore
@@ -155,7 +164,21 @@ class LegalEntityRepository(BaseRepository[LegalEntity]):
         return self._session.scalars(stmt).first()
 
 class PartnerCatalogPartRepository(BaseRepository[PartnerCatalogPart]):
-    pass
+    def get_by_catalog_part_id_business_partner_id(self, catalog_part_id: int, business_partner_id: int) -> Optional[PartnerCatalogPart]:
+        stmt = select(PartnerCatalogPart).where(
+            PartnerCatalogPart.catalog_part_id == catalog_part_id).where(
+            PartnerCatalogPart.business_partner_id == business_partner_id)
+        return self._session.scalars(stmt).first()
+    
+    def create_new(self, catalog_part_id: int, business_partner_id: int, customer_part_id: str) -> PartnerCatalogPart:
+        """Create a new PartnerCatalogPart instance."""
+        partner_catalog_part = PartnerCatalogPart(
+            catalog_part_id=catalog_part_id,
+            business_partner_id=business_partner_id,
+            customer_part_id=customer_part_id,
+        )
+        self.create(partner_catalog_part)
+        return partner_catalog_part
 
 class EnablementServiceStackRepository(BaseRepository[EnablementServiceStack]):
     def get_by_name(self, name: str) -> Optional[EnablementServiceStack]:

--- a/ichub-backend/managers/submodels/__init__.py
+++ b/ichub-backend/managers/submodels/__init__.py
@@ -1,0 +1,28 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+# Package-level variables
+__author__ = 'Eclipse Tractus-X Contributors'
+__license__ = "Apache License, Version 2.0"
+
+from .submodel_document_generator import SubmodelDocumentGenerator

--- a/ichub-backend/managers/submodels/submodel_document_generator.py
+++ b/ichub-backend/managers/submodels/submodel_document_generator.py
@@ -1,0 +1,69 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from typing import Dict, Any, Optional
+from uuid import UUID
+
+SEM_ID_PART_TYPE_INFORMATION_V1 = "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation"
+
+
+class SubmodelDocumentGenerator:
+    """Class to generate submodel documents."""
+
+    def __init__(self):
+        pass
+
+    def generate_document(self, semantic_id, data: Dict[str, Any]) -> Dict[str, Any]:
+        if semantic_id == SEM_ID_PART_TYPE_INFORMATION_V1:
+            return self.generate_part_type_information_v1(**data)
+        
+        raise ValueError(f"Unsupported semantic ID: {semantic_id}")
+    
+    def generate_part_type_information_v1(self,
+        global_id: UUID,
+        manufacturer_part_id: str,
+        category: Optional[str] = None,
+        bpns: Optional[str] = None) -> Dict[str, Any]:
+        """Generate part type information for version 1."""
+        
+        if not category:
+            category = "Unknown"
+        
+        result = {
+            "catenaXId": str(global_id),
+            "partTypeInformation": {
+                "manufacturerPartId" : manufacturer_part_id,
+                "nameAtManufacturer" : category
+            }
+        }
+
+        if bpns:
+            result['partSitesInformationAsPlanned'] = [
+                {
+                    "catenaXsiteId" : bpns,
+                    "function" : "production" # not nice because hardcoded; question is in general if in the future we want to store this in the metdata DB
+                }
+            ]
+
+        return result

--- a/ichub-backend/models/services/part_management.py
+++ b/ichub-backend/models/services/part_management.py
@@ -32,7 +32,6 @@ from models.services.partner_management import BusinessPartnerRead
 class CatalogPartBase(BaseModel):
     manufacturer_id: str = Field(alias="manufacturerId", description="The BPNL (manufactuer ID) of the part to register.")
     manufacturer_part_id: str = Field(alias="manufacturerPartId", description="The manufacturer part ID of the part.")
-    category: Optional[str] = Field(description="The category of the part.", default=None)
 
 class PartnerCatalogPartBase(BaseModel):
     customer_part_id: str = Field(alias="customerPartId", description="The customer part ID for partner specific mapping of the catalog part.")
@@ -40,9 +39,10 @@ class PartnerCatalogPartBase(BaseModel):
 
 class CatalogPartRead(CatalogPartBase):
     customer_part_ids: Optional[Dict[str, BusinessPartnerRead]] = Field(alias="customerPartIds", description="The list of customer part IDs mapped to the respective Business Partners.", default={})
+    category: Optional[str] = Field(description="The category of the part.", default=None)
 
-class CatalogPartCreate(CatalogPartBase):
-    customer_part_ids: Optional[List[PartnerCatalogPartBase]] = Field(alias="customerPartIds", description="An optional list of customer part IDs to business partner name mappings.", default=[])
+class CatalogPartCreate(CatalogPartRead):
+    pass
 
 class CatalogPartDelete(CatalogPartBase):
     pass

--- a/ichub-backend/services/part_sharing_shortcut_service.py
+++ b/ichub-backend/services/part_sharing_shortcut_service.py
@@ -1,0 +1,148 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from .twin_management_service import TwinManagementService
+from managers.submodels.submodel_document_generator import SubmodelDocumentGenerator, SEM_ID_PART_TYPE_INFORMATION_V1
+from managers.metadata_database.manager import RepositoryManagerFactory
+from models.services.twin_management import CatalogPartTwinCreate, CatalogPartTwinShare, TwinAspectCreate, CatalogPartTwinDetailsRead
+from models.metadata_database.models import BusinessPartner, DataExchangeAgreement, EnablementServiceStack
+
+class PartSharingShortcutService:
+    """
+    Service to handle part sharing shortcuts.
+    """
+    
+    def __init__(self):
+        self.submodel_document_generator = SubmodelDocumentGenerator()
+        self.twin_management_service = TwinManagementService()
+
+    def create_catalog_part_sharing_shortcut(self, create_input: CatalogPartTwinShare, auto_generate_part_type_information: bool = False) -> CatalogPartTwinDetailsRead:
+        
+        with RepositoryManagerFactory.create() as repo:
+            # Step 1: Retrieve the catalog part entity according to the catalog part data (manufacturer_id, manufacturer_part_id)
+            db_catalog_parts = repo.catalog_part_repository.find_by_manufacturer_id_manufacturer_part_id(
+                create_input.manufacturer_id,
+                create_input.manufacturer_part_id,
+                join_partner_catalog_parts=True
+            )
+            if not db_catalog_parts:
+                raise ValueError("Catalog part not found.")
+            
+            db_catalog_part = db_catalog_parts[0]
+
+            # Step 2: Retrieve the enablement service stack entity from the DB according to the given name
+            # (if not there => create it with the default name)
+            db_enablement_service_stacks = repo.enablement_service_stack_repository.find_all()
+            if not db_enablement_service_stacks:
+                db_legal_entity = repo.legal_entity_repository.find_all()[0]
+                
+                db_enablement_service_stack = repo.enablement_service_stack_repository.create(EnablementServiceStack(name = 'EDC/DTR Default', legal_entity_id=db_legal_entity.id))
+                repo.commit()
+                repo.refresh(db_enablement_service_stack)
+            else:
+                db_enablement_service_stack = db_enablement_service_stacks[0]
+            
+            # Step 3: Retrieve the business partner entity according to the business_partner_name
+            # (if not there => create it)
+            db_business_partner = repo.business_partner_repository.get_by_bpnl(create_input.business_partner_number)
+            if not db_business_partner:
+                # First create the business partner entity
+                db_business_partner = repo.business_partner_repository.create(BusinessPartner(
+                    name='Partner_' + create_input.business_partner_number,
+                    bpnl=create_input.business_partner_number
+                ))
+
+                # Needed to get the generated ID from the database into the entity
+                repo.commit()
+                repo.refresh(db_business_partner)
+
+            # Step 4: Retrieve the first data exchange agreement entity for the business partner
+            # (if not there => create it with the default name)
+            db_data_exchange_agreements = repo.data_exchange_agreement_repository.get_by_business_partner_id(
+                db_business_partner.id
+            )
+
+            if not db_data_exchange_agreements:
+                db_data_exchange_agreement = repo.data_exchange_agreement_repository.create(
+                    DataExchangeAgreement(
+                        business_partner_id=db_business_partner.id,
+                        name='Default'
+                    ))
+                repo.commit()
+                repo.refresh(db_data_exchange_agreement)
+            else:
+                db_data_exchange_agreement = db_data_exchange_agreements[0]
+            
+
+            # Step 5: Get the partner catalog part entity from the DB according to the catalog part and business partner
+            # (if not there => create it was a generated customer part id)
+            db_partner_catalog_part = repo.partner_catalog_part_repository.get_by_catalog_part_id_business_partner_id(
+                business_partner_id=db_business_partner.id,
+                catalog_part_id=db_catalog_part.id
+            )
+            if not db_partner_catalog_part:
+                db_partner_catalog_part = repo.partner_catalog_part_repository.create_new(
+                    catalog_part_id=db_catalog_part.id,
+                    business_partner_id=db_business_partner.id,
+                    customer_part_id=db_business_partner.bpnl + '_' + db_catalog_part.manufacturer_part_id,
+                )
+                repo.commit()
+                repo.refresh(db_partner_catalog_part)
+
+            # Step 6: Let the Twin Management Service create the catalog part twin
+            # Then retrieve the twin from the DB
+            twin_read = self.twin_management_service.create_catalog_part_twin(CatalogPartTwinCreate(
+                manufacturerId=create_input.manufacturer_id,
+                manufacturerPartId=create_input.manufacturer_part_id,
+            ))
+            db_twin = repo.twin_repository.find_by_global_id(twin_read.global_id)
+
+            # Step 7: Check if there is already a twin exchange entity for the twin and data exchange agreement and create it if not
+            db_twin_exchange = repo.twin_exchange_repository.get_by_twin_id_data_exchange_agreement_id(
+                db_twin.id,
+                db_data_exchange_agreement.id
+            )
+            if not db_twin_exchange:
+                db_twin_exchange = repo.twin_exchange_repository.create_new(
+                    twin_id=db_twin.id,
+                    data_exchange_agreement_id=db_data_exchange_agreement.id
+                )
+                repo.commit()
+
+            # Step 8: If specified, generate and upload the part type information submodel document
+            if auto_generate_part_type_information:
+                payload = self.submodel_document_generator.generate_part_type_information_v1(
+                    global_id=db_twin.global_id,
+                    manufacturer_part_id=create_input.manufacturer_part_id,
+                    category=db_catalog_part.category,
+                    bpns=db_catalog_part.bpns
+                )
+
+                self.twin_management_service.create_twin_aspect(TwinAspectCreate(
+                    globalId=db_twin.global_id,
+                    semanticId=SEM_ID_PART_TYPE_INFORMATION_V1,
+                    payload=payload
+                ))
+            
+            return self.twin_management_service.get_catalog_part_twin_details(db_twin.global_id)

--- a/ichub-backend/services/twin_management_service.py
+++ b/ichub-backend/services/twin_management_service.py
@@ -337,7 +337,7 @@ class TwinManagementService:
                 }
             )
 
-    def get_catalog_part_twin_details(self, global_id: UUID) -> CatalogPartTwinDetailsRead:
+    def get_catalog_part_twin_details(self, global_id: UUID) -> Optional[CatalogPartTwinDetailsRead]:
         with RepositoryManagerFactory.create() as repo:
             db_twins = repo.twin_repository.find_catalog_part_twins(
                 global_id=global_id,
@@ -345,60 +345,59 @@ class TwinManagementService:
                 include_aspects=True,
                 include_registrations=True
             )
+            if not db_twins:
+                return None
             
-            result = []
-            for db_twin in db_twins:
-                db_catalog_part = db_twin.catalog_part
-                twin_result = CatalogPartTwinDetailsRead(
-                    globalId=db_twin.global_id,
-                    dtrAasId=db_twin.aas_id,
-                    createdDate=db_twin.created_date,
-                    modifiedDate=db_twin.modified_date,
-                    manufacturerId=db_catalog_part.legal_entity.bpnl,
-                    manufacturerPartId=db_catalog_part.manufacturer_part_id,
-                    category=db_catalog_part.category,
-                    additionalContext=db_twin.additional_context,
-                    customerPartIds={partner_catalog_part.customer_part_id: BusinessPartnerRead(
-                        name=partner_catalog_part.business_partner.name,
-                        bpnl=partner_catalog_part.business_partner.bpnl
-                    ) for partner_catalog_part in db_catalog_part.partner_catalog_parts}
-                )
-
-                twin_result.shares = [
-                    DataExchangeAgreementRead(
-                        name=db_twin_exchange.data_exchange_agreement.name,
-                        businessPartner=BusinessPartnerRead(
-                            name=db_twin_exchange.data_exchange_agreement.business_partner.name,
-                            bpnl=db_twin_exchange.data_exchange_agreement.business_partner.bpnl
-                        )
-                    ) for db_twin_exchange in db_twin.twin_exchanges
-                ]
-
-                twin_result.registrations = {
-                    db_twin_registration.enablement_service_stack.name: db_twin_registration.dtr_registered
-                     for db_twin_registration in db_twin.twin_registrations
-                }
-
-                twin_result.aspects = {
-                    db_twin_aspect.semantic_id: TwinAspectRead(
-                        semanticId=db_twin_aspect.semantic_id,
-                        submodelId=db_twin_aspect.submodel_id,
-                        registrations={
-                            db_twin_aspect_registration.enablement_service_stack.name: TwinAspectRegistration(
-                                enablementServiceStackName=db_twin_aspect_registration.enablement_service_stack.name,
-                                status=TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
-                                mode=TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
-                                createdDate=db_twin_aspect_registration.created_date,
-                                modifiedDate=db_twin_aspect_registration.modified_date
-                            ) for db_twin_aspect_registration in db_twin_aspect.twin_aspect_registrations
-                        } 
-                    ) for db_twin_aspect in db_twin.twin_aspects
-                }
-
-
-                result.append(twin_result)
+            db_twin = db_twins[0]
             
-            return result
+            db_catalog_part = db_twin.catalog_part
+            twin_result = CatalogPartTwinDetailsRead(
+                globalId=db_twin.global_id,
+                dtrAasId=db_twin.aas_id,
+                createdDate=db_twin.created_date,
+                modifiedDate=db_twin.modified_date,
+                manufacturerId=db_catalog_part.legal_entity.bpnl,
+                manufacturerPartId=db_catalog_part.manufacturer_part_id,
+                category=db_catalog_part.category,
+                additionalContext=db_twin.additional_context,
+                customerPartIds={partner_catalog_part.customer_part_id: BusinessPartnerRead(
+                    name=partner_catalog_part.business_partner.name,
+                    bpnl=partner_catalog_part.business_partner.bpnl
+                ) for partner_catalog_part in db_catalog_part.partner_catalog_parts}
+            )
+
+            twin_result.shares = [
+                DataExchangeAgreementRead(
+                    name=db_twin_exchange.data_exchange_agreement.name,
+                    businessPartner=BusinessPartnerRead(
+                        name=db_twin_exchange.data_exchange_agreement.business_partner.name,
+                        bpnl=db_twin_exchange.data_exchange_agreement.business_partner.bpnl
+                    )
+                ) for db_twin_exchange in db_twin.twin_exchanges
+            ]
+
+            twin_result.registrations = {
+                db_twin_registration.enablement_service_stack.name: db_twin_registration.dtr_registered
+                    for db_twin_registration in db_twin.twin_registrations
+            }
+
+            twin_result.aspects = {
+                db_twin_aspect.semantic_id: TwinAspectRead(
+                    semanticId=db_twin_aspect.semantic_id,
+                    submodelId=db_twin_aspect.submodel_id,
+                    registrations={
+                        db_twin_aspect_registration.enablement_service_stack.name: TwinAspectRegistration(
+                            enablementServiceStackName=db_twin_aspect_registration.enablement_service_stack.name,
+                            status=TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
+                            mode=TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
+                            createdDate=db_twin_aspect_registration.created_date,
+                            modifiedDate=db_twin_aspect_registration.modified_date
+                        ) for db_twin_aspect_registration in db_twin_aspect.twin_aspect_registrations
+                    } 
+                ) for db_twin_aspect in db_twin.twin_aspects
+            }
+
+            return twin_result
 
 
 def _create_dtr_manager(connection_settings: Optional[Dict[str, Any]]) -> DTRManager:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adds an implementation of a "shortcut" share API. This only take manufacturerId, manufacturerPartId and business partner number and will auto-generate everything missing in the metadata database.
On demand a minimal PartTypeInformation apect model can also be generated with that.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
