### PR TITLE
Fix: Include loading spinner in catalog parts to not show error message

### DIFF
--- a/ichub-frontend/src/assets/styles/pages/_PartnersList.scss
+++ b/ichub-frontend/src/assets/styles/pages/_PartnersList.scss
@@ -22,18 +22,4 @@
 
 @use '../config/variables' as *;
 @use '../config/mixins';
-
-.spinner {
-    border: 4px solid rgba(0,0,0,0.1);
-    width: 70px;
-    height: 70px;
-    border-radius: 50%;
-    border-left-color: $brand-text;
-    animation: spin 1s ease infinite;
-    margin: auto;
-  }
-  
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
   

--- a/ichub-frontend/src/assets/styles/pages/_PartnersList.scss
+++ b/ichub-frontend/src/assets/styles/pages/_PartnersList.scss
@@ -22,3 +22,18 @@
 
 @use '../config/variables' as *;
 @use '../config/mixins';
+
+.spinner {
+    border: 4px solid rgba(0,0,0,0.1);
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    border-left-color: $brand-text;
+    animation: spin 1s ease infinite;
+    margin: auto;
+  }
+  
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  

--- a/ichub-frontend/src/assets/styles/pages/_ProductList.scss
+++ b/ichub-frontend/src/assets/styles/pages/_ProductList.scss
@@ -61,3 +61,17 @@
         font-size: 8em;
     }
 }
+
+.spinner {
+    border: 4px solid rgba(0,0,0,0.1);
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    border-left-color: $brand-text;
+    animation: spin 1s ease infinite;
+    margin: auto;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}

--- a/ichub-frontend/src/components/general/LoadingSpinner.tsx
+++ b/ichub-frontend/src/components/general/LoadingSpinner.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mui/material'
+
+const LoadingSpinner = () => {
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        margin: "auto",
+        height: "100%",
+      }}
+    >
+      <span className="spinner"></span>
+    </Box>
+  )
+}
+
+export default LoadingSpinner

