### PR TITLE
feat: Add a service that emulates the DTR Read API (without need of a separate DTR service running)

### DIFF
--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -116,8 +116,22 @@ async def twin_management_share_catalog_part_twin(catalog_part_twin_share: Catal
 async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreate) -> TwinAspectRead:
     return twin_management_service.create_twin_aspect(twin_aspect_create)
 
-@app.get("/submodel-dispatcher/{semantic_id}/{global_id}/submodel", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
+@app.get("/submodel-dispatcher/{semantic_id}/{global_id}", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
 async def submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID, request: Request) -> Dict[str, Any]:
+    return _submodel_dispatcher_get_submodel_content(semantic_id, global_id, request)
+    
+@app.get("/submodel-dispatcher/{semantic_id}/{global_id}/submodel", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
+async def submodel_dispatcher_get_submodel_content_submodel(semantic_id: str, global_id: UUID, request: Request) -> Dict[str, Any]:
+    return _submodel_dispatcher_get_submodel_content(semantic_id, global_id, request)
+
+@app.get("/submodel-dispatcher/{semantic_id}/{global_id}/submodel/$value", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
+async def submodel_dispatcher_get_submodel_content_submodel_value(semantic_id: str, global_id: UUID, request: Request) -> Dict[str, Any]:
+    return _submodel_dispatcher_get_submodel_content(semantic_id, global_id, request)
+
+def _submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID, request: Request) -> Dict[str, Any]:
+    """
+    Dispatch a submodel to the appropriate service or endpoint.
+    """
     # Extract the headers we get from the EDC Data Plane
     edc_bpn = request.headers.get("Edc-Bpn")
     edc_contract_agreement_id = request.headers.get("Edc-Contract-Agreement-Id")

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -117,7 +117,7 @@ async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreat
     return twin_management_service.create_twin_aspect(twin_aspect_create)
 
 @app.get("/submodel-dispatcher/{semantic_id}/{global_id}/submodel", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
-async def submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID, request: Request) -> TwinAspectRead:
+async def submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID, request: Request) -> Dict[str, Any]:
     # Extract the headers we get from the EDC Data Plane
     edc_bpn = request.headers.get("Edc-Bpn")
     edc_contract_agreement_id = request.headers.get("Edc-Contract-Agreement-Id")

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -116,7 +116,7 @@ async def twin_management_share_catalog_part_twin(catalog_part_twin_share: Catal
 async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreate) -> TwinAspectRead:
     return twin_management_service.create_twin_aspect(twin_aspect_create)
 
-@app.get("/submodel-dispatcher/{semantic_id}/{global_id}", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
+@app.get("/submodel-dispatcher/{semantic_id}/{global_id}/submodel", response_model=Dict[str, Any], tags=["Submodel Dispatcher"])
 async def submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID, request: Request) -> TwinAspectRead:
     # Extract the headers we get from the EDC Data Plane
     edc_bpn = request.headers.get("Edc-Bpn")

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -35,7 +35,7 @@ from services.submodel_dispatcher_service import SubmodelDispatcherService, Subm
 from services.part_management_service import PartManagementService
 from services.partner_management_service import PartnerManagementService
 from services.twin_management_service import TwinManagementService
-from services.dtr_facade_service import DTRFacadeService, NotAuthorizedError, TwinNotFoundError
+from services.dtr_facade_service import DTRFacadeService, NotAuthorizedError, TwinNotFoundError, NotValidTwinError
 from models.services.part_management import CatalogPartBase, CatalogPartRead, CatalogPartCreate
 from models.services.partner_management import BusinessPartnerRead, BusinessPartnerCreate, DataExchangeAgreementRead
 from models.services.twin_management import TwinRead, TwinAspectRead, TwinAspectCreate, CatalogPartTwinRead, CatalogPartTwinDetailsRead, CatalogPartTwinCreate, CatalogPartTwinShare
@@ -181,12 +181,10 @@ async def dtr_facade_get_shell_descriptors(
         default=None
     ),
 ) -> Dict[str, Any]:
