### PR TITLE
feat: enable unshare mechanism

### DIFF
--- a/ichub-backend/controllers/fastapi/routers/twin_management.py
+++ b/ichub-backend/controllers/fastapi/routers/twin_management.py
@@ -31,7 +31,8 @@ from models.services.twin_management import (
     CatalogPartTwinRead, CatalogPartTwinDetailsRead,
     CatalogPartTwinCreate, CatalogPartTwinShareCreate,
     SerializedPartTwinRead, SerializedPartTwinDetailsRead,
-    SerializedPartTwinCreate, SerializedPartTwinShareCreate
+    SerializedPartTwinCreate, SerializedPartTwinShareCreate,
+    SerializedPartTwinUnshareCreate
 )
 from tools.exceptions import exception_responses
 
@@ -95,5 +96,16 @@ async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreat
 async def twin_management_share_serialized_part_twin(serialized_part_twin_share: SerializedPartTwinShareCreate):
     if twin_management_service.create_serialized_part_twin_share(serialized_part_twin_share):
         return JSONResponse(status_code=201, content={"description":"Serialized part twin shared successfully"})
+    else:
+        return JSONResponse(status_code=204, content=None)
+    
+@router.post("/serialized-part-twin/unshare", responses={
+    201: {"description": "Catalog part twin unshared successfully"},
+    204: {"description": "Catalog part twin already unshared"},
+    **exception_responses
+})
+async def twin_management_unshare_serialized_part_twin(serialized_part_twin_unshare: SerializedPartTwinUnshareCreate):
+    if twin_management_service.part_twin_unshare(serialized_part_twin_unshare):
+        return JSONResponse(status_code=201, content={"description":"Serialized part twin unshared successfully"})
     else:
         return JSONResponse(status_code=204, content=None)

--- a/ichub-backend/managers/enablement_services/dtr_manager.py
+++ b/ichub-backend/managers/enablement_services/dtr_manager.py
@@ -266,6 +266,131 @@ class DTRManager:
             raise ExternalAPIError("Error creating or updating shell descriptor", res.to_json_string())
 
         return res