--- a/ichub-frontend/src/components/general/LoadingSpinner.tsx
+++ b/ichub-frontend/src/components/general/LoadingSpinner.tsx
@@ -1,3 +1,25 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 import { Box } from '@mui/material'
 
 const LoadingSpinner = () => {

--- a/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
@@ -28,6 +28,7 @@ import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import { CardChip } from "./CardChip";
 import { StatusVariants } from "../../../../types/statusVariants";
 import { ErrorNotFound } from "../../../../components/general/ErrorNotFound";
+import LoadingSpinner from "../../../../components/general/LoadingSpinner";
 
 export interface AppContent {
   id?: string;
@@ -74,17 +75,7 @@ export const ProductCard = ({
   return (
     <Box className="custom-cards-list">
       {isLoading && (
-        <Box
-          sx={{
-            width: "100%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            margin: "auto",
-          }}
-        >
-          <span className="spinner"></span>
-        </Box>
+        <LoadingSpinner />
       )}
       {!isLoading && items.length === 0 && (
         <ErrorNotFound icon={ReportProblemIcon} message="No catalog parts available, please check your ichub-backend connection/configuration"/>

--- a/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
@@ -43,6 +43,7 @@ export interface CardDecisionProps {
   onShare: (e1: string, e2: string) => void;
   onMore: (e1: string, e2: string) => void;
   onClick: (e: string) => void;
+  isLoading: boolean;
 }
 
 export enum ButtonEvents {
@@ -55,6 +56,7 @@ export const ProductCard = ({
   onShare,
   onMore,
   onClick,
+  isLoading,
 }: CardDecisionProps) => {
 
   const handleDecision = (
@@ -71,7 +73,20 @@ export const ProductCard = ({
 
   return (
     <Box className="custom-cards-list">
-      {items.length === 0 && (
+      {isLoading && (
+        <Box
+          sx={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            margin: "auto",
+          }}
+        >
+          <span className="spinner"></span>
+        </Box>
+      )}
+      {!isLoading && items.length === 0 && (
         <ErrorNotFound icon={ReportProblemIcon} message="No catalog parts available, please check your ichub-backend connection/configuration"/>
       )}
       {items.map((item) => {

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-import React from "react";
+import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import sharedPartners from '../tests/payloads/shared-partners.json';
 import { StatusTag, Button, Icon } from '@catena-x/portal-shared-components';
@@ -36,6 +36,7 @@ import ShareDialog from "../components/general/ShareDialog";
 import { PartType } from "../types/product";
 import { fetchCatalogPart } from "../features/catalog-management/api";
 import { mapApiPartDataToPartType } from "../features/catalog-management/utils";
+import LoadingSpinner from "../components/general/LoadingSpinner";
 
 const ProductsDetails = () => {
 
@@ -44,13 +45,14 @@ const ProductsDetails = () => {
     manufacturerPartId: string;
   }>();
 
-  const [partType, setPartType] = React.useState<PartType>();
-  const [jsonDialogOpen, setJsonDialogOpen] = React.useState(false);
-  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
-  const [notification, setNotification] = React.useState<{ open: boolean; severity: "success" | "error"; title: string } | null>(null);
+  const [partType, setPartType] = useState<PartType>();
+  const [jsonDialogOpen, setJsonDialogOpen] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [notification, setNotification] = useState<{ open: boolean; severity: "success" | "error"; title: string } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!manufacturerId || !manufacturerPartId) return;
 
       fetchData();
@@ -62,6 +64,7 @@ const ProductsDetails = () => {
   const productId = manufacturerId + "/" + manufacturerPartId
 
   const fetchData = async () => {
+    setIsLoading(true);
     try {
       const apiData = await fetchCatalogPart(manufacturerId, manufacturerPartId);
       console.log(apiData)
@@ -71,10 +74,16 @@ const ProductsDetails = () => {
       setPartType(mappedCarParts);
     } catch (error) {
       console.error("Error fetching data:", error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
-        // Map API data to PartInstance[]
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+  
+  // Map API data to PartInstance[]
   if (!partType) {
     return <div>Product not found</div>;
   }

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -24,19 +24,25 @@ import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import sharedPartners from '../tests/payloads/shared-partners.json';
 import { StatusTag, Button, Icon } from '@catena-x/portal-shared-components';
-import { PRODUCT_STATUS } from "../types/common";
-import JsonViewerDialog from "../features/catalog-management/components/product-detail/JsonViewerDialog";
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import Grid2 from '@mui/material/Grid2';
+
 import InstanceProductsTable from "../features/catalog-management/components/product-detail/InstanceProductsTable";
-import PageNotification from "../components/general/PageNotification";
 import ShareDropdown from "../features/catalog-management/components/product-detail/ShareDropdown";
 import ProductButton from "../features/catalog-management/components/product-detail/ProductButton";
 import ProductData from "../features/catalog-management/components/product-detail/ProductData";
+import JsonViewerDialog from "../features/catalog-management/components/product-detail/JsonViewerDialog";
+
 import ShareDialog from "../components/general/ShareDialog";
+import {ErrorNotFound} from "../components/general/ErrorNotFound";
+import LoadingSpinner from "../components/general/LoadingSpinner";
+import PageNotification from "../components/general/PageNotification";
+
 import { PartType } from "../types/product";
+import { PRODUCT_STATUS } from "../types/common";
+
 import { fetchCatalogPart } from "../features/catalog-management/api";
 import { mapApiPartDataToPartType } from "../features/catalog-management/utils";
-import LoadingSpinner from "../components/general/LoadingSpinner";
 
 const ProductsDetails = () => {
 
@@ -85,7 +91,7 @@ const ProductsDetails = () => {
   
   // Map API data to PartInstance[]
   if (!partType) {
-    return <div>Product not found</div>;
+    return <ErrorNotFound icon={ReportProblemIcon} message="Product not found"/>;
   }
 
   const handleOpenJsonDialog = () => {

--- a/ichub-frontend/src/pages/ProductsList.tsx
+++ b/ichub-frontend/src/pages/ProductsList.tsx
@@ -25,7 +25,7 @@ import { useNavigate } from "react-router-dom";
 import { ProductCard } from "../features/catalog-management/components/product-list/ProductCard";
 import { PartType, ApiPartData } from "../types/product";
 import TablePagination from "@mui/material/TablePagination";
-import { Typography, Grid2, Box } from "@mui/material"; // Removed Paper
+import { Typography, Grid2, Box } from "@mui/material";
 import { Button } from "@catena-x/portal-shared-components";
 import AddIcon from "@mui/icons-material/Add";
 import ShareDialog from "../components/general/ShareDialog";
@@ -42,6 +42,7 @@ const ProductsList = () => {
   const rowsPerPage = 10;
   const navigate = useNavigate();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleChangePage = (
     _event: React.MouseEvent<HTMLButtonElement> | null,
@@ -51,6 +52,7 @@ const ProductsList = () => {
   };
 
   const fetchData = async () => {
+    setIsLoading(true);
     try {
       const apiData: ApiPartData[] = await fetchCatalogParts();
 
@@ -63,6 +65,8 @@ const ProductsList = () => {
       setInitialCarParts(mappedCarParts);
     } catch (error) {
       console.error("Error fetching data:", error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -151,6 +155,7 @@ const ProductsList = () => {
               category: part.category,
               status: part.status,
             }))}
+            isLoading={isLoading}
           />
         </Grid2>
 


### PR DESCRIPTION
## Description

The new error message to display when there are no catalog parts, was displayed one second before the list was loaded (the time it took for the API to respond). To avoid this problem, an `isLoading`  state has been included, to show a loading spinner while loading and thus show the error message only when the list is empty.

Take into account that now, the API is really fast to respond, so the loading state is almost nothing in a matter of time. However, this is important because if the API would take longer to load, the error message would be displayed without any error.

![image](https://github.com/user-attachments/assets/99823269-f51b-4704-b8ac-916ea29418f1)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files