-    return {
-        "pagingMetadata": {
-            "cursor": "123"
-        },
-        "result": []
-    }
+    return dtr_facade_service.get_shell_descriptors(
+        enablement_service_stack_id,
+        edc_bpn=request.headers.get("Edc-Bpn"),
+        limit=limit)
 
 @app.get("/dtr-facade/{enablement_service_stack_id}/shell-descriptors/{aasIdentifier}",
     description="Returns a specific Asset Administration Shell Descriptor",
@@ -202,7 +200,7 @@ async def dtr_facade_get_shell_descriptor(enablement_service_stack_id: int, aasI
     
     try:
         return dtr_facade_service.get_shell_descriptor(enablement_service_stack_id, aasIdentifier, edc_bpn)
-    except TwinNotFoundError as e:
+    except (TwinNotFoundError, NotValidTwinError) as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except NotAuthorizedError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -156,26 +156,67 @@ def _submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID,
     # If the requestor has no access to the twin return a respective 403
     except SubmodelNotSharedWithBusinessPartnerError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+
+
+@app.get("/dtr-facade/{enablement_service_stack_id}/shell-descriptors",
+    description="Returns all Asset Administration Shell Descriptors",
+    response_model=Dict[str, Any],
+    tags=["Digital Twin Registry Facade"])
+async def dtr_facade_get_shell_descriptors(
+    # TODO: Define explicit result schema to match the DTR API specs
+    enablement_service_stack_id: int,
+    request: Request,
+    limit: Optional[int] = Query(ge=1, description="The maximum number of elements in the response array", default=None),
+    cursor: Optional[str] = Query(description="A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue", default=None),
+    asset_kind: Optional[str] = Query(
+        alias="assetKind",
+        description="The Asset's kind (Instance or Type)",
+        enum=["Instance", "NotApplicable", "Type"],  # List of allowed values,
+        default=None
+    ),
+    asset_type: Optional[str] = Query(
+        alias="assetType",
+        description="The Asset's type (UTF8-BASE64-URL-encoded)",
+        regex="^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$",
+        default=None
+    ),
+) -> Dict[str, Any]:
+    return {
+        "pagingMetadata": {
+            "cursor": "123"
+        },
+        "result": []
+    }
+
+@app.get("/dtr-facade/{enablement_service_stack_id}/shell-descriptors/{aasIdentifier}",
+    description="Returns a specific Asset Administration Shell Descriptor",
+    response_model=Dict[str, Any],
+    tags=["Digital Twin Registry Facade"])
+async def dtr_facade_get_shell_descriptor(enablement_service_stack_id: int, aasIdentifier: str, request: Request) -> Dict[str, Any]:
+    # TODO: Define explicit result schema to match the DTR API specs
     
-@app.get("/dtr-facade/{enablement_service_stack_id}/shell-descriptors/{aas_id_b64}", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
-async def dtr_facade_get_shell_descriptor(enablement_service_stack_id: int, aas_id_b64: str, request: Request) -> Dict[str, Any]:
     """
     Get the shell descriptor for a given AAS ID.
     """
     edc_bpn = request.headers.get("Edc-Bpn")
     
     try:
-        return dtr_facade_service.get_shell_descriptor(enablement_service_stack_id, aas_id_b64, edc_bpn)
+        return dtr_facade_service.get_shell_descriptor(enablement_service_stack_id, aasIdentifier, edc_bpn)
     except TwinNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except NotAuthorizedError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     
-@app.get("/dtr-facade/{enablement_service_stack_id}/lookup/shells", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
+@app.get("/dtr-facade/{enablement_service_stack_id}/lookup/shells",
+    description="Returns a list of Asset Administration Shell ids linked to specific Asset identifiers",
+    response_model=Dict[str, Any],
+    tags=["Digital Twin Registry Facade"])
 async def dtr_facade_lookup_shells(
     request: Request,
     enablement_service_stack_id: int,
-    asset_ids: Optional[List[str]] = Query(alias="assetIds", description="List of asset IDs to lookup (format: base64 encoded JSON with 'name' and 'value' keys)", default=None),
+    asset_ids: Optional[List[str]] = Query(alias="assetIds", description="A list of specific Asset identifiers", default=None),
+    limit: Optional[int] = Query(ge=1, description="The maximum number of elements in the response array", default=None),
+    cursor: Optional[str] = Query(description="A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue", default=None),
 ) -> Dict[str, Any]:
     """
     Lookup shells for a given enablement service stack ID.

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -25,7 +25,10 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import FastAPI, HTTPException, Request
+import json
+import base64
+
+from fastapi import FastAPI, HTTPException, Request, Query
 from fastapi.responses import JSONResponse
 
 from services.submodel_dispatcher_service import SubmodelDispatcherService, SubmodelNotSharedWithBusinessPartnerError
@@ -154,16 +157,38 @@ def _submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID,
     except SubmodelNotSharedWithBusinessPartnerError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     
-@app.get("/dtr-facade/shell-descriptors/{aas_id_b64}", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
-async def dtr_facade_get_shell_descriptor(aas_id_b64: str, request: Request) -> Dict[str, Any]:
+@app.get("/dtr-facade/{enablement_service_stack_id}/shell-descriptors/{aas_id_b64}", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
+async def dtr_facade_get_shell_descriptor(enablement_service_stack_id: int, aas_id_b64: str, request: Request) -> Dict[str, Any]:
     """
     Get the shell descriptor for a given AAS ID.
     """
     edc_bpn = request.headers.get("Edc-Bpn")
     
     try:
-        return dtr_facade_service.get_shell_descriptor(aas_id_b64, edc_bpn)
+        return dtr_facade_service.get_shell_descriptor(enablement_service_stack_id, aas_id_b64, edc_bpn)
     except TwinNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except NotAuthorizedError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
+    
+@app.get("/dtr-facade/{enablement_service_stack_id}/lookup/shells", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
+async def dtr_facade_lookup_shells(
+    request: Request,
+    enablement_service_stack_id: int,
+    asset_ids: Optional[List[str]] = Query(alias="assetIds", description="List of asset IDs to lookup (format: base64 encoded JSON with 'name' and 'value' keys)", default=None),
+) -> Dict[str, Any]:
+    """
+    Lookup shells for a given enablement service stack ID.
+    """
+    edc_bpn = request.headers.get("Edc-Bpn")
+    
+    search_params = {}
+    if asset_ids:
+        for asset_id in asset_ids:
+            try:
+                decoded_asset_id = json.loads(base64.b64decode(asset_id).decode('utf-8'))
+                search_params[decoded_asset_id["name"]] = decoded_asset_id["value"]
+            except (json.JSONDecodeError, KeyError, ValueError) as e:
+                raise HTTPException(status_code=400, detail=f"Invalid asset ID format: {asset_id}") from e
+
+    return dtr_facade_service.lookup_shells(enablement_service_stack_id, search_params, edc_bpn)

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -32,6 +32,7 @@ from services.submodel_dispatcher_service import SubmodelDispatcherService, Subm
 from services.part_management_service import PartManagementService
 from services.partner_management_service import PartnerManagementService
 from services.twin_management_service import TwinManagementService
+from services.dtr_facade_service import DTRFacadeService, NotAuthorizedError, TwinNotFoundError
 from models.services.part_management import CatalogPartBase, CatalogPartRead, CatalogPartCreate
 from models.services.partner_management import BusinessPartnerRead, BusinessPartnerCreate, DataExchangeAgreementRead
 from models.services.twin_management import TwinRead, TwinAspectRead, TwinAspectCreate, CatalogPartTwinRead, CatalogPartTwinDetailsRead, CatalogPartTwinCreate, CatalogPartTwinShare
@@ -52,6 +53,10 @@ tags_metadata = [
     {
         "name": "Submodel Dispatcher",
         "description": "Internal API called by EDC Data Planes in order the deliver data of of the internall used Submodel Service"
+    },
+    {
+        "name": "Digital Twin Registry Facade",
+        "description": "DTR compatible API provided directly out of the Industry Core Hub Backend. No separate DTR service is needed"
     }
 ]
 
@@ -61,6 +66,7 @@ part_management_service = PartManagementService()
 partner_management_service = PartnerManagementService()
 twin_management_service = TwinManagementService()
 submodel_dispatcher_service = SubmodelDispatcherService()
+dtr_facade_service = DTRFacadeService()
 
 @app.get("/part-management/catalog-part/{manufacturer_id}/{manufacturer_part_id}", response_model=CatalogPartRead, tags=["Part Management"])
 async def part_management_get_catalog_part(manufacturer_id: str, manufacturer_part_id: str) -> Optional[CatalogPartRead]:
@@ -146,4 +152,18 @@ def _submodel_dispatcher_get_submodel_content(semantic_id: str, global_id: UUID,
     
     # If the requestor has no access to the twin return a respective 403
     except SubmodelNotSharedWithBusinessPartnerError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    
+@app.get("/dtr-facade/shell-descriptors/{aas_id_b64}", response_model=Dict[str, Any], tags=["Digital Twin Registry Facade"])
+async def dtr_facade_get_shell_descriptor(aas_id_b64: str, request: Request) -> Dict[str, Any]:
+    """
+    Get the shell descriptor for a given AAS ID.
+    """
+    edc_bpn = request.headers.get("Edc-Bpn")
+    
+    try:
+        return dtr_facade_service.get_shell_descriptor(aas_id_b64, edc_bpn)
+    except TwinNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except NotAuthorizedError as e:
         raise HTTPException(status_code=403, detail=str(e)) from e

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -311,6 +311,19 @@ class TwinExchangeRepository(BaseRepository[TwinExchange]):
         )
         self.create(twin_exchange)
         return twin_exchange
+    
+    def find_by_global_id_business_partner_number(self, global_id: UUID, business_partner_number: str) -> Optional[TwinExchange]:
+        stmt = select(TwinExchange).join(
+            Twin, TwinExchange.twin_id == Twin.id
+        ).join(
+            DataExchangeAgreement, TwinExchange.data_exchange_agreement_id == DataExchangeAgreement.id
+        ).join(
+            BusinessPartner, BusinessPartner.id == DataExchangeAgreement.business_partner_id
+        ).where(
+            Twin.global_id == global_id,
+            BusinessPartner.bpnl == business_partner_number
+        )
+        return self._session.scalars(stmt).first()  
 
 class TwinRegistrationRepository(BaseRepository[TwinRegistration]):
     def get_by_twin_id_enablement_service_stack_id(self, twin_id: int, enablement_service_stack_id: int) -> Optional[TwinRegistration]:

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -22,7 +22,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-from sqlmodel import SQLModel, Session, select
+from sqlmodel import SQLModel, Session, select, desc
 from sqlalchemy.orm import selectinload
 from typing import TypeVar, Type, List, Optional, Generic
 from uuid import UUID, uuid4
@@ -220,6 +220,26 @@ class TwinRepository(BaseRepository[Twin]):
 
 
         return self._session.scalars(stmt).first()
+
+    def find_by_enablement_service_stack_id(self,
+        enablement_service_stack_id: int,
+        include_data_exchange_agreements: bool = False,
+        include_aspects: bool = False,
+        include_registrations: bool = False,
+        limit: int = 50,
+        offset: int = 0) -> List[Twin]:
+        
+        stmt = select(Twin).join(
+            TwinRegistration, TwinRegistration.twin_id == Twin.id
+        ).where(
+            TwinRegistration.enablement_service_stack_id == enablement_service_stack_id
+        ).order_by(desc(Twin.created_date)  # type: ignore
+        ).offset(offset).limit(limit)
+
+        stmt = self._apply_subquery_filters(stmt, include_data_exchange_agreements, include_aspects, include_registrations)
+
+
+        return self._session.scalars(stmt).all()
 
     def find_catalog_part_twins(self,
             manufacturer_id: Optional[str] = None,

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -125,6 +125,25 @@ class CatalogPartRepository(BaseRepository[CatalogPart]):
             CatalogPart.manufacturer_part_id == manufacturer_part_id)
         return self._session.scalars(stmt).first()
 
+    def get_by_twin_id(
+        self,
+        twin_id: int,
+        join_legal_entity: bool = False,
+        join_partner_catalog_parts: bool = False
+    ) -> Optional[CatalogPart]:
+        
+        stmt = select(CatalogPart)
+        
+        if join_legal_entity:
+            stmt = stmt.join(LegalEntity, LegalEntity.id == CatalogPart.legal_entity_id)
+
+        if join_partner_catalog_parts:
+            subquery = select(PartnerCatalogPart).join(BusinessPartner, BusinessPartner.id == PartnerCatalogPart.business_partner_id).where(PartnerCatalogPart.catalog_part_id == CatalogPart.id).subquery()
+            stmt = stmt.join(subquery, subquery.c.catalog_part_id == CatalogPart.id, isouter=True)
+
+        stmt = stmt.where(CatalogPart.twin_id == twin_id)
+        return self._session.scalars(stmt).first()
+
     def find_by_manufacturer_id_manufacturer_part_id(self, manufacturer_id: Optional[str], manufacturer_part_id: Optional[str], join_partner_catalog_parts : bool = False) -> List[CatalogPart]:
         stmt = select(CatalogPart).distinct()
 
@@ -188,6 +207,20 @@ class TwinRepository(BaseRepository[Twin]):
             Twin.global_id == global_id)
         return self._session.scalars(stmt).first()
     
+    def find_by_dtr_aas_id(self,
+        dtr_aas_id: UUID,
+        include_data_exchange_agreements: bool = False,
+        include_aspects: bool = False,
+        include_registrations: bool = False) -> Optional[Twin]:
+       
+        stmt = select(Twin).where(
+            Twin.aas_id == dtr_aas_id)
+
+        stmt = self._apply_subquery_filters(stmt, include_data_exchange_agreements, include_aspects, include_registrations)
+
+
+        return self._session.scalars(stmt).first()
+
     def find_catalog_part_twins(self,
             manufacturer_id: Optional[str] = None,
             manufacturer_part_id: Optional[str] = None,

--- a/ichub-backend/models/metadata_database/models.py
+++ b/ichub-backend/models/metadata_database/models.py
@@ -70,6 +70,13 @@ class Twin(SQLModel, table=True):
 
     __tablename__ = "twin"
 
+    def has_registration(self, enablement_service_stack_id: int) -> bool:
+        """Check if the twin has a registration with the given enablement service stack ID."""
+        for registration in self.twin_registrations:
+            if registration.enablement_service_stack_id == enablement_service_stack_id:
+                return registration.dtr_registered
+        return False
+
 
 class CatalogPart(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -98,6 +105,13 @@ class CatalogPart(SQLModel, table=True):
         """Find the partner catalog part for a given business partner."""
         for partner_catalog_part in self.partner_catalog_parts:
             if partner_catalog_part.business_partner.bpnl == bpnl:
+                return partner_catalog_part
+        return None
+
+    def find_partner_catalog_part_by_customer_part_id(self, customer_part_id: str) -> Optional["PartnerCatalogPart"]:
+        """Find the partner catalog part for a given business partner."""
+        for partner_catalog_part in self.partner_catalog_parts:
+            if partner_catalog_part.customer_part_id == customer_part_id:
                 return partner_catalog_part
         return None
 

--- a/ichub-backend/services/dtr_facade_service.py
+++ b/ichub-backend/services/dtr_facade_service.py
@@ -28,7 +28,8 @@ from base64 import b64decode
 from urllib.parse import quote
 
 from services.twin_management_service import TwinManagementService
-from managers.metadata_database.manager import RepositoryManagerFactory
+from managers.metadata_database.manager import RepositoryManagerFactory, RepositoryManager
+from models.metadata_database.models import Twin
 from tools.submodel_type_util import SubmodelType, get_submodel_type
 
 class TwinNotFoundError(ValueError):
@@ -41,6 +42,11 @@ class NotAuthorizedError(ValueError):
     Exception raised when a requested twin is not authorized for the specified business partner.
     """
 
+class NotValidTwinError(ValueError):
+    """
+    Exception raised when a requested twin is not valid (i.e. it is not attached to any part)
+    """
+
 class DTRFacadeService:
     """
     Service class for managing DTR facade operations.
@@ -50,6 +56,35 @@ class DTRFacadeService:
         self.twin_management_service = TwinManagementService()
         self.control_plane_url = control_plane_url
         self.data_plane_url = data_plane_url
+
+    def get_shell_descriptors(self, enablement_service_stack_id: int, edc_bpn: Optional[str] = None, limit: int = 50) -> Dict[str, Any]:
+        """
+        Get shell descriptors for a given enablement service stack ID.
+        """
+        result: List[Dict[str, Any]] = []
+
+        with RepositoryManagerFactory.create() as repos:
+            db_twins = repos.twin_repository.find_by_enablement_service_stack_id(enablement_service_stack_id, limit=limit, include_aspects=True)
+
+            for db_twin in db_twins:
+                shell_descriptor = {
+                    "id": db_twin.aas_id.urn,
+                    "assetType": "AssetType"
+                }
+                try:
+                    self._fill_shell_descriptor(repos, db_twin, shell_descriptor, edc_bpn)
+                except (NotAuthorizedError, NotValidTwinError):
+                    # Skip twins that are not authorized for the given business partner
+                    continue
+
+                result.append(shell_descriptor)
+
+        return {
+            "paging_metadata": {
+                "cursor": "foo"
+            },
+            "result": result
+        }
 
     def get_shell_descriptor(self, enablement_service_stack_id: int, aas_id_b64: str, edc_bpn: Optional[str] = None) -> Dict[str, Any]:
         """
@@ -63,111 +98,13 @@ class DTRFacadeService:
             "assetType": "AssetType"
         }
 
-        specific_asset_ids: List[Dict[str, Any]] = []
-
         with RepositoryManagerFactory.create() as repos:
             db_twin = repos.twin_repository.find_by_dtr_aas_id(aas_id, include_aspects=True, include_registrations=True)
             
             if db_twin is None or not db_twin.has_registration(enablement_service_stack_id):
                 raise TwinNotFoundError(f"Shell descriptor {aas_id} not found.")
-
-            result["globalAssetId"] = db_twin.global_id.urn
-
-            db_catalog_part = repos.catalog_part_repository.get_by_twin_id(db_twin.id)
-            if db_catalog_part:
-
-                # Called from a partner => check if the catalog part is shared with the partner
-                if edc_bpn:
-                    db_partner_catalog_part = db_catalog_part.find_partner_catalog_part_by_bpnl(edc_bpn)
-
-                    # Not found => then the partner has no access to the twin
-                    if not db_partner_catalog_part:
-                        raise NotAuthorizedError(f"Catalog part with AAS ID {aas_id} not shared with business partner {edc_bpn}.")
-                    
-                    db_partner_catalog_parts = [db_partner_catalog_part]
-                else:
-                    db_partner_catalog_parts = db_catalog_part.partner_catalog_parts
-
-                
-                result["assetKind"] = "Type"
-                self._add_specific_asset_id(
-                    specific_asset_ids,
-                    "manufacturerPartId",
-                    db_catalog_part.manufacturer_part_id,
-                    "PUBLIC_READABLE"
-                )
-                
-                for db_partner_catalog_part in db_partner_catalog_parts:
-                    self._add_specific_asset_id(
-                        specific_asset_ids,
-                        "digitalTwinType",
-                        "PartType",
-                        db_partner_catalog_part.business_partner.bpnl
-                    )
-                    
-                    self._add_specific_asset_id(
-                        specific_asset_ids,
-                        "manufacturerId",
-                        db_catalog_part.legal_entity.bpnl,
-                        db_partner_catalog_part.business_partner.bpnl
-                    )
-
-                    self._add_specific_asset_id(
-                        specific_asset_ids,
-                        "customerPartId",
-                        db_partner_catalog_part.customer_part_id,
-                        db_partner_catalog_part.business_partner.bpnl
-                    )
-
-                submodel_descriptors: List[Dict[str, Any]] = []
-                for db_twin_aspect in db_twin.twin_aspects:
-                    semandic_id = db_twin_aspect.semantic_id
-                    submodel_type_data = get_submodel_type(semandic_id)
-                    asset_id = self._generate_asset_id(db_twin, db_twin_aspect)
-
-                    entry = {
-                        "id": db_twin_aspect.submodel_id.urn,
-                        "idShort": submodel_type_data.id_short,
-                        "semanticId": {
-                            "type": "ExternalReference",
-                            "keys": [{
-                                "type": "GlobalReference",
-                                "value": semandic_id
-                            }]
-                        },
-                        "supplementalSemanticId": [],
-                        "description": [],
-                        "displayName": [],
-                        "endpoints": [{
-                            "interface": "SUBMODEL-3.0",
-                            "protocolInformation": {
-                                "href": f"{self.data_plane_url}/api/public/{quote(semandic_id)}/{str(db_twin.global_id)}/submodel",
-                                "endpointProtocol": "HTTP",
-                                "endpointProtocolVersion": [
-                                "1.1"
-                                ],
-                                "subprotocol": "DSP",
-                                "subprotocolBody": f"id={asset_id};dspEndpoint={self.control_plane_url}",
-                                "subprotocolBodyEncoding": "plain",
-                                "securityAttributes": [
-                                {
-                                    "type": "NONE",
-                                    "key": "NONE",
-                                    "value": "NONE"
-                                }
-                                ]
-                            }
-                            }
-                        ],                        
-                    }
-                                            
-                    submodel_descriptors.append(entry)
-                
-
-                result["specificAssetIds"] = specific_asset_ids
-                if submodel_descriptors:
-                    result["submodelDescriptors"] = submodel_descriptors
-
+            
+            self._fill_shell_descriptor(repos, db_twin, result, edc_bpn)
 
         return result
 
@@ -271,6 +208,106 @@ class DTRFacadeService:
             "paging_metadata": {},
             "result": [aas_id.urn for aas_id in result]
         }
+
+    def _fill_shell_descriptor(self, repos: RepositoryManager, db_twin: Twin, shell_descriptor: Dict[str, Any], edc_bpn: Optional[str] = None) -> None:
+        shell_descriptor["globalAssetId"] = db_twin.global_id.urn
+        specific_asset_ids: List[Dict[str, Any]] = []
+
+        db_catalog_part = repos.catalog_part_repository.get_by_twin_id(db_twin.id)
+        if db_catalog_part:
+
+            # Called from a partner => check if the catalog part is shared with the partner
+            if edc_bpn:
+                db_partner_catalog_part = db_catalog_part.find_partner_catalog_part_by_bpnl(edc_bpn)
+
+                # Not found => then the partner has no access to the twin
+                if not db_partner_catalog_part:
+                    raise NotAuthorizedError(f"Catalog part with AAS ID {db_twin.aas_id} not shared with business partner {edc_bpn}.")
+                
+                db_partner_catalog_parts = [db_partner_catalog_part]
+            else:
+                db_partner_catalog_parts = db_catalog_part.partner_catalog_parts
+
+            
+            shell_descriptor["assetKind"] = "Type"
+            self._add_specific_asset_id(
+                specific_asset_ids,
+                "manufacturerPartId",
+                db_catalog_part.manufacturer_part_id,
+                "PUBLIC_READABLE"
+            )
+            
+            for db_partner_catalog_part in db_partner_catalog_parts:
+                self._add_specific_asset_id(
+                    specific_asset_ids,
+                    "digitalTwinType",
+                    "PartType",
+                    db_partner_catalog_part.business_partner.bpnl
+                )
+                
+                self._add_specific_asset_id(
+                    specific_asset_ids,
+                    "manufacturerId",
+                    db_catalog_part.legal_entity.bpnl,
+                    db_partner_catalog_part.business_partner.bpnl
+                )
+
+                self._add_specific_asset_id(
+                    specific_asset_ids,
+                    "customerPartId",
+                    db_partner_catalog_part.customer_part_id,
+                    db_partner_catalog_part.business_partner.bpnl
+                )
+
+            submodel_descriptors: List[Dict[str, Any]] = []
+            for db_twin_aspect in db_twin.twin_aspects:
+                semandic_id = db_twin_aspect.semantic_id
+                submodel_type_data = get_submodel_type(semandic_id)
+                asset_id = self._generate_asset_id(db_twin, db_twin_aspect)
+
+                entry = {
+                    "id": db_twin_aspect.submodel_id.urn,
+                    "idShort": submodel_type_data.id_short,
+                    "semanticId": {
+                        "type": "ExternalReference",
+                        "keys": [{
+                            "type": "GlobalReference",
+                            "value": semandic_id
+                        }]
+                    },
+                    "supplementalSemanticId": [],
+                    "description": [],
+                    "displayName": [],
+                    "endpoints": [{
+                        "interface": "SUBMODEL-3.0",
+                        "protocolInformation": {
+                            "href": f"{self.data_plane_url}/api/public/{quote(semandic_id)}/{str(db_twin.global_id)}/submodel",
+                            "endpointProtocol": "HTTP",
+                            "endpointProtocolVersion": [
+                            "1.1"
+                            ],
+                            "subprotocol": "DSP",
+                            "subprotocolBody": f"id={asset_id};dspEndpoint={self.control_plane_url}",
+                            "subprotocolBodyEncoding": "plain",
+                            "securityAttributes": [
+                            {
+                                "type": "NONE",
+                                "key": "NONE",
+                                "value": "NONE"
+                            }
+                            ]
+                        }
+                        }
+                    ],                        
+                }
+                                        
+                submodel_descriptors.append(entry)
+        else:
+            raise NotValidTwinError(f"Shell descriptor {db_twin.aas_id} is not attached to a part.")
+
+        shell_descriptor["specificAssetIds"] = specific_asset_ids
+        if submodel_descriptors:
+            shell_descriptor["submodelDescriptors"] = submodel_descriptors
 
     def _generate_asset_id(self, db_twin, db_twin_aspect) -> str:
         """

--- a/ichub-backend/services/dtr_facade_service.py
+++ b/ichub-backend/services/dtr_facade_service.py
@@ -51,7 +51,7 @@ class DTRFacadeService:
         self.control_plane_url = control_plane_url
         self.data_plane_url = data_plane_url
 
-    def get_shell_descriptor(self, aas_id_b64: str, edc_bpn: Optional[str] = None) -> Dict[str, Any]:
+    def get_shell_descriptor(self, enablement_service_stack_id: int, aas_id_b64: str, edc_bpn: Optional[str] = None) -> Dict[str, Any]:
         """
         Get the shell descriptor for a given AAS ID.
         """
@@ -66,11 +66,11 @@ class DTRFacadeService:
         specific_asset_ids: List[Dict[str, Any]] = []
 
         with RepositoryManagerFactory.create() as repos:
-            db_twin = repos.twin_repository.find_by_dtr_aas_id(aas_id, include_aspects=True)
+            db_twin = repos.twin_repository.find_by_dtr_aas_id(aas_id, include_aspects=True, include_registrations=True)
             
-            if db_twin is None:
+            if db_twin is None or not db_twin.has_registration(enablement_service_stack_id):
                 raise TwinNotFoundError(f"Shell descriptor {aas_id} not found.")
-            
+
             result["globalAssetId"] = db_twin.global_id.urn
 
             db_catalog_part = repos.catalog_part_repository.get_by_twin_id(db_twin.id)
@@ -170,6 +170,107 @@ class DTRFacadeService:
 
 
         return result
+
+    def lookup_shells(self, enablement_service_stack_id: int, search_params: Dict[str, Any], edc_bpn: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Lookup shells based on the provided search parameters.
+        """
+        print(search_params)
+        print(edc_bpn)
+
+        search_catalog_parts = True
+        search_serilized_parts = True
+        search_jis_parts = True
+        search_batches = True
+
+        global_id = None
+        manufacturer_id = None
+        manufacturer_part_id = None
+        customer_part_id = None
+        intrinsic_id = None
+        batch_id = None
+        part_instance_id = None
+        van = None
+        jis_number = None
+        parent_order_number = None
+        jis_call_date = None
+
+        for name, value in search_params.items():
+            if name == "globalAssetId":
+                global_id = UUID(value)
+            elif name == "manufacturerId":
+                manufacturer_id = value
+            elif name == "manufacturerPartId":
+                manufacturer_part_id = value
+            elif name == "customerPartId":
+                customer_part_id = value
+            elif name == "intrinsicId":
+                intrinsic_id = value
+            elif name == "batchId":
+                search_catalog_parts = False
+                search_jis_parts = False
+                search_serilized_parts = False
+                batch_id = value
+            elif name == "partInstanceId":
+                search_batches = False
+                search_catalog_parts = False
+                search_jis_parts = False
+                part_instance_id = value
+            elif name == "van":
+                search_batches = False
+                search_catalog_parts = False
+                search_jis_parts = False
+                van = value
+            elif name == "jisNumber":
+                search_batches = False
+                search_catalog_parts = False
+                search_serilized_parts = False
+                jis_number = value
+            elif name == "parentOrderNumber":
+                search_batches = False
+                search_catalog_parts = False
+                search_serilized_parts = False
+                parent_order_number = value
+            elif name == "jisCallDate":
+                search_batches = False
+                search_catalog_parts = False
+                search_serilized_parts = False
+                jis_call_date = value
+
+        result: List[UUID] = []
+        with RepositoryManagerFactory.create() as repos:
+            if search_catalog_parts:
+                db_twins = repos.twin_repository.find_catalog_part_twins(
+                    manufacturer_id = manufacturer_id,
+                    manufacturer_part_id = manufacturer_part_id,
+                    global_id = global_id,
+                    include_registrations=True
+                )
+
+                for db_twin in db_twins:
+                    if not db_twin.has_registration(enablement_service_stack_id):
+                        continue
+
+                    if edc_bpn is not None or customer_part_id is not None:
+                        db_catalog_part = repos.catalog_part_repository.get_by_twin_id(db_twin.id, join_partner_catalog_parts=True)
+
+                        if edc_bpn is not None:
+                            db_partner_catalog_part = db_catalog_part.find_partner_catalog_part_by_bpnl(edc_bpn)
+                            if not db_partner_catalog_part:
+                                continue
+
+                        if customer_part_id is not None:
+                            db_partner_catalog_part = db_catalog_part.find_partner_catalog_part_by_customer_part_id(customer_part_id)
+                            if not db_partner_catalog_part:
+                                continue
+
+                    result.append(db_twin.aas_id) 
+
+
+        return {
+            "paging_metadata": {},
+            "result": [aas_id.urn for aas_id in result]
+        }
 
     def _generate_asset_id(self, db_twin, db_twin_aspect) -> str:
         """

--- a/ichub-backend/services/dtr_facade_service.py
+++ b/ichub-backend/services/dtr_facade_service.py
@@ -1,0 +1,203 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+from base64 import b64decode
+from urllib.parse import quote
+
+from services.twin_management_service import TwinManagementService
+from managers.metadata_database.manager import RepositoryManagerFactory
+from tools.submodel_type_util import SubmodelType, get_submodel_type
+
+class TwinNotFoundError(ValueError):
+    """
+    Exception raised when a requested twin is not found in the database.
+    """
+
+class NotAuthorizedError(ValueError):
+    """
+    Exception raised when a requested twin is not authorized for the specified business partner.
+    """
+
+class DTRFacadeService:
+    """
+    Service class for managing DTR facade operations.
+    """
+    
+    def __init__(self, control_plane_url: str = "https://control.plane.url", data_plane_url: str = "https://data.plane.url"):
+        self.twin_management_service = TwinManagementService()
+        self.control_plane_url = control_plane_url
+        self.data_plane_url = data_plane_url
+
+    def get_shell_descriptor(self, aas_id_b64: str, edc_bpn: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Get the shell descriptor for a given AAS ID.
+        """
+        # Decode the base64-encoded AAS ID
+        aas_id = UUID(b64decode(aas_id_b64).decode('utf-8'))
+
+        result = {
+            "id": aas_id.urn,
+            "assetType": "AssetType"
+        }
+
+        specific_asset_ids: List[Dict[str, Any]] = []
+
+        with RepositoryManagerFactory.create() as repos:
+            db_twin = repos.twin_repository.find_by_dtr_aas_id(aas_id, include_aspects=True)
+            
+            if db_twin is None:
+                raise TwinNotFoundError(f"Shell descriptor {aas_id} not found.")
+            
+            result["globalAssetId"] = db_twin.global_id.urn
+
+            db_catalog_part = repos.catalog_part_repository.get_by_twin_id(db_twin.id)
+            if db_catalog_part:
+
+                # Called from a partner => check if the catalog part is shared with the partner
+                if edc_bpn:
+                    db_partner_catalog_part = db_catalog_part.find_partner_catalog_part_by_bpnl(edc_bpn)
+
+                    # Not found => then the partner has no access to the twin
+                    if not db_partner_catalog_part:
+                        raise NotAuthorizedError(f"Catalog part with AAS ID {aas_id} not shared with business partner {edc_bpn}.")
+                    
+                    db_partner_catalog_parts = [db_partner_catalog_part]
+                else:
+                    db_partner_catalog_parts = db_catalog_part.partner_catalog_parts
+
+                
+                result["assetKind"] = "Type"
+                self._add_specific_asset_id(
+                    specific_asset_ids,
+                    "manufacturerPartId",
+                    db_catalog_part.manufacturer_part_id,
+                    "PUBLIC_READABLE"
+                )
+                
+                for db_partner_catalog_part in db_partner_catalog_parts:
+                    self._add_specific_asset_id(
+                        specific_asset_ids,
+                        "digitalTwinType",
+                        "PartType",
+                        db_partner_catalog_part.business_partner.bpnl
+                    )
+                    
+                    self._add_specific_asset_id(
+                        specific_asset_ids,
+                        "manufacturerId",
+                        db_catalog_part.legal_entity.bpnl,
+                        db_partner_catalog_part.business_partner.bpnl
+                    )
+
+                    self._add_specific_asset_id(
+                        specific_asset_ids,
+                        "customerPartId",
+                        db_partner_catalog_part.customer_part_id,
+                        db_partner_catalog_part.business_partner.bpnl
+                    )
+
+                submodel_descriptors: List[Dict[str, Any]] = []
+                for db_twin_aspect in db_twin.twin_aspects:
+                    semandic_id = db_twin_aspect.semantic_id
+                    submodel_type_data = get_submodel_type(semandic_id)
+                    asset_id = self._generate_asset_id(db_twin, db_twin_aspect)
+
+                    entry = {
+                        "id": db_twin_aspect.submodel_id.urn,
+                        "idShort": submodel_type_data.id_short,
+                        "semanticId": {
+                            "type": "ExternalReference",
+                            "keys": [{
+                                "type": "GlobalReference",
+                                "value": semandic_id
+                            }]
+                        },
+                        "supplementalSemanticId": [],
+                        "description": [],
+                        "displayName": [],
+                        "endpoints": [{
+                            "interface": "SUBMODEL-3.0",
+                            "protocolInformation": {
+                                "href": f"{self.data_plane_url}/api/public/{quote(semandic_id)}/{str(db_twin.global_id)}/submodel",
+                                "endpointProtocol": "HTTP",
+                                "endpointProtocolVersion": [
+                                "1.1"
+                                ],
+                                "subprotocol": "DSP",
+                                "subprotocolBody": f"id={asset_id};dspEndpoint={self.control_plane_url}",
+                                "subprotocolBodyEncoding": "plain",
+                                "securityAttributes": [
+                                {
+                                    "type": "NONE",
+                                    "key": "NONE",
+                                    "value": "NONE"
+                                }
+                                ]
+                            }
+                            }
+                        ],                        
+                    }
+                                            
+                    submodel_descriptors.append(entry)
+                
+
+                result["specificAssetIds"] = specific_asset_ids
+                if submodel_descriptors:
+                    result["submodelDescriptors"] = submodel_descriptors
+
+
+        return result
+
+    def _generate_asset_id(self, db_twin, db_twin_aspect) -> str:
+        """
+        Generate an asset ID based on the twin and aspect information.
+        """
+        return "dummy:asset:id"  # Placeholder for actual asset ID generation logic
+
+    def _add_specific_asset_id(
+        self,
+        specific_asset_ids: List[Dict[str, Any]],
+        name: str,
+        value: str,
+        external_subject_id: Optional[str] = None) -> None:
+        
+        entry = {
+            "supplementalSemanticIds": [],
+            "name": name,
+            "value": value
+        }
+        if external_subject_id:
+            entry["externalSubjectId"] = {
+                "type": "ExternalReference",
+                "keys": [
+                    {
+                        "type": "GlobalReference",
+                        "value": external_subject_id
+                    }
+                ]
+            }
+
+        specific_asset_ids.append(entry)

--- a/ichub-backend/services/submodel_dispatcher_service.py
+++ b/ichub-backend/services/submodel_dispatcher_service.py
@@ -62,7 +62,9 @@ class SubmodelDispatcherService:
             db_twin_exchange = repos.twin_exchange_repository.find_by_global_id_business_partner_number(
                 global_id, edc_bpn)
             
+            # We found no "share" for the part => raise an error
             if not db_twin_exchange:
                 raise SubmodelNotSharedWithBusinessPartnerError(f"Requested twin with global ID {global_id} not shared with business partner {edc_bpn}.")
             
+            # Call the submodel service manager to get the submodel content from the submodel service
             return self.submodel_service_manager.get_twin_aspect_document(global_id, semantic_id)

--- a/ichub-backend/services/submodel_dispatcher_service.py
+++ b/ichub-backend/services/submodel_dispatcher_service.py
@@ -1,0 +1,68 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from uuid import UUID
+from typing import Dict, Any
+
+from managers.enablement_services.submodel_service_manager import SubmodelServiceManager
+from managers.metadata_database.manager import RepositoryManagerFactory
+
+class SubmodelNotSharedWithBusinessPartnerError(ValueError):
+    """
+    Exception raised when a requested twin is not shared with the specified business partner.
+    """
+
+class SubmodelDispatcherService:
+    """
+    Service class for managing submodel dispatching.
+    """
+    
+    def __init__(self):
+        # TODO: Deal with the proper config => Submodel Service is normally a singleton
+        self.submodel_service_manager = SubmodelServiceManager()
+
+    def get_submodel_content(self,
+        edc_bpn: str,
+        edc_contract_agreement_id: str,
+        semantic_id: str,
+        global_id: UUID) -> Dict[str, Any]:
+        """
+        Dispatch a submodel to the appropriate service or endpoint.
+        """
+
+        # This implementation just checks if the twin where the submodel belongs to is shared with the business partner
+        # via any data exchange agreement.
+        # It does not check the semantic ID of the sumodel. This could later be done when we also manage the
+        # submodel contracts behind the data exchange agreements.
+        # Also to be analyzed later: does the contract agreement ID (which the EDC Data Plane provides to us)
+        # somehow give us more possibilities of evaluating? (drawback: in this service we should actually
+        # avoid calling too many other services - especially not the EDC Control Plane)
+        with RepositoryManagerFactory.create() as repos:
+            db_twin_exchange = repos.twin_exchange_repository.find_by_global_id_business_partner_number(
+                global_id, edc_bpn)
+            
+            if not db_twin_exchange:
+                raise SubmodelNotSharedWithBusinessPartnerError(f"Requested twin with global ID {global_id} not shared with business partner {edc_bpn}.")
+            
+            return self.submodel_service_manager.get_twin_aspect_document(global_id, semantic_id)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adds service that provides an API compatible to the DTR Read API which is based on the IC-Hub internal metamodel and not on a separate DTR installation.
In this way the API could be directly put behind the standardized DTR asset of the front EDC keeping CX-0002 standard compliance.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
