### PR TITLE
fix: responsiveness fixes for new components in product detail page

### DIFF
--- a/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/ProductData.tsx
@@ -40,23 +40,24 @@ const sharedInformation = {
 
 const ProductData = ({ part, sharedParts }: ProductDataProps) => {
   return (
-    <Grid2 container justifyContent="space-between" className="mb-5" columnSpacing={8} display={"flex"} flexDirection={"row"}>
+    <Grid2 container size={12} justifyContent="space-between" className="mb-5" columnSpacing={8}>
         <Grid2 size={12}>
             <Grid2 className="ml-5 title-subtitle">
                 <Typography variant="h2">{part.name}</Typography>
                 <Typography variant="caption1">{part.category}</Typography>
             </Grid2>
         </Grid2>
+        
         <Grid2 size={{lg: 5, md: 12, sm: 12}} display={"flex"} flexDirection={"column"}>
             {/*Content on the left side*/}
             <Grid2 className="product-card-details mb-5">
                 <Box>
-                <Typography variant="label3">Manufacturer</Typography>
-                <Typography variant="body1">{part.manufacturerId}</Typography>
+                    <Typography variant="label3">Manufacturer</Typography>
+                    <Typography variant="body1">{part.manufacturerId}</Typography>
                 </Box>
                 <Box>
-                <Typography variant="label3">Manufacturer Part Id</Typography>
-                <Typography variant="body1">{part.manufacturerPartId}</Typography>
+                    <Typography variant="label3">Manufacturer Part Id</Typography>
+                    <Typography variant="body1">{part.manufacturerPartId}</Typography>
                 </Box>
                 <Box>
                     <Typography variant="label3">Site of Origin (BPNS)</Typography>
@@ -103,20 +104,19 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
             {/*Materials and dimensions*/}
             <Box className="product-card mb-5">
                 <Typography variant="h6" className="mt-4">More Information:</Typography>
-                <Box
-                    component="ul"
+                <Box component="ul"
                     sx={{
                         listStyle: 'none',
                         padding: 0,
                         mt: 2,
                         display: 'flex',
-                        flexDirection: 'row',
+                        flexDirection: { xs: 'column', md: 'row' },
                         alignItems: 'flex-start',
-                        gap: 8,
+                        gap: { xs: 0, md: 8 },
                     }}
                 >
                     {/*chart of materials*/}
-                    <Box sx={{ width: '50%'}}>
+                    <Grid2 size={{ md: 8, xs: 12 }}>
                         <Typography variant="label3">Materials:</Typography>
                         {(part.materials && part.materials.length>0) ? (
                             <PieChart
@@ -148,26 +148,26 @@ const ProductData = ({ part, sharedParts }: ProductDataProps) => {
                                 </Typography>
                             </Box>
                         )}
-                    </Box>
+                    </Grid2>
                     {/*physical properties*/}
-                    <Box sx={{ width: '50%'}}>
-                        <Box>
+                    <Grid2 container size={{ md: 4, xs: 12 }} sx={{ marginY: 'auto' }}>
+                        <Grid2 size={6} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
                             <Typography variant="label3">Width:</Typography>
                             <Typography variant="body1">{part.width?.value} {part.width?.unit}</Typography>
-                        </Box>
-                        <Box>
+                        </Grid2>
+                        <Grid2 size={6} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
                             <Typography variant="label3">Height:</Typography>
                             <Typography variant="body1">{part.height?.value} {part.height?.unit}</Typography>
-                        </Box>
-                        <Box>
+                        </Grid2>
+                        <Grid2 size={6} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
                             <Typography variant="label3">Length:</Typography>
                             <Typography variant="body1">{part.length?.value} {part.length?.unit}</Typography>
-                        </Box>
-                        <Box>
+                        </Grid2>
+                        <Grid2 size={6} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
                             <Typography variant="label3">Weight:</Typography>
                             <Typography variant="body1">{part.weight?.value} {part.weight?.unit}</Typography>
-                        </Box>
-                    </Box>
+                        </Grid2>
+                    </Grid2>
 
                 </Box>
             </Box>

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -170,31 +170,26 @@ const ProductsDetails = () => {
     <>
       <PageNotification notification={notification} />
 
-      <Grid2 container direction="column" className="productDetail">
-        <Grid2 container spacing={2} className="mb-5">
-          <Grid2 size={{lg: 4, md: 6, sm: 6}} display="flex" justifyContent="start">
-            {getStatusTag(partType.status ?? PRODUCT_STATUS.DRAFT)}
-          </Grid2>
-          <Grid2 size={{lg: 4, md: 6, sm: 6}} display="flex" justifyContent={{ lg: "center", md: "end", sm: "end" }}>
-            <Button size="small" onClick={() => console.log("DCM v2.0 button")} className="update-button" endIcon={<Icon fontSize="16" iconName="Edit" />}>            
-                <span className="update-button-content">UPDATE</span>            
-            </Button>
-          </Grid2>
-          <Grid2 size={{lg: 4, md: 12, sm: 12}} display="flex" justifyContent="end">
-            <ShareDropdown handleCopy={handleCopy} handleDownload={handleDownload} handleShare={handleOpenShareDialog} />
-          </Grid2>
+      <Grid2 container className="productDetail">
+        <Grid2 size={4} display="flex" justifyContent="start">
+          {getStatusTag(partType.status ?? PRODUCT_STATUS.DRAFT)}
         </Grid2>
+        <Grid2 size={4} display="flex" justifyContent="center">
+          <Button size="small" onClick={() => console.log("DCM v2.0 button")} className="update-button" endIcon={<Icon fontSize="16" iconName="Edit" />}>            
+              <span className="update-button-content">UPDATE</span>            
+          </Button>
+        </Grid2>
+        <Grid2 size={4} display="flex" justifyContent="end">
+          <ShareDropdown handleCopy={handleCopy} handleDownload={handleDownload} handleShare={handleOpenShareDialog} />
+        </Grid2>
+
         <ProductData part={partType} sharedParts={sharedPartners} />
-        <Grid2 container spacing={2} direction="column" className="add-on-buttons">
-
+        
+        <Grid2 container size={12} spacing={2}className="add-on-buttons">
           <ProductButton gridSize={{ sm: 12 }} buttonText="MORE INFORMATION" onClick={handleOpenJsonDialog} />
-
-          <Grid2 container spacing={2} justifyContent="center">
-            <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="PCF v3.0.0" onClick={() => console.log("PCF v2.0 button")} />
-            <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DIGITAL PRODUCT PASSPORT v6.0.0" onClick={() => console.log("TRANSMISSION PASS v2.0.0")} />
-            <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DCM v2.0.0" onClick={() => console.log("DPP v2.0 button")} />
-          </Grid2>
-
+          <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="PCF v3.0.0" onClick={() => console.log("PCF v2.0 button")} />
+          <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DIGITAL PRODUCT PASSPORT v6.0.0" onClick={() => console.log("TRANSMISSION PASS v2.0.0")} />
+          <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DCM v2.0.0" onClick={() => console.log("DPP v2.0 button")} />
           <Grid2 size={{ sm: 12 }}>
             <Button className="submodel-button" color="success" size="small" onClick={() => console.log("Add button")} fullWidth={true} style={{ padding: "5px" }}>
               <Icon fontSize="18" iconName="Add" />


### PR DESCRIPTION
## Description

As described in the issue #269 , the interface broke in small screens.

In this pull request the `ProductsDetails` page and `ProductData` component have been corrected to be completely responsive in all sizes screens. As an example:

![image](https://github.com/user-attachments/assets/0279680d-b956-4636-82fe-6790165d59cc)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files