+
+    def remove_bpn_shell_descriptor(self,
+        aas_id: UUID,
+        bpns_to_remove: list[str],
+        manufacturer_id: str,
+        asset_id_names_filter: list[str] | None = None,
+    ) -> ShellDescriptor:
+        """
+        Removes specified BPNs from the external_subject_id.keys of specific asset IDs in a shell descriptor.
+        Updates the shell descriptor in the DTR using PUT command.
+        
+        Args:
+            aas_id: The UUID of the Asset Administration Shell
+            bpns_to_remove: List of BPN values to remove from external_subject_id.keys
+            manufacturer_id: The manufacturer BPN for authentication/authorization
+            asset_id_names_filter: Optional list of asset ID names to filter. If provided, BPNs will only be removed
+                                 from specific asset IDs with these names. If None, BPNs are removed from all asset IDs.
+            
+        Returns:
+            ShellDescriptor: The updated shell descriptor
+            
+        Raises:
+            ExternalAPIError: If the shell doesn't exist or update fails
+        """
+        # Retrieve and validate existing shell
+        existing_shell = self._get_existing_shell(aas_id, manufacturer_id)
+        
+        logger.info(f"Removing BPNs {bpns_to_remove} from Shell with ID {aas_id}")
+        if asset_id_names_filter:
+            logger.info(f"Filtering to asset ID names: {asset_id_names_filter}")
+        
+        # Process asset IDs and remove BPNs
+        specific_asset_ids = existing_shell.specific_asset_ids or []
+        modified = self._remove_bpns_from_filtered_assets(specific_asset_ids, bpns_to_remove, asset_id_names_filter)
+        
+        if not modified:
+            filter_msg = f" (filtered to {asset_id_names_filter})" if asset_id_names_filter else ""
+            logger.warning(f"No BPN references were found to remove for shell {aas_id.urn}{filter_msg}")
+            return existing_shell
+        
+        # Update shell descriptor
+        return self._update_shell_after_bpn_removal(existing_shell, specific_asset_ids, aas_id, manufacturer_id)
+
+    def _get_existing_shell(self, aas_id: UUID, manufacturer_id: str) -> ShellDescriptor:
+        """Get and validate existing shell descriptor for BPN removal operation."""
+        existing_shell = self.aas_service.get_asset_administration_shell_descriptor_by_id(
+            aas_identifier=aas_id.urn, bpn=manufacturer_id
+        )
+        
+        if not isinstance(existing_shell, ShellDescriptor):
+            raise ExternalAPIError(f"Shell with ID {aas_id.urn} not found or access denied", "Shell not found")
+        
+        return existing_shell
+
+    def _remove_bpns_from_filtered_assets(self, specific_asset_ids: list[SpecificAssetId], 
+                                        bpns_to_remove: list[str], 
+                                        asset_id_names_filter: list[str] | None) -> bool:
+        """Remove BPNs from filtered specific asset IDs. Returns True if any modifications were made."""
+        modified = False
+        
+        for sa_id in specific_asset_ids:
+            if self._should_process_asset_id(sa_id, asset_id_names_filter):
+                if self._remove_bpns_from_single_asset(sa_id, bpns_to_remove):
+                    modified = True
+        
+        return modified
+
+    def _should_process_asset_id(self, sa_id: SpecificAssetId, asset_id_names_filter: list[str] | None) -> bool:
+        """Check if asset ID should be processed based on filter and structure."""
+        if asset_id_names_filter and sa_id.name not in asset_id_names_filter:
+            return False
+        return sa_id.external_subject_id and hasattr(sa_id.external_subject_id, "keys")
+
+    def _remove_bpns_from_single_asset(self, sa_id: SpecificAssetId, bpns_to_remove: list[str]) -> bool:
+        """Remove BPNs from a single asset ID. Returns True if modifications were made."""
+        original_key_count = len(sa_id.external_subject_id.keys)
+        self._remove_bpns_from_sa_id(sa_id, bpns_to_remove)
+        
+        if len(sa_id.external_subject_id.keys) < original_key_count:
+            removed_count = original_key_count - len(sa_id.external_subject_id.keys)
+            logger.info(f"Removed {removed_count} BPN reference(s) from asset ID '{sa_id.name}={sa_id.value}'")
+            return True
+        return False
+
+    def _update_shell_after_bpn_removal(self, existing_shell: ShellDescriptor, 
+                                      specific_asset_ids: list[SpecificAssetId], 
+                                      aas_id: UUID, manufacturer_id: str) -> ShellDescriptor:
+        """Update shell descriptor after BPN removal."""
+        existing_shell.specific_asset_ids = specific_asset_ids
+        
+        try:
+            res = self.aas_service.update_asset_administration_shell_descriptor(
+                shell_descriptor=existing_shell, aas_identifier=aas_id.urn, bpn=manufacturer_id
+            )
+            logger.info(f"Successfully removed BPN references from AAS with id {aas_id.urn}!")
+        except Exception as e:
+            logger.error(f"Failed to update AAS {aas_id.urn}: {str(e)}")
+            raise ExternalAPIError("Failed to update shell descriptor", str(e))
+
+        if isinstance(res, Result):
+            raise ExternalAPIError("Error updating shell descriptor", res.to_json_string())
+
+        return res
+
+    @staticmethod
+    def _remove_bpns_from_sa_id(sa_id: SpecificAssetId, bpns_to_remove: list[str]) -> SpecificAssetId:
+        """
+        Removes multiple BPN ReferenceKeys from sa_id.external_subject_id.keys.
+        Returns the updated sa_id.
+        
+        Args:
+            sa_id: The SpecificAssetId to modify
+            bpns_to_remove: List of BPN values to remove
+            
+        Returns:
+            SpecificAssetId: The updated asset ID
+        """
+        if not sa_id.external_subject_id or not hasattr(sa_id.external_subject_id, "keys"):
+            return sa_id
+
+        sa_id.external_subject_id.keys = [
+            key for key in sa_id.external_subject_id.keys
+            if key.value not in bpns_to_remove
+        ]
+        return sa_id
         
     
     def create_shell_descriptor(

--- a/ichub-backend/managers/enablement_services/dtr_manager.py
+++ b/ichub-backend/managers/enablement_services/dtr_manager.py
@@ -311,10 +311,10 @@ class DTRManager:
         if not modified:
             filter_msg = f" (filtered to {asset_id_names_filter})" if asset_id_names_filter else ""
             logger.warning(f"No BPN references were found to remove for shell {aas_id.urn}{filter_msg}")
-            return existing_shell
+            return existing_shell, modified
         
         # Update shell descriptor
-        return self._update_shell_after_bpn_removal(existing_shell, specific_asset_ids, aas_id, manufacturer_id)
+        return self._update_shell_after_bpn_removal(existing_shell, specific_asset_ids, aas_id, manufacturer_id), modified
 
     def _get_existing_shell(self, aas_id: UUID, manufacturer_id: str) -> ShellDescriptor:
         """Get and validate existing shell descriptor for BPN removal operation."""

--- a/ichub-backend/models/services/__init__.py
+++ b/ichub-backend/models/services/__init__.py
@@ -66,5 +66,7 @@ from .twin_management import (
     SerializedPartTwinCreate,
     SerializedPartTwinRead,
     SerializedPartTwinDetailsRead,
+    SerializedPartTwinShareCreate,
+    SerializedPartTwinUnshareCreate
 )
 

--- a/ichub-backend/models/services/twin_management.py
+++ b/ichub-backend/models/services/twin_management.py
@@ -144,3 +144,8 @@ class SerializedPartTwinShareCreate(SerializedPartBase):
     # Hint: we don't need the TwinShareCreateBase here, because a serialized part has already a link to a single business partner
     pass
 
+class SerializedPartTwinUnshareCreate(BaseModel):
+    aas_id: UUID = Field(alias="aasId", description="The AAS ID of the serialized part twin to unshare.")
+    business_partner_number_to_unshare: list[str] = Field(alias="businessPartnerNumberToUnshare", description="The business partner number of the business partner with which the serialized part twin should be unshared.")
+    manufacturer_id: str = Field(alias="manufacturerId", description="The manufacturer ID of the serialized part twin to unshare.")
+    asset_id_names_filter: Optional[List[str]] = Field(alias="assetIdNamesFilter", description="An optional list of asset ID names to filter the serialized part twin unshare operation. If provided, only asset IDs with names in this list will be considered for unsharing.", default=None)


### PR DESCRIPTION
## WHAT

This PR adds the ability to unshare.

## WHY

Previously, once a part was shared, it could not be unshared. This limitation prevented users from managing shared access effectively. The change ensures better control over data sharing.

Closes #262 
