### PR TITLE
Fix/frontend fixes

### DIFF
--- a/ichub-frontend/src/assets/styles/components/_SharedTable.scss
+++ b/ichub-frontend/src/assets/styles/components/_SharedTable.scss
@@ -27,6 +27,18 @@
     width: 100%;
     overflow: hidden;
     background-color: $brand-dark!important;
+    margin-top: 16px;
+
+    tbody td {
+        padding-bottom: 10px;
+        padding-top: 10px;
+    }
+
+    thead th {
+        padding-bottom: 10px;
+        padding-top: 10px;
+        background: $brand-dark-gray;
+    }
 }
 
 div#menu-[role="presentation"] li {

--- a/ichub-frontend/src/assets/styles/components/_SharedTable.scss
+++ b/ichub-frontend/src/assets/styles/components/_SharedTable.scss
@@ -20,6 +20,15 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-@forward 'CustomCardList';
-@forward 'Dialog';
-@forward 'SharedTable';
+@use "../config/variables" as *;
+@use '../config/mixins';
+
+.shared-table {
+    width: 100%;
+    overflow: hidden;
+    background-color: $brand-dark!important;
+}
+
+div#menu-[role="presentation"] li {
+    color: $brand-text!important;
+}

--- a/ichub-frontend/src/assets/styles/pages/_ProductDetail.scss
+++ b/ichub-frontend/src/assets/styles/pages/_ProductDetail.scss
@@ -26,6 +26,10 @@
 .productDetail {
     padding: 20px;
     margin: 20px 50px 30px;
+
+    @media (max-width: 600px) {
+        margin: 0;
+    }
   
     * {
         color: $brand-text !important;

--- a/ichub-frontend/src/assets/styles/pages/_ProductDetail.scss
+++ b/ichub-frontend/src/assets/styles/pages/_ProductDetail.scss
@@ -36,6 +36,7 @@
         @include mixins.rounded-bordered;
         @include mixins.space-shadow($brand-blue);
         padding: 20px;
+        margin-bottom: 20px;
         
         .MuiBox-root, .MuiGrid2-root {
             margin: 10px 0;

--- a/ichub-frontend/src/components/general/ShareDialog.tsx
+++ b/ichub-frontend/src/components/general/ShareDialog.tsx
@@ -27,16 +27,10 @@ import SendIcon from '@mui/icons-material/Send';
 import CloseIcon from '@mui/icons-material/Close';
 
 import { ProductDetailDialogProps } from '../../types/dialogViewer';
-import { shareCatalogPart } from '../../features/catalog-management/api';
+import { PartnerInstance } from "../../types/partner";
 
-// Sample BPNL data for the autocomplete field
-// After the integration, this data would be fetched from the API
-const PREVIOUS_BPNLS = [
-  'BPNL0000000001XY',
-  'BPNL0000000002XY',
-  'BPNL0000000003XY',
-  'BPNL0000000004XY',
-];
+import { shareCatalogPart } from '../../features/catalog-management/api';
+import { fetchPartners } from '../../features/partner-management/api';
 
 const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
   const title = partData?.name ?? "Part name not obtained";
@@ -45,6 +39,7 @@ const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
   const [error, setError] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [apiErrorMessage, setApiErrorMessage] = useState('');
+  const [partnerBpnlsList, setPartnerBpnlsList] = useState<string[]>([]);
 
   useEffect(() => {
     // Reset fields when dialog opens or partData changes
@@ -53,6 +48,17 @@ const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
       setError(false);
       setSuccessMessage('');
       setApiErrorMessage('');
+
+      const fetchData = async () => {
+        try {
+          const data = await fetchPartners();          
+          setPartnerBpnlsList(data.map((partner: PartnerInstance) => partner.bpnl));
+        } catch (error) {
+          console.error('Error fetching data:', error);  
+          setPartnerBpnlsList([]);
+        }
+      };
+      fetchData();
     }
   }, [open, partData]);
 
@@ -133,7 +139,7 @@ const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
         <Box sx={{ mt: 2, mx: 'auto', maxWidth: 400 }}>
           <Autocomplete
             freeSolo
-            options={PREVIOUS_BPNLS}
+            options={partnerBpnlsList}
             inputValue={bpnl}
             onInputChange={handleBpnlChange}
             renderInput={(params) => (

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
@@ -21,14 +21,12 @@
 ********************************************************************************/
 
 import { Box, Grid2 } from '@mui/material'
-import { Icon, Typography } from '@catena-x/portal-shared-components';
+import { Typography } from '@catena-x/portal-shared-components';
 import { PartType } from '../../../../types/product';
 import { PieChart } from '@mui/x-charts/PieChart';
 
-interface SharedPartner {
-    name: string;
-    bpnl: string;
-}
+import { SharedPartner } from '../../../../types/sharedPartners';
+import SharedTable from './SharedTable';
 
 interface ProductDataProps {
     part: PartType;
@@ -42,12 +40,14 @@ const sharedInformation = {
 
 const ProductData = ({ part, sharedParts }: ProductDataProps) => {
   return (
-    <Grid2 container justifyContent="space-between" className="mb-5" spacing={8} display={"flex"} flexDirection={"row"}>
-        <Grid2 size={{lg: 6, md: 12, sm: 12}} display={"flex"} flexDirection={"column"}>
-            <Grid2 className="ml-5 mb-5 title-subtitle">
+    <Grid2 container justifyContent="space-between" className="mb-5" columnSpacing={8} display={"flex"} flexDirection={"row"}>
+        <Grid2 size={12}>
+            <Grid2 className="ml-5 title-subtitle">
                 <Typography variant="h2">{part.name}</Typography>
                 <Typography variant="caption1">{part.category}</Typography>
             </Grid2>
+        </Grid2>
+        <Grid2 size={{lg: 5, md: 12, sm: 12}} display={"flex"} flexDirection={"column"}>
             {/*Content on the left side*/}
             <Grid2 className="ml-2 mt-5 product-card-details">
                 <Box>
@@ -80,7 +80,7 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
         </Grid2>
 
         {/*Content on the right side*/}
-        <Grid2 size={{lg: 6, md: 12, sm: 12}}>
+        <Grid2 size={{lg: 7, md: 12, sm: 12}}>
             {/* <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
                 <img src={part.image} alt={part.name} className="product-image" />
                 <Typography variant="label4">{part.uuid}</Typography>
@@ -89,19 +89,7 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
             {/*Sharing information*/}
             <Box component="ul" sx={{ listStyle: 'none', padding: 0, mt: 2 }} className={"product-card"}>
                 <Typography variant="h6" className="mt-4">Shared With:</Typography>
-                {(sharedParts ?? []).map(({ name, bpnl }, index) => (
-                    <Box key={index} component="li" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start' }}>
-                        <Icon fontSize="16" iconName="Polyline" className="my-auto mr-1" />
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
-                            <Typography variant="label2" sx={{ mr: '5px', fontWeight: 'bold' }}> {name} -</Typography>
-                            <Typography variant="body2">{bpnl}</Typography>
-                        </Box>
-                    </Box>
-                ))}
-                <Box component="li" sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
-                <Icon fontSize="16" iconName="Launch" className="my-auto mr-1" />
-                    <a href="">512 more</a>
-                </Box>
+                <SharedTable sharedParts={sharedParts} />
             </Box>
             {/*Materials and dimensions*/}
             <Box className="product-card">

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
@@ -49,7 +49,7 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
         </Grid2>
         <Grid2 size={{lg: 5, md: 12, sm: 12}} display={"flex"} flexDirection={"column"}>
             {/*Content on the left side*/}
-            <Grid2 className="ml-2 mt-5 product-card-details">
+            <Grid2 className="product-card-details">
                 <Box>
                 <Typography variant="label3">Manufacturer</Typography>
                 <Typography variant="body1">{part.manufacturerId}</Typography>
@@ -87,7 +87,7 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
             </Box> */}
 
             {/*Sharing information*/}
-            <Box component="ul" sx={{ listStyle: 'none', padding: 0, mt: 2 }} className={"product-card"}>
+            <Box className="product-card">
                 <Typography variant="h6" className="mt-4">Shared With:</Typography>
                 <SharedTable sharedParts={sharedParts} />
             </Box>

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/SharedTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/SharedTable.tsx
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+import React, { useState } from "react";
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TablePagination} from "@mui/material";
+
+import { SharedPartner } from '../../../../types/sharedPartners';
+
+interface SharedTableProps {
+  sharedParts: SharedPartner[];
+}
+
+const SharedTable = ({ sharedParts }: SharedTableProps) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Paper className="shared-table">
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>BPNL</TableCell>
+              <TableCell>Customer part ID</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sharedParts
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell>{row.bpnl}</TableCell>
+                  <TableCell>{row.customerPartId}</TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination className="table-pagination"
+        component="div"
+        count={sharedParts.length}
+        page={page}
+        onPageChange={handleChangePage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={[5, 10, 25]}
+      />
+    </Paper>
+  );
+};
+
+export default SharedTable;

--- a/ichub-frontend/src/features/partner-management/components/general/CreateProductListDialog.tsx
+++ b/ichub-frontend/src/features/partner-management/components/general/CreateProductListDialog.tsx
@@ -67,10 +67,7 @@ const initialJsonPlaceholder = JSON.stringify(
     width: { value: 200, unit: Unit.MM },
     height: { value: 100, unit: Unit.MM },
     length: { value: 50, unit: Unit.MM },
-    weight: { value: 5, unit: Unit.KG },
-    customer_part_ids: {
-      BPNL0000000CUSTA: "CUSTA-PART-EXAMPLE",
-    },
+    weight: { value: 5, unit: Unit.KG }
   } as Omit<PartType, "status">, // Use Omit to exclude status from placeholder type
   null,
   2
@@ -287,16 +284,10 @@ const CreateProductListDialog = ({
       await createCatalogPart(
         mapPartInstanceToApiPartData(parsedPayload as PartType)
       );
-      console.log(
-        `Catalog Part created via API with content: ${jsonContent.substring(
-          0,
-          100
-        )}...`
-      );
-      onSave?.({ jsonContent: jsonContent.trim() });
-      setSuccessMessage(`Catalog Part created successfully.`);
+      setSuccessMessage(`Catalog part created successfully.`);
       setTimeout(() => {
         setSuccessMessage("");
+        onSave?.({ jsonContent: jsonContent.trim() });
         onClose();
       }, 3000);
     } catch (axiosError) {

--- a/ichub-frontend/src/features/partner-management/components/partners-list/PartnerCard.tsx
+++ b/ichub-frontend/src/features/partner-management/components/partners-list/PartnerCard.tsx
@@ -57,7 +57,7 @@ export const PartnerCard = ({ items, onClick, onDelete, onEdit }: CardDecisionPr
               <Box className="custom-card-header">
                 <Box></Box>
                 <Box className="custom-card-header-buttons">
-                  <IconButton
+                  {/* <IconButton
                     onClick={() => {
                       onEdit?.(bpnl);
                     }}
@@ -72,7 +72,7 @@ export const PartnerCard = ({ items, onClick, onDelete, onEdit }: CardDecisionPr
                     }}
                   >
                     <DeleteIcon sx={{ color: "rgba(255, 255, 255, 0.68)" }} />
-                  </IconButton>
+                  </IconButton> */}
                 </Box>
               </Box>
               <Box className="custom-card-content">

--- a/ichub-frontend/src/features/partner-management/components/partners-list/PartnerCard.tsx
+++ b/ichub-frontend/src/features/partner-management/components/partners-list/PartnerCard.tsx
@@ -57,7 +57,7 @@ export const PartnerCard = ({ items, onClick, onDelete, onEdit }: CardDecisionPr
               <Box className="custom-card-header">
                 <Box></Box>
                 <Box className="custom-card-header-buttons">
-                  {/* <IconButton
+                  <IconButton sx={{ cursor: "default", pointerEvents: "none", opacity: 0.4 }}
                     onClick={() => {
                       onEdit?.(bpnl);
                     }}
@@ -65,14 +65,14 @@ export const PartnerCard = ({ items, onClick, onDelete, onEdit }: CardDecisionPr
                     <EditIcon sx={{ color: "white" }} />
                   </IconButton>
                   
-                  <IconButton
+                  <IconButton sx={{ cursor: "default", pointerEvents: "none", opacity: 0.4 }}
                     onClick={(e) => {
                       e.stopPropagation();
                       onDelete?.(bpnl);
                     }}
                   >
                     <DeleteIcon sx={{ color: "rgba(255, 255, 255, 0.68)" }} />
-                  </IconButton> */}
+                  </IconButton>
                 </Box>
               </Box>
               <Box className="custom-card-content">

--- a/ichub-frontend/src/pages/ProductsList.tsx
+++ b/ichub-frontend/src/pages/ProductsList.tsx
@@ -59,6 +59,8 @@ const ProductsList = () => {
         mapApiPartDataToPartType(part)
       );
 
+      mappedCarParts.reverse(); // Reverse the order of the array
+
       setCarParts(mappedCarParts);
       setInitialCarParts(mappedCarParts);
     } catch (error) {

--- a/ichub-frontend/src/tests/payloads/shared-partners.json
+++ b/ichub-frontend/src/tests/payloads/shared-partners.json
@@ -1,22 +1,27 @@
 [
     {
         "name": "Volkswagen AG",
-        "bpnl": "BPNL4565423555AS"
+        "bpnl": "BPNL4565423555AS",
+        "customerPartId": "BPNL4565423555AS_AUT_527TR"
     },
     {
         "name": "BMW Racing Gmbh",
-        "bpnl": "BPNL0000001023"
+        "bpnl": "BPNL0000001023",
+        "customerPartId": "BPNL0000001023_AUT_527TR"
     },
     {
         "name": "BASF",
-        "bpnl": "BPNL5004654513"
+        "bpnl": "BPNL5004654513",
+        "customerPartId": "BPNL5004654513_AUT_527TR"
     },
     {
         "name": "Mercedes-Benz",
-        "bpnl": "BPNL856ASD9656A"
+        "bpnl": "BPNL856ASD9656A",
+        "customerPartId": "BPNL856ASD9656A_AUT_527TR"
     },
     {
         "name": "BOSCH",
-        "bpnl": "BPNL5470544322"
+        "bpnl": "BPNL5470544322",
+        "customerPartId": "BPNL5470544322_AUT_527TR"
     }
 ]

--- a/ichub-frontend/src/types/sharedPartners.ts
+++ b/ichub-frontend/src/types/sharedPartners.ts
@@ -20,6 +20,8 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-@forward 'CustomCardList';
-@forward 'Dialog';
-@forward 'SharedTable';
+export interface SharedPartner {
+    name: string;
+    bpnl: string;
+    customerPartId: string;
+}


### PR DESCRIPTION
## Description

Frontend fixes. Tasks done:
- Pagination. Invert order of catalog parts to show first the newest parts.
- Set as disabled edit and delete buttons in partners view.
- Show a success message when creating parts.
- BPNLs of the dropdown button of share, are obtained from API.
- "Shared with" section converted to a table with pagination.
- Card borders of the product cards have been checked but the mentioned problem does not happen.

![image](https://github.com/user-attachments/assets/75179231-c188-4797-813f-2d81c4c1bc5e)

Tasks not done for now:

- “created”, ‘updated’, “global id” and the “aas_id” data showed from API data. (It was not possible to do it because the API is not yet done)
- Refresh on share (It was not possible to do it because I was getting a 500 error when sharing).

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files