### PR TITLE
System management services - Part I

### DIFF
--- a/ichub-backend/connector.py
+++ b/ichub-backend/connector.py
@@ -74,6 +74,16 @@ try:
     agreements = ConfigManager.get_config("agreements")
     path_submodel_dispatcher = ConfigManager.get_config("provider.submodel_dispatcher.apiPath", default="/submodel-dispatcher")
 
+    provider_connector_controlplane_catalog_path=ConfigManager.get_config("provider.connector.controlplane.protocolPath"),
+    provider_connector_dataplane_hostname=ConfigManager.get_config("provider.connector.dataplane.hostname"),
+    provider_connector_dataplane_public_path=ConfigManager.get_config("provider.connector.dataplane.publicPath")
+
+
+    provider_connector_controlplane_catalog_path=ConfigManager.get_config("provider.connector.controlplane.protocolPath"),
+    provider_connector_dataplane_hostname=ConfigManager.get_config("provider.connector.dataplane.hostname"),
+    provider_connector_dataplane_public_path=ConfigManager.get_config("provider.connector.dataplane.publicPath")
+
+
     # Authorization configuration — defaults to local backend auth
     authorization_enabled = ConfigManager.get_config("authorization.enabled", False)
     backend_api_key = ConfigManager.get_config("authorization.api_key.key", "X-Api-Key")
@@ -123,6 +133,10 @@ try:
             connector_provider_service=provider_connector_service,
             ichub_url=ichub_url,
             agreements=agreements,
+            connector_controlplane_hostname=provider_connector_controlplane_hostname,
+            connector_controlplane_catalog_path=provider_connector_controlplane_catalog_path,
+            connector_dataplane_hostname=provider_connector_dataplane_hostname,
+            connector_dataplane_public_path=provider_connector_dataplane_public_path,
             path_submodel_dispatcher=path_submodel_dispatcher,
             authorization=authorization_enabled,
             backend_api_key=backend_api_key,

--- a/ichub-backend/connector.py
+++ b/ichub-backend/connector.py
@@ -1,6 +1,8 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -32,7 +32,7 @@ import os
 import logging
 
 from tools.exceptions import BaseError, ValidationError
-from tools.constants import API_V1
+from tools.constants import API_V1, API_V2
 from managers.config.config_manager import ConfigManager
 
 startup_logger = logging.getLogger("app.startup")
@@ -91,7 +91,8 @@ from .routers.provider.v1 import (
     partner_management,
     twin_management,
     submodel_dispatcher,
-    sharing_handler
+    sharing_handler,
+    system_management,
 )
 from .routers.consumer.v1 import (
     connection_management,
@@ -102,6 +103,11 @@ from .routers.notifications.v1 import (
     notifications_management
 )
 from .routers.addons import addons
+
+from .routers.provider.v2 import (
+    twin_management as twin_management_v2,
+    sharing_handler as sharing_handler_v2,
+)
 
 tags_metadata = [
     {
@@ -123,6 +129,10 @@ tags_metadata = [
     {
         "name": "Submodel Dispatcher",
         "description": "Internal API called by EDC Data Planes or Admins in order the deliver data of of the internal used Submodel Service"
+    },
+    {
+        "name": "System Management",
+        "description": "Management of integrated system components (EDC, DTR, etc.)"
     },
     {
         "name": "Open Connection Management",
@@ -147,7 +157,7 @@ tags_metadata = [
     {
         "name": "EcoPass KIT Microservices",
         "description": "Provider-side EcoPass KIT endpoints"
-    }
+    },
 ]
 
 app = FastAPI(title="Industry Core Hub Backend API", version="0.0.1", openapi_tags=tags_metadata, lifespan=lifespan)
@@ -219,14 +229,21 @@ v1_router.include_router(partner_management.router)
 v1_router.include_router(twin_management.router)
 v1_router.include_router(submodel_dispatcher.router)
 v1_router.include_router(sharing_handler.router)
+v1_router.include_router(system_management.router)
 v1_router.include_router(connection_management.router)
 v1_router.include_router(discovery_management.router)
 v1_router.include_router(digital_twin_event_api.router)
 v1_router.include_router(notifications_management.router)
 v1_router.include_router(addons.router)
 
+# API Version 2
+v2_router = APIRouter(prefix=f"/{API_V2}")
+v2_router.include_router(twin_management_v2.router)
+v2_router.include_router(sharing_handler_v2.router)
+
 # Include the API version 1 router into the main app
 app.include_router(v1_router)
+app.include_router(v2_router)
 
 
 def custom_openapi():

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
@@ -32,9 +32,6 @@ from models.services.provider.system_management import (
     ConnectorControlPlaneCreate,
     ConnectorControlPlaneRead,
     ConnectorControlPlaneUpdate,
-    EnablementServiceStackCreate,
-    EnablementServiceStackRead,
-    EnablementServiceStackUpdate,
     LegalEntityCreate,
     LegalEntityRead,
     LegalEntityUpdate,
@@ -42,26 +39,6 @@ from models.services.provider.system_management import (
 
 router = APIRouter(prefix="/system-management", tags=["System Management"])
 system_management_service = SystemManagementService()
-
-@router.post("/enablement-service-stack", response_model=EnablementServiceStackRead)
-async def create_enablement_service_stack(stack_create: EnablementServiceStackCreate):
-    return system_management_service.create_enablement_service_stack(stack_create)
-
-@router.get("/enablement-service-stack", response_model=List[EnablementServiceStackRead])
-async def get_enablement_service_stacks():
-    return system_management_service.get_enablement_service_stacks()
-
-@router.get("/enablement-service-stack/{stack_id}", response_model=EnablementServiceStackRead)
-async def get_enablement_service_stack(stack_id: int):
-    return system_management_service.get_enablement_service_stack(stack_id)
-
-@router.put("/enablement-service-stack/{stack_id}", response_model=EnablementServiceStackRead)
-async def update_enablement_service_stack(stack_id: int, stack_update: EnablementServiceStackUpdate):
-    return system_management_service.update_enablement_service_stack(stack_id, stack_update)
-
-@router.delete("/enablement-service-stack/{stack_id}", response_model=bool)
-async def delete_enablement_service_stack(stack_id: int):
-    return system_management_service.delete_enablement_service_stack(stack_id)
 
 # Connector Control Plane endpoints
 @router.post("/connector-control-plane", response_model=ConnectorControlPlaneRead)

--- a/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v1/system_management.py
@@ -1,0 +1,128 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by routerlicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from fastapi import APIRouter
+from typing import List
+from services.provider.system_management_service import SystemManagementService
+from models.services.provider.system_management import (
+    TwinRegistryCreate,
+    TwinRegistryRead,
+    TwinRegistryUpdate,
+    ConnectorControlPlaneCreate,
+    ConnectorControlPlaneRead,
+    ConnectorControlPlaneUpdate,
+    EnablementServiceStackCreate,
+    EnablementServiceStackRead,
+    EnablementServiceStackUpdate,
+    LegalEntityCreate,
+    LegalEntityRead,
+    LegalEntityUpdate,
+)
+
+router = APIRouter(prefix="/system-management", tags=["System Management"])
+system_management_service = SystemManagementService()
+
+@router.post("/enablement-service-stack", response_model=EnablementServiceStackRead)
+async def create_enablement_service_stack(stack_create: EnablementServiceStackCreate):
+    return system_management_service.create_enablement_service_stack(stack_create)
+
+@router.get("/enablement-service-stack", response_model=List[EnablementServiceStackRead])
+async def get_enablement_service_stacks():
+    return system_management_service.get_enablement_service_stacks()
+
+@router.get("/enablement-service-stack/{stack_id}", response_model=EnablementServiceStackRead)
+async def get_enablement_service_stack(stack_id: int):
+    return system_management_service.get_enablement_service_stack(stack_id)
+
+@router.put("/enablement-service-stack/{stack_id}", response_model=EnablementServiceStackRead)
+async def update_enablement_service_stack(stack_id: int, stack_update: EnablementServiceStackUpdate):
+    return system_management_service.update_enablement_service_stack(stack_id, stack_update)
+
+@router.delete("/enablement-service-stack/{stack_id}", response_model=bool)
+async def delete_enablement_service_stack(stack_id: int):
+    return system_management_service.delete_enablement_service_stack(stack_id)
+
+# Connector Control Plane endpoints
+@router.post("/connector-control-plane", response_model=ConnectorControlPlaneRead)
+async def create_connector_control_plane(connector_create: ConnectorControlPlaneCreate):
+    return system_management_service.create_connector_control_plane(connector_create)
+
+@router.get("/connector-control-plane", response_model=List[ConnectorControlPlaneRead])
+async def get_connector_control_planes():
+    return system_management_service.retrieve_connector_control_planes()
+
+@router.get("/connector-control-plane/{connector_id}", response_model=ConnectorControlPlaneRead)
+async def get_connector_control_plane(connector_id: int):
+    return system_management_service.get_connector_control_plane(connector_id)
+
+@router.put("/connector-control-plane/{connector_id}", response_model=ConnectorControlPlaneRead)
+async def update_connector_control_plane(connector_id: int, connector_update: ConnectorControlPlaneUpdate):
+    return system_management_service.update_connector_control_plane(connector_id, connector_update)
+
+@router.delete("/connector-control-plane/{connector_id}", response_model=bool)
+async def delete_connector_control_plane(connector_id: int):
+    return system_management_service.delete_connector_control_plane(connector_id)
+
+# Twin Registry endpoints
+@router.post("/twin-registry", response_model=TwinRegistryRead)
+async def create_twin_registry(dtr_create: TwinRegistryCreate):
+    return system_management_service.create_twin_registry(dtr_create)
+
+@router.get("/twin-registry", response_model=List[TwinRegistryRead])
+async def get_twin_registries():
+    return system_management_service.get_twin_registries()
+
+@router.get("/twin-registry/{dtr_id}", response_model=TwinRegistryRead)
+async def get_twin_registry(dtr_id: int):
+    return system_management_service.get_twin_registry(dtr_id)
+
+@router.put("/twin-registry/{dtr_id}", response_model=TwinRegistryRead)
+async def update_twin_registry(dtr_id: int, dtr_update: TwinRegistryUpdate):
+    return system_management_service.update_twin_registry(dtr_id, dtr_update)
+
+@router.delete("/twin-registry/{dtr_id}", response_model=bool)
+async def delete_twin_registry(dtr_id: int):
+    return system_management_service.delete_twin_registry(dtr_id)
+
+# LegalEntity endpoints
+@router.post("/legal-entity", response_model=LegalEntityRead)
+async def create_legal_entity(legal_entity_create: LegalEntityCreate):
+    return system_management_service.create_legal_entity(legal_entity_create)
+
+@router.get("/legal-entity", response_model=List[LegalEntityRead])
+async def get_legal_entities():
+    return system_management_service.get_legal_entities()
+
+@router.get("/legal-entity/{legal_entity_id}", response_model=LegalEntityRead)
+async def get_legal_entity(legal_entity_id: int):
+    return system_management_service.get_legal_entity(legal_entity_id)
+
+@router.put("/legal-entity/{legal_entity_id}", response_model=LegalEntityRead)
+async def update_legal_entity(legal_entity_id: int, legal_entity_update: LegalEntityUpdate):
+    return system_management_service.update_legal_entity(legal_entity_id, legal_entity_update)
+
+@router.delete("/legal-entity/{legal_entity_id}", response_model=bool)
+async def delete_legal_entity(legal_entity_id: int):
+    return system_management_service.delete_legal_entity(legal_entity_id)
+

--- a/ichub-backend/controllers/fastapi/routers/provider/v1/twin_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v1/twin_management.py
@@ -23,7 +23,7 @@
 
 from fastapi import APIRouter, Query, Depends
 from fastapi.responses import JSONResponse
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from services.provider.twin_management_service import TwinManagementService
@@ -134,6 +134,10 @@ async def twin_management_create_twin_aspect(twin_aspect_create: TwinAspectCreat
     if default:
         return twin_management_service.create_twin_aspect(twin_aspect_create)
     return twin_management_service.create_or_update_twin_aspect_not_default(twin_aspect_create)
+
+@router.get("/twin-registrations/{global_id}", response_model=Dict[int, bool], responses=exception_responses)
+async def get_twin_registrations(global_id: UUID) -> Dict[int, bool]:
+    return twin_management_service.get_twin_registrations(global_id)
 
 @router.post("/serialized-part-twin/share", responses={
     201: {"description": "Catalog part twin shared successfully"},

--- a/ichub-backend/controllers/fastapi/routers/provider/v1/twin_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v1/twin_management.py
@@ -2,6 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025 LKS Next
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/controllers/fastapi/routers/provider/v2/sharing_handler.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v2/sharing_handler.py
@@ -1,0 +1,48 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by routerlicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from fastapi import APIRouter, Depends
+
+from services.provider.sharing_service import SharingService
+from models.services.provider.sharing_management import (
+    SharedPartBase,
+    ShareCatalogPart,
+)
+from tools.exceptions import exception_responses
+from controllers.fastapi.routers.authentication.auth_api import get_authentication_dependency
+
+router = APIRouter(
+    prefix="/share",
+    tags=["Sharing Functionality"],
+    dependencies=[Depends(get_authentication_dependency())]
+)
+part_sharing_service = SharingService()
+
+@router.post("/{twin_registry_id}/{connector_control_plane_id}/catalog-part", response_model=SharedPartBase, responses=exception_responses)
+async def share_catalog_part(twin_registry_id: int, connector_control_plane_id: int, catalog_part_to_share: ShareCatalogPart) -> SharedPartBase:
+    return part_sharing_service.share_catalog_part(
+        catalog_part_to_share=catalog_part_to_share,
+        db_twin_registry_id=twin_registry_id,
+        db_connector_control_plane_id=connector_control_plane_id
+    )

--- a/ichub-backend/controllers/fastapi/routers/provider/v2/sharing_handler.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v2/sharing_handler.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/controllers/fastapi/routers/provider/v2/twin_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v2/twin_management.py
@@ -1,0 +1,79 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by routerlicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from fastapi import APIRouter, Query, Depends
+from fastapi.responses import JSONResponse
+
+from services.provider.twin_management_service import TwinManagementService
+from models.services.provider.twin_management import (
+    TwinRead, TwinAspectRead, TwinAspectCreate,
+    CatalogPartTwinCreate, CatalogPartTwinShareCreate,
+    SerializedPartTwinCreate, SerializedPartTwinShareCreate,
+    SerializedPartTwinUnshareCreate
+)
+from tools.exceptions import exception_responses
+from utils.async_utils import AsyncManagerWrapper
+from controllers.fastapi.routers.authentication.auth_api import get_authentication_dependency
+
+router = APIRouter(
+    prefix="/twin-management",
+    tags=["Twin Management"],
+    dependencies=[Depends(get_authentication_dependency())]
+)
+twin_management_service = TwinManagementService()
+
+# Create universal async wrapper - works with any service!
+async_twin_service = AsyncManagerWrapper(twin_management_service, "TwinManagement")
+
+@router.post("/{twin_registry_id}/catalog-part-twin", response_model=TwinRead, responses=exception_responses)
+async def twin_management_create_catalog_part_twin(
+    twin_registry_id: int,
+    catalog_part_twin_create: CatalogPartTwinCreate,
+    auto_create_part_type_information: bool = Query(True, alias="autoCreatePartTypeInformation", description="Automatically create part type information submodel if not present.")
+) -> TwinRead:
+    return twin_management_service.create_catalog_part_twin(
+        catalog_part_twin_create,
+        auto_create_part_type_information,
+        db_twin_registry_id=twin_registry_id
+    )
+
+@router.post("/{twin_registry_id}/serialized-part-twin", response_model=TwinRead, responses=exception_responses)
+async def twin_management_create_serialized_part_twin(twin_registry_id: int, serialized_part_twin_create: SerializedPartTwinCreate, auto_create_serial_part: bool = Query(True, alias="autoCreatePartTypeInformation", description="Automatically create part type information submodel if not present.")) -> TwinRead:
+    return twin_management_service.create_serialized_part_twin(
+        serialized_part_twin_create,
+        auto_create_serial_part,
+        db_twin_registry_id=twin_registry_id)
+
+@router.post("/{twin_registry_id}/{connector_control_plane_id}/twin-aspect", response_model=TwinAspectRead, responses=exception_responses)
+async def twin_management_create_twin_aspect(twin_registry_id: int, connector_control_plane_id: int, twin_aspect_create: TwinAspectCreate, default: bool = True) -> TwinAspectRead:
+    if default:
+        return twin_management_service.create_twin_aspect(
+            twin_aspect_create,
+            db_twin_registry_id=twin_registry_id,
+            db_connector_control_plane_id=connector_control_plane_id
+        )
+    return twin_management_service.create_or_update_twin_aspect_not_default(
+        twin_aspect_create,
+        db_twin_registry_id=twin_registry_id,
+        db_connector_control_plane_id=connector_control_plane_id)

--- a/ichub-backend/controllers/fastapi/routers/provider/v2/twin_management.py
+++ b/ichub-backend/controllers/fastapi/routers/provider/v2/twin_management.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/dtr.py
+++ b/ichub-backend/dtr.py
@@ -77,11 +77,7 @@ try:
 
     dtr_provider_manager = DtrProviderManager(
         dtr_url=dtr_url, dtr_lookup_url=dtr_lookup_url,
-        api_path=str(dtr_api_path),
-        connector_controlplane_hostname=ConfigManager.get_config("provider.connector.controlplane.hostname"),
-        connector_controlplane_catalog_path=ConfigManager.get_config("provider.connector.controlplane.protocolPath"),
-        connector_dataplane_hostname=ConfigManager.get_config("provider.connector.dataplane.hostname"),
-        connector_dataplane_public_path=ConfigManager.get_config("provider.connector.dataplane.publicPath")
+        api_path=str(dtr_api_path)
     )
 
     dtr_manager = DtrManager(

--- a/ichub-backend/dtr.py
+++ b/ichub-backend/dtr.py
@@ -1,6 +1,8 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
@@ -2,6 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
@@ -46,6 +46,10 @@ class ConnectorProviderManager:
                  connector_provider_service: BaseConnectorProviderService,
                  ichub_url: str,
                  agreements: list,
+                 connector_controlplane_hostname: str,
+                 connector_controlplane_catalog_path: str,
+                 connector_dataplane_hostname: str,
+                 connector_dataplane_public_path: str,
                  path_submodel_dispatcher: str = "/submodel-dispatcher",
                  authorization: bool = False,
                  backend_api_key: str = "X-Api-Key",
@@ -58,6 +62,11 @@ class ConnectorProviderManager:
         self.path_submodel_dispatcher = path_submodel_dispatcher
         self.agreements = agreements
         self.backend_submodel_dispatcher = self.ichub_url + self.path_submodel_dispatcher
+
+        self.connector_controlplane_hostname = connector_controlplane_hostname
+        self.connector_controlplane_catalog_path = connector_controlplane_catalog_path
+        self.connector_dataplane_hostname = connector_dataplane_hostname
+        self.connector_dataplane_public_path = connector_dataplane_public_path
 
         # "filesystem" = local ICHub backend serves submodels directly
         # "http"       = an external submodel service is used; EDC asset data-address

--- a/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
@@ -54,11 +54,7 @@ class DtrProviderManager:
         self,
         dtr_url: str,
         dtr_lookup_url: str,
-        api_path: str,
-        connector_controlplane_hostname: str,
-        connector_controlplane_catalog_path: str,
-        connector_dataplane_hostname: str,
-        connector_dataplane_public_path: str,
+        api_path: str
     ):
         self.dtr_url = dtr_url
         self.dtr_lookup_url = dtr_lookup_url
@@ -67,10 +63,6 @@ class DtrProviderManager:
             base_lookup_url=dtr_lookup_url,
             api_path=api_path,
         )
-        self.connector_controlplane_hostname = connector_controlplane_hostname
-        self.connector_controlplane_catalog_path = connector_controlplane_catalog_path
-        self.connector_dataplane_hostname = connector_dataplane_hostname
-        self.connector_dataplane_public_path = connector_dataplane_public_path
         
     @staticmethod
     def get_dtr_url(base_dtr_url: str = '', uri: str = '', api_path: str = '') -> str:
@@ -385,6 +377,8 @@ class DtrProviderManager:
         submodel_id: UUID|str,
         semantic_id: str,
         connector_asset_id: str,
+        dsp_endpoint_url: str,
+        href_url: str
     ) -> SubModelDescriptor:
         """
         Creates a submodel descriptor in the DTR.
@@ -404,15 +398,11 @@ class DtrProviderManager:
             submodel_id = UUID(submodel_id)
         # Check that href and DSP URLs are valid
         
-        href_url = f"{self.connector_dataplane_hostname}{self.connector_dataplane_public_path}/{submodel_id.urn}/submodel"
-
-        parsed_href_url = parse.urlparse(href_url)
+        parsed_href_url = parse.urlparse(f"{href_url}/{submodel_id.urn}/submodel")
         if not (parsed_href_url.scheme == "https" and parsed_href_url.netloc):
             raise InvalidError(f"Generated href URL is malformed: {href_url}")
 
-        dsp_endpoint_url = (
-            f"{self.connector_controlplane_hostname}{self.connector_controlplane_catalog_path}"
-        )
+
         parsed_dsp_endpoint_url = parse.urlparse(dsp_endpoint_url)
         if not (
             parsed_dsp_endpoint_url.scheme == "https" and parsed_dsp_endpoint_url.netloc

--- a/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
@@ -1,6 +1,8 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/managers/metadata_database/manager.py
+++ b/ichub-backend/managers/metadata_database/manager.py
@@ -35,7 +35,6 @@ class RepositoryManager:
         self._connector_control_plane_repository = None
         self._data_exchange_agreement_repository = None
         self._twin_registry_repository = None
-        self._enablement_service_stack_repository = None
         self._legal_entity_repository = None
         self._partner_catalog_part_repository = None
         self._serialized_part_repository = None
@@ -118,14 +117,6 @@ class RepositoryManager:
             from managers.metadata_database.repositories import TwinRegistryRepository
             self._twin_registry_repository = TwinRegistryRepository(self._session)
         return self._twin_registry_repository
-
-    @property
-    def enablement_service_stack_repository(self):
-        """Lazy initialization of the enablement service stack repository."""
-        if self._enablement_service_stack_repository is None:
-            from managers.metadata_database.repositories import EnablementServiceStackRepository
-            self._enablement_service_stack_repository = EnablementServiceStackRepository(self._session)
-        return self._enablement_service_stack_repository
 
     @property
     def legal_entity_repository(self):

--- a/ichub-backend/managers/metadata_database/manager.py
+++ b/ichub-backend/managers/metadata_database/manager.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/managers/metadata_database/manager.py
+++ b/ichub-backend/managers/metadata_database/manager.py
@@ -32,7 +32,9 @@ class RepositoryManager:
         self._session = session
         self._business_partner_repository = None
         self._catalog_part_repository = None
+        self._connector_control_plane_repository = None
         self._data_exchange_agreement_repository = None
+        self._twin_registry_repository = None
         self._enablement_service_stack_repository = None
         self._legal_entity_repository = None
         self._partner_catalog_part_repository = None
@@ -94,12 +96,28 @@ class RepositoryManager:
         return self._catalog_part_repository
 
     @property
+    def connector_control_plane_repository(self):
+        """Lazy initialization of the connector service repository."""
+        if self._connector_control_plane_repository is None:
+            from managers.metadata_database.repositories import ConnectorControlPlaneRepository
+            self._connector_control_plane_repository = ConnectorControlPlaneRepository(self._session)
+        return self._connector_control_plane_repository
+
+    @property
     def data_exchange_agreement_repository(self):
         """Lazy initialization of the data exchange agreement repository."""
         if self._data_exchange_agreement_repository is None:
             from managers.metadata_database.repositories import DataExchangeAgreementRepository
             self._data_exchange_agreement_repository = DataExchangeAgreementRepository(self._session)
         return self._data_exchange_agreement_repository
+
+    @property
+    def twin_registry_repository(self):
+        """Lazy initialization of the DTR service repository."""
+        if self._twin_registry_repository is None:
+            from managers.metadata_database.repositories import TwinRegistryRepository
+            self._twin_registry_repository = TwinRegistryRepository(self._session)
+        return self._twin_registry_repository
 
     @property
     def enablement_service_stack_repository(self):

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -34,7 +34,6 @@ from models.metadata_database.provider.models import (
     ConnectorControlPlane,
     BusinessPartner,
     TwinRegistry,
-    EnablementServiceStack,
     LegalEntity,
     Twin,
     TwinAspect,
@@ -255,33 +254,6 @@ class PartnerCatalogPartRepository(BaseRepository[PartnerCatalogPart]):
             self._session.refresh(existing)
         return existing
     
-class EnablementServiceStackRepository(BaseRepository[EnablementServiceStack]):
-    def get_by_name(self, name: str,
-        join_legal_entity: bool = False,
-        join_connector_control_plane: bool = False,
-        join_twin_registry: bool = False) -> Optional[EnablementServiceStack]:
-        
-        stmt = select(EnablementServiceStack).where(
-            EnablementServiceStack.name == name)  # type: ignore
-        
-        if join_connector_control_plane or join_legal_entity:
-            stmt = stmt.join(ConnectorControlPlane, ConnectorControlPlane.id == EnablementServiceStack.connector_control_plane_id)
-
-        if join_legal_entity:
-            stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id)
-
-        if join_twin_registry:
-            stmt = stmt.join(TwinRegistry, TwinRegistry.id == EnablementServiceStack.twin_registry_id)
-
-        return self._session.scalars(stmt).first()
-    
-    def find_by_legal_entity_bpnl(self, legal_entity_bpnl: str) -> List[EnablementServiceStack]:
-        stmt = select(EnablementServiceStack)
-        stmt = stmt.join(ConnectorControlPlane, ConnectorControlPlane.id == EnablementServiceStack.connector_control_plane_id)
-        stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id).where(
-            LegalEntity.bpnl == legal_entity_bpnl)
-        return self._session.scalars(stmt).all()
-
 class SerializedPartRepository(BaseRepository[SerializedPart]):
     def get_by_partner_catalog_part_id_part_instance_id(self, partner_catalog_part_id: int, part_instance_id: str) -> Optional[SerializedPart]:
         stmt = select(SerializedPart).where(
@@ -481,7 +453,6 @@ class TwinRepository(BaseRepository[Twin]):
             van: Optional[str] = None,
             business_partner_number: Optional[str] = None,
             global_id: Optional[UUID] = None,
-            enablement_service_stack_id: Optional[int] = None,
             min_incl_created_date: Optional[datetime] = None,
             max_excl_created_date: Optional[datetime] = None,
             limit: int = 50,
@@ -517,13 +488,6 @@ class TwinRepository(BaseRepository[Twin]):
 
         if global_id:
             stmt = stmt.where(Twin.global_id == global_id)
-
-        if enablement_service_stack_id:
-            stmt = stmt.join(
-                TwinRegistration, TwinRegistration.twin_id == Twin.id
-            ).where(
-                TwinRegistration.enablement_service_stack_id == enablement_service_stack_id
-            )
 
         if business_partner_number:
             stmt = stmt.join(BusinessPartner, BusinessPartner.id == PartnerCatalogPart.business_partner_id

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -31,7 +31,9 @@ from uuid import UUID, uuid4
 from datetime import datetime, timezone
 
 from models.metadata_database.provider.models import (
+    ConnectorControlPlane,
     BusinessPartner,
+    TwinRegistry,
     EnablementServiceStack,
     LegalEntity,
     Twin,
@@ -254,18 +256,29 @@ class PartnerCatalogPartRepository(BaseRepository[PartnerCatalogPart]):
         return existing
     
 class EnablementServiceStackRepository(BaseRepository[EnablementServiceStack]):
-    def get_by_name(self, name: str, join_legal_entity: bool = False) -> Optional[EnablementServiceStack]:
+    def get_by_name(self, name: str,
+        join_legal_entity: bool = False,
+        join_connector_control_plane: bool = False,
+        join_twin_registry: bool = False) -> Optional[EnablementServiceStack]:
+        
         stmt = select(EnablementServiceStack).where(
             EnablementServiceStack.name == name)  # type: ignore
         
+        if join_connector_control_plane or join_legal_entity:
+            stmt = stmt.join(ConnectorControlPlane, ConnectorControlPlane.id == EnablementServiceStack.connector_control_plane_id)
+
         if join_legal_entity:
-            stmt = stmt.join(LegalEntity, LegalEntity.id == EnablementServiceStack.legal_entity_id)
+            stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id)
+
+        if join_twin_registry:
+            stmt = stmt.join(TwinRegistry, TwinRegistry.id == EnablementServiceStack.twin_registry_id)
 
         return self._session.scalars(stmt).first()
     
     def find_by_legal_entity_bpnl(self, legal_entity_bpnl: str) -> List[EnablementServiceStack]:
-        stmt = select(EnablementServiceStack).join(
-            LegalEntity, LegalEntity.id == EnablementServiceStack.legal_entity_id).where(
+        stmt = select(EnablementServiceStack)
+        stmt = stmt.join(ConnectorControlPlane, ConnectorControlPlane.id == EnablementServiceStack.connector_control_plane_id)
+        stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id).where(
             LegalEntity.bpnl == legal_entity_bpnl)
         return self._session.scalars(stmt).all()
 
@@ -420,9 +433,13 @@ class TwinRepository(BaseRepository[Twin]):
         
         return twin
     
-    def find_by_global_id(self, global_id: UUID) -> Optional[Twin]:
+    def find_by_global_id(self, global_id: UUID, include_registrations: bool = False) -> Optional[Twin]:
         stmt = select(Twin).where(
             Twin.global_id == global_id)
+        
+        if include_registrations:
+            stmt = stmt.options(selectinload(Twin.twin_registrations))
+        
         return self._session.scalars(stmt).first()
     
     def find_by_aas_id(self, aas_id: UUID) -> Optional[Twin]:
@@ -585,39 +602,39 @@ class TwinAspectRepository(BaseRepository[TwinAspect]):
             submodel_id=submodel_id,
             semantic_id=semantic_id,
             twin_id=twin_id,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
         )
         self.create(twin_aspect)
         return twin_aspect
 
 
 class TwinAspectRegistrationRepository(BaseRepository[TwinAspectRegistration]):
-    def get_by_twin_aspect_id_enablement_service_stack_id(
-        self, twin_aspect_id: int, enablement_service_stack_id: int
+    def get_by_twin_aspect_id_twin_registry_id(
+        self, twin_aspect_id: int, twin_registry_id: int
     ) -> Optional[TwinAspectRegistration]:
-        """Retrieve a TwinAspectRegistration by twin_aspect_id and enablement_service_stack_id."""
+        """Retrieve a TwinAspectRegistration by twin_aspect_id and twin_registry_id."""
         stmt = select(TwinAspectRegistration).where(
             TwinAspectRegistration.twin_aspect_id == twin_aspect_id
         ).where(
-            TwinAspectRegistration.enablement_service_stack_id == enablement_service_stack_id
+            TwinAspectRegistration.twin_registry_id == twin_registry_id
         )
         return self._session.scalars(stmt).first()
 
     def create_new(
         self,
         twin_aspect_id: int,
-        enablement_service_stack_id: int,
+        twin_registry_id: int,
+        connector_control_plane_id: int,
         status: int = 0,
         registration_mode: int = 0,
     ) -> TwinAspectRegistration:
         """Create a new TwinAspectRegistration instance."""
         twin_aspect_registration = TwinAspectRegistration(
             twin_aspect_id=twin_aspect_id,
-            enablement_service_stack_id=enablement_service_stack_id,
+            twin_registry_id=twin_registry_id,
+            connector_control_plane_id=connector_control_plane_id,
             status=status,
             registration_mode=registration_mode,
-            created_at=datetime.now(timezone.utc),
+            created_date=datetime.now(timezone.utc),
             modified_date=datetime.now(timezone.utc),
         )
         self.create(twin_aspect_registration)
@@ -653,20 +670,49 @@ class TwinExchangeRepository(BaseRepository[TwinExchange]):
         return self._session.scalars(stmt).first()  
 
 class TwinRegistrationRepository(BaseRepository[TwinRegistration]):
-    def get_by_twin_id_enablement_service_stack_id(self, twin_id: int, enablement_service_stack_id: int) -> Optional[TwinRegistration]:
+    def get_by_twin_id_twin_registry_id(self, twin_id: int, twin_registry_id: int) -> Optional[TwinRegistration]:
         stmt = select(TwinRegistration).where(
             TwinRegistration.twin_id == twin_id).where(
-            TwinRegistration.enablement_service_stack_id == enablement_service_stack_id)
+            TwinRegistration.twin_registry_id == twin_registry_id)
         return self._session.scalars(stmt).first()
-    
-    def create_new(self, twin_id: int, enablement_service_stack_id: int, dtr_registered: bool = False) -> TwinRegistration:
+
+    def create_new(self, twin_id: int, twin_registry_id: int, dtr_registered: bool = False) -> TwinRegistration:
         twin_registration = TwinRegistration(
             twin_id=twin_id,
-            enablement_service_stack_id=enablement_service_stack_id,
+            twin_registry_id=twin_registry_id,
             dtr_registered=dtr_registered
         )
         self.create(twin_registration)
         return twin_registration
+
+class ConnectorControlPlaneRepository(BaseRepository[ConnectorControlPlane]):
+    def get_by_id(self, id: int, join_legal_entity: bool = False) -> Optional[ConnectorControlPlane]:
+        stmt = select(ConnectorControlPlane).where(ConnectorControlPlane.id == id)
+        if join_legal_entity:   
+            stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id)
+        return self._session.scalars(stmt).first()
+
+    def get_by_name(self, name: str, join_legal_entity: bool = False) -> Optional[ConnectorControlPlane]:
+        stmt = select(ConnectorControlPlane).where(ConnectorControlPlane.name == name)
+        if join_legal_entity:   
+            stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id)
+        return self._session.scalars(stmt).first()
+    
+    def get_default(self, join_legal_entity: bool = False) -> Optional[ConnectorControlPlane]:
+        stmt = select(ConnectorControlPlane).where(ConnectorControlPlane.is_default == True)
+        if join_legal_entity:   
+            stmt = stmt.join(LegalEntity, LegalEntity.id == ConnectorControlPlane.legal_entity_id)
+        return self._session.scalars(stmt).first()
+
+
+class TwinRegistryRepository(BaseRepository[TwinRegistry]):
+    def get_by_name(self, name: str) -> Optional[TwinRegistry]:
+        stmt = select(TwinRegistry).where(TwinRegistry.name == name)
+        return self._session.scalars(stmt).first()
+    
+    def get_default(self) -> Optional[TwinRegistry]:
+        stmt = select(TwinRegistry).where(TwinRegistry.is_default == True)
+        return self._session.scalars(stmt).first()
 
 class NotificationRepository(BaseRepository[NotificationEntity]):
     """

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -2,7 +2,7 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025,2026 LKS Next
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/metadata_database/__init__.py
+++ b/ichub-backend/models/metadata_database/__init__.py
@@ -23,7 +23,7 @@
 #################################################################################
 
 from .provider.models import (
-    LegalEntity, BusinessPartner, EnablementServiceStack,
+    LegalEntity, BusinessPartner, EnablementServiceStack, ConnectorControlPlane, TwinRegistry,
     Twin, TwinAspect, TwinAspectRegistration, TwinExchange, TwinRegistration,
     CatalogPart, PartnerCatalogPart, SerializedPart, JISPart, Batch, BatchBusinessPartner,
     DataExchangeAgreement, DataExchangeContract

--- a/ichub-backend/models/metadata_database/__init__.py
+++ b/ichub-backend/models/metadata_database/__init__.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/metadata_database/__init__.py
+++ b/ichub-backend/models/metadata_database/__init__.py
@@ -23,7 +23,7 @@
 #################################################################################
 
 from .provider.models import (
-    LegalEntity, BusinessPartner, EnablementServiceStack, ConnectorControlPlane, TwinRegistry,
+    LegalEntity, BusinessPartner, ConnectorControlPlane, TwinRegistry,
     Twin, TwinAspect, TwinAspectRegistration, TwinExchange, TwinRegistration,
     CatalogPart, PartnerCatalogPart, SerializedPart, JISPart, Batch, BatchBusinessPartner,
     DataExchangeAgreement, DataExchangeContract

--- a/ichub-backend/models/metadata_database/provider/__init__.py
+++ b/ichub-backend/models/metadata_database/provider/__init__.py
@@ -23,7 +23,7 @@
 #################################################################################
 
 from .models import (
-    LegalEntity, BusinessPartner, EnablementServiceStack,
+    LegalEntity, BusinessPartner, EnablementServiceStack, ConnectorControlPlane, TwinRegistry,
     Twin, TwinAspect, TwinAspectRegistration, TwinExchange, TwinRegistration,
     CatalogPart, PartnerCatalogPart, SerializedPart, JISPart, Batch, BatchBusinessPartner,
     DataExchangeAgreement, DataExchangeContract

--- a/ichub-backend/models/metadata_database/provider/__init__.py
+++ b/ichub-backend/models/metadata_database/provider/__init__.py
@@ -23,7 +23,7 @@
 #################################################################################
 
 from .models import (
-    LegalEntity, BusinessPartner, EnablementServiceStack, ConnectorControlPlane, TwinRegistry,
+    LegalEntity, BusinessPartner, ConnectorControlPlane, TwinRegistry,
     Twin, TwinAspect, TwinAspectRegistration, TwinExchange, TwinRegistration,
     CatalogPart, PartnerCatalogPart, SerializedPart, JISPart, Batch, BatchBusinessPartner,
     DataExchangeAgreement, DataExchangeContract

--- a/ichub-backend/models/metadata_database/provider/__init__.py
+++ b/ichub-backend/models/metadata_database/provider/__init__.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/metadata_database/provider/models.py
+++ b/ichub-backend/models/metadata_database/provider/models.py
@@ -102,7 +102,7 @@ class BusinessPartner(SQLModel, table=True):
     # Relationships
     partner_catalog_parts: List["PartnerCatalogPart"] = Relationship(back_populates="business_partner")
     data_exchange_agreements: List["DataExchangeAgreement"] = Relationship(back_populates="business_partner")
-    
+
     __tablename__ = "business_partner"
 
 
@@ -203,7 +203,7 @@ class CatalogPart(SQLModel, table=True):
     twin: Optional[Twin] = Relationship(back_populates="catalog_part")
     partner_catalog_parts: List["PartnerCatalogPart"] = Relationship(back_populates="catalog_part")
     batches: List["Batch"] = Relationship(back_populates="catalog_part")
-    
+
 
     __table_args__ = (
         UniqueConstraint("legal_entity_id", "manufacturer_part_id", name="uk_catalog_part_legal_entity_id_manufacturer_part_id"),
@@ -493,11 +493,11 @@ class DataExchangeContract(SQLModel, table=True):
 
     __tablename__ = "data_exchange_contract"
 
+
 class ConnectorControlPlane(SQLModel, table=True):
     """
     Represents a Connector Control Plane.
     It holds information about the Connector Control Plane, including its ID, name, and connection settings.
-    It is linked to the enablement_service_stack by a foreign key (enablement_service_stack_id).
     Also it refers the legal entity under whose BPNL the Connector is registered.
 
     Attributes:
@@ -509,23 +509,36 @@ class ConnectorControlPlane(SQLModel, table=True):
         legal_entity_id (int): The ID of the associated legal entity (foreign key to legal_entity).
 
     Relationships:
-        enablement_service_stack (EnablementServiceStack): The enablement service stack associated with this Connector service.
+        legal_entity (LegalEntity): The legal entity associated with this Connector Control Plane.
+        twin_aspect_registrations (List["TwinAspectRegistration"]): The twin aspect registrations associated with this Connector Control Plane.
 
     Table Name:
         connector_control_plane
     """
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True, unique=True, description="The name of the Connector Control Plane.")
-    dataspace_version: str = Field(default="jupiter", description="The version of the dataspace release.")
-    dma_path: str = Field(default="/management", description="The path to the Connector management API.")
-    connection_settings: Optional[Dict[str, Any]] = Field(sa_column=Column(JSON), description="Connection settings stored as JSON")
-    is_default: bool = Field(default=False, description="Indicates if this is the default Connector Control Plane")
-    legal_entity_id: int = Field(index=True, foreign_key="legal_entity.id", description="The ID of the associated legal entity.")
+    name: str = Field(index=True,
+                      unique=True,
+                      description="The name of the Connector Control Plane.")
+    dataspace_version: str = Field(
+        default="jupiter", description="The version of the dataspace release.")
+    dma_path: str = Field(
+        default="/management",
+        description="The path to the Connector management API.")
+    connection_settings: Optional[Dict[str, Any]] = Field(
+        sa_column=Column(JSON),
+        description="Connection settings stored as JSON")
+    is_default: bool = Field(
+        default=False,
+        description="Indicates if this is the default Connector Control Plane")
+    legal_entity_id: int = Field(
+        index=True,
+        foreign_key="legal_entity.id",
+        description="The ID of the associated legal entity.")
 
     # Relationships
-    enablement_service_stack: Optional["EnablementServiceStack"] = Relationship(back_populates="connector_control_plane")
     legal_entity: LegalEntity = Relationship()
-    twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(back_populates="connector_control_plane")
+    twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(
+        back_populates="connector_control_plane")
 
     __tablename__ = "connector_control_plane"
 
@@ -534,7 +547,6 @@ class TwinRegistry(SQLModel, table=True):
     """
     Represents a Digital Twin Registry (DTR).
     It holds information about the Twin Registry, including its ID, name, and connection settings.
-    It is linked to the enablement_service_stack by a foreign key (enablement_service_stack_id).
 
     Attributes:
         id (Optional[int]): The unique identifier for the Twin Registry.
@@ -543,7 +555,6 @@ class TwinRegistry(SQLModel, table=True):
         connection_settings (Optional[Dict[str, Any]]): Connection settings stored as JSON.
 
     Relationships:
-        enablement_service_stack (EnablementServiceStack): The enablement service stack associated with this DTR service.
         twin_aspect_registrations (List["TwinAspectRegistration"]): The twin aspect registrations associated with this service stack.
 
     Table Name:
@@ -556,51 +567,10 @@ class TwinRegistry(SQLModel, table=True):
     is_default: bool = Field(default=False, description="Indicates if this is the default Twin Registry")
 
     # Relationships
-    enablement_service_stack: Optional["EnablementServiceStack"] = Relationship(back_populates="twin_registry")
     twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(back_populates="twin_registry")
     twin_registrations: List["TwinRegistration"] = Relationship(back_populates="twin_registry")
 
     __tablename__ = "twin_registry"
-
-
-class EnablementServiceStack(SQLModel, table=True):
-    """
-    An instance/installation of the `Enablement services` stack.
-    The `Enablement services` stack is a set of services that are used to enable standardized exchange of data between partners.
-    For this implementation, it needs to consist at least of one unique Connector Control Plane
-    and one (sharable) Digital Twin Registry (DTR).
-
-    Attributes:
-        id (Optional[int]): The unique identifier for the enablement service stack.
-        name (str): The name of the enablement service stack.
-        settings (Optional[Dict[str, Any]]): Any stack specific settings stored as JSON. 
-        connector_control_plane_id (int): The ID of the associated Connector control plane (foreign key to connector_control_plane).
-        twin_registry_id (int): The ID of the associated twin registry (foreign key to twin_registry).
-
-    Relationships:
-        connector_control_plane (ConnectorControlPlane): The Connector control plane associated with this enablement service stack.
-        twin_registry (TwinRegistry): The twin registry associated with this enablement service stack.
-        twin_registrations (List["TwinRegistration"]): The twin registrations associated with this service stack.
-
-    Table Name:
-        enablement_service_stack
-
-    """
-    id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True, unique=True, description="The name of the enablement service stack.")
-    settings: Optional[Dict[str, Any]] = Field(
-        sa_column=Column(JSON),  # Specify JSON column type
-        description="Any stack specific settings stored as JSON"
-    )
-    connector_control_plane_id: int = Field(index=True, unique=True, foreign_key="connector_control_plane.id", description="The ID of the associated connector control plane.")
-    twin_registry_id: int = Field(index=True, foreign_key="twin_registry.id", description="The ID of the associated twin registry.")
-
-    # Relationships
-    connector_control_plane: ConnectorControlPlane = Relationship(back_populates="enablement_service_stack")
-    twin_registry: TwinRegistry = Relationship(back_populates="enablement_service_stack")
-
-    __tablename__ = "enablement_service_stack"
-
 
 class TwinAspect(SQLModel, table=True):
     """

--- a/ichub-backend/models/metadata_database/provider/models.py
+++ b/ichub-backend/models/metadata_database/provider/models.py
@@ -63,7 +63,7 @@ class LegalEntity(SQLModel, table=True):
 
     Relationships:
         catalog_parts (List["CatalogPart"]):  A list of catalog parts offered by this legal entity.
-        enablement_service_stacks (List["EnablementServiceStack"]): A list of enablement service stacks associated with this legal entity.
+        connector_control_planes (List["ConnectorControlPlane"]): A list of connector control planes associated with this legal entity.
 
     Table Name:
         legal_entity
@@ -73,7 +73,7 @@ class LegalEntity(SQLModel, table=True):
 
     # Relationships
     catalog_parts: List["CatalogPart"] = Relationship(back_populates="legal_entity")
-    enablement_service_stacks: List["EnablementServiceStack"] = Relationship(back_populates="legal_entity")
+    connector_control_planes: List["ConnectorControlPlane"] = Relationship(back_populates="legal_entity")
 
     __tablename__ = "legal_entity"
 
@@ -493,27 +493,93 @@ class DataExchangeContract(SQLModel, table=True):
 
     __tablename__ = "data_exchange_contract"
 
+class ConnectorControlPlane(SQLModel, table=True):
+    """
+    Represents a Connector Control Plane.
+    It holds information about the Connector Control Plane, including its ID, name, and connection settings.
+    It is linked to the enablement_service_stack by a foreign key (enablement_service_stack_id).
+    Also it refers the legal entity under whose BPNL the Connector is registered.
+
+    Attributes:
+        id (Optional[int]): The unique identifier for the Connector Control Plane.
+        name (str): The name of the Connector Control Plane.
+        dataspace_version (str): The version of the dataspace release.
+        dma_path (str): The path to the Connector management API.
+        connection_settings (Optional[Dict[str, Any]]): Connection settings stored as JSON.
+        legal_entity_id (int): The ID of the associated legal entity (foreign key to legal_entity).
+
+    Relationships:
+        enablement_service_stack (EnablementServiceStack): The enablement service stack associated with this Connector service.
+
+    Table Name:
+        connector_control_plane
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True, description="The name of the Connector Control Plane.")
+    dataspace_version: str = Field(default="jupiter", description="The version of the dataspace release.")
+    dma_path: str = Field(default="/management", description="The path to the Connector management API.")
+    connection_settings: Optional[Dict[str, Any]] = Field(sa_column=Column(JSON), description="Connection settings stored as JSON")
+    is_default: bool = Field(default=False, description="Indicates if this is the default Connector Control Plane")
+    legal_entity_id: int = Field(index=True, foreign_key="legal_entity.id", description="The ID of the associated legal entity.")
+
+    # Relationships
+    enablement_service_stack: Optional["EnablementServiceStack"] = Relationship(back_populates="connector_control_plane")
+    legal_entity: LegalEntity = Relationship()
+    twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(back_populates="connector_control_plane")
+
+    __tablename__ = "connector_control_plane"
+
+
+class TwinRegistry(SQLModel, table=True):
+    """
+    Represents a Digital Twin Registry (DTR).
+    It holds information about the Twin Registry, including its ID, name, and connection settings.
+    It is linked to the enablement_service_stack by a foreign key (enablement_service_stack_id).
+
+    Attributes:
+        id (Optional[int]): The unique identifier for the Twin Registry.
+        name (str): The name of the Twin Registry.
+        version (str): The version of the Twin Registry.
+        connection_settings (Optional[Dict[str, Any]]): Connection settings stored as JSON.
+
+    Relationships:
+        enablement_service_stack (EnablementServiceStack): The enablement service stack associated with this DTR service.
+        twin_aspect_registrations (List["TwinAspectRegistration"]): The twin aspect registrations associated with this service stack.
+
+    Table Name:
+        twin_registry
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True, description="The name of the Twin Registry.")
+    version: str = Field(default="3.0", description="The version of the Twin Registry.")
+    connection_settings: Optional[Dict[str, Any]] = Field(sa_column=Column(JSON), description="Connection settings stored as JSON")
+    is_default: bool = Field(default=False, description="Indicates if this is the default Twin Registry")
+
+    # Relationships
+    enablement_service_stack: Optional["EnablementServiceStack"] = Relationship(back_populates="twin_registry")
+    twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(back_populates="twin_registry")
+    twin_registrations: List["TwinRegistration"] = Relationship(back_populates="twin_registry")
+
+    __tablename__ = "twin_registry"
+
 
 class EnablementServiceStack(SQLModel, table=True):
     """
     An instance/installation of the `Enablement services` stack.
     The `Enablement services` stack is a set of services that are used to enable standardized exchange of data between partners.
-    For this implementation, it needs to consist at least of an Eclipse Dataspace Connector (EDC)
-    and a Digital Twin Registry (DTR) connection.
-    It is linked to legal_entity through a foreign key (legal_entity_id) depicting that the EDC and DTR
-    are related to the respective (company-owned) BPNL of the data provider 
+    For this implementation, it needs to consist at least of one unique Connector Control Plane
+    and one (sharable) Digital Twin Registry (DTR).
 
     Attributes:
         id (Optional[int]): The unique identifier for the enablement service stack.
         name (str): The name of the enablement service stack.
-        connection_settings (Optional[Dict[str, Any]]): Connection settings stored as JSON. 
-			In the future could contain all necessary config to connect to the DTR/EDC/Submodel service. 
-			For the moment we only have one DTR/EDC/Submodel service and it will be statically provided.
-        legal_entity_id (int): The ID of the associated legal entity (foreign key to legal_entity).
+        settings (Optional[Dict[str, Any]]): Any stack specific settings stored as JSON. 
+        connector_control_plane_id (int): The ID of the associated Connector control plane (foreign key to connector_control_plane).
+        twin_registry_id (int): The ID of the associated twin registry (foreign key to twin_registry).
 
     Relationships:
-        legal_entity (LegalEntity): The legal entity associated with this service stack.
-        twin_aspect_registrations (List["TwinAspectRegistration"]): The twin aspect registrations associated with this service stack.
+        connector_control_plane (ConnectorControlPlane): The Connector control plane associated with this enablement service stack.
+        twin_registry (TwinRegistry): The twin registry associated with this enablement service stack.
         twin_registrations (List["TwinRegistration"]): The twin registrations associated with this service stack.
 
     Table Name:
@@ -522,17 +588,16 @@ class EnablementServiceStack(SQLModel, table=True):
     """
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(index=True, unique=True, description="The name of the enablement service stack.")
-    connection_settings: Optional[Dict[str, Any]] = Field(
+    settings: Optional[Dict[str, Any]] = Field(
         sa_column=Column(JSON),  # Specify JSON column type
-        description="Connection settings stored as JSON"
+        description="Any stack specific settings stored as JSON"
     )
-    legal_entity_id: int = Field(index=True, foreign_key="legal_entity.id", description="The ID of the associated legal entity.")
+    connector_control_plane_id: int = Field(index=True, unique=True, foreign_key="connector_control_plane.id", description="The ID of the associated connector control plane.")
+    twin_registry_id: int = Field(index=True, foreign_key="twin_registry.id", description="The ID of the associated twin registry.")
 
     # Relationships
-    legal_entity: LegalEntity = Relationship(back_populates="enablement_service_stacks")
-    twin_aspect_registrations: List["TwinAspectRegistration"] = Relationship(back_populates="enablement_service_stack")
-    twin_registrations: List["TwinRegistration"] = Relationship(back_populates="enablement_service_stack")
-
+    connector_control_plane: ConnectorControlPlane = Relationship(back_populates="enablement_service_stack")
+    twin_registry: TwinRegistry = Relationship(back_populates="enablement_service_stack")
 
     __tablename__ = "enablement_service_stack"
 
@@ -572,25 +637,25 @@ class TwinAspect(SQLModel, table=True):
 
     __tablename__ = "twin_aspect"
 
-    def find_registration_by_stack_id(self, enablement_service_stack_id: int) -> Optional["TwinAspectRegistration"]:
-        """Find the registration for a given enablement service stack."""
+    def find_registration_by_twin_registry_id(self, twin_registry_id: int) -> Optional["TwinAspectRegistration"]:
+        """Find the registration for a given twin registry."""
         for registration in self.twin_aspect_registrations:
-            if registration.enablement_service_stack_id == enablement_service_stack_id:
+            if registration.twin_registry_id == twin_registry_id:
                 return registration
         return None
 
 
 class TwinAspectRegistration(SQLModel, table=True):
     """
-    Represents the relation between a twin_aspect and an enablement_service_stack
-    through their ids (twin_aspect_id and enablement_service_stack_id).
+    Represents the relation between a twin_aspect and a twin_registry
+    through their ids (twin_aspect_id and twin_registry_id).
     It holds information about the status, the registration mode and creation and update dates.
 
     Attributes:
         twin_aspect_id (int): The ID of the associated twin aspect (foreign key to twin_aspect).
-        enablement_service_stack_id (int): The ID of the associated enablement service stack (foreign key).
+        twin_registry_id (int): The ID of the associated twin registry (foreign key).
         status (int): The status of the registration.
-			It‘s actually the status for all 3 services DTR/EDC/Submodel Service (number). It will be set by the system internally.
+			It's actually the status for all 3 services DTR/EDC/Submodel Service (number). It will be set by the system internally.
         registration_mode (int): The registration mode. It indicates asset bundling (yes or no). 
 			In the first version, there is no asset bundling. Later provided by the API caller
         created_date (datetime): The creation date of the registration. Auto-generated in the DB.
@@ -598,7 +663,7 @@ class TwinAspectRegistration(SQLModel, table=True):
 
     Relationships:
         twin_aspect (TwinAspect): The twin aspect being registered.
-        enablement_service_stack (EnablementServiceStack): The enablement service stack used for registration.
+        twin_registry (TwinRegistry): The twin registry used for registration.
 
     Table Name:
         twin_aspect_registration
@@ -606,7 +671,8 @@ class TwinAspectRegistration(SQLModel, table=True):
    
     """
     twin_aspect_id: int = Field(foreign_key="twin_aspect.id", primary_key=True, description="The ID of the associated twin aspect.")
-    enablement_service_stack_id: int = Field(foreign_key="enablement_service_stack.id", primary_key=True, description="The ID of the associated enablement service stack.")
+    twin_registry_id: int = Field(foreign_key="twin_registry.id", primary_key=True, description="The ID of the associated twin registry.")
+    connector_control_plane_id: int = Field(index=True, foreign_key="connector_control_plane.id", description="The ID of the associated connector control plane.")
     status: int = Field(index=True, default=0, description="The status of the registration.", sa_type=SmallInteger) # TODO: Use Enum for status
     registration_mode: int = Field(index=True, default=0, description="The registration mode.", sa_type=SmallInteger) # TODO: Use Enum for registration mode
     created_date: datetime = Field(index=True, default_factory=datetime.utcnow, description="The creation date of the registration.")
@@ -614,7 +680,8 @@ class TwinAspectRegistration(SQLModel, table=True):
 
     # Relationships
     twin_aspect: TwinAspect = Relationship(back_populates="twin_aspect_registrations")
-    enablement_service_stack: EnablementServiceStack = Relationship(back_populates="twin_aspect_registrations")
+    twin_registry: TwinRegistry = Relationship(back_populates="twin_aspect_registrations")
+    connector_control_plane: ConnectorControlPlane = Relationship(back_populates="twin_aspect_registrations")
 
     __tablename__ = "twin_aspect_registration"
 
@@ -654,29 +721,29 @@ class TwinExchange(SQLModel, table=True):
 
 class TwinRegistration(SQLModel, table=True):
     """
-    Represents the relation between s twin and an enablement_service_stack
-    through their ids (twin_id and enablement_service_stack_id).
-    It also indicates if the twin is registered in the DTR using a boolean (dtr_registered).
+    Represents the relation between a twin and a twin registry
+    through their ids (twin_id and twin_registry_id).
+    It also indicates if the twin is registered in the twin registry using a boolean (twin_registered).
 
     Attributes:
         twin_id (int): The ID of the associated twin (foreign key to twin).
-        enablement_service_stack_id (int): The ID of the associated enablement service stack (foreign key).
-        dtr_registered (bool): Whether the twin is registered in the DTR.
+        twin_registry_id (int): The ID of the associated twin registry (foreign key).
+        dtr_registered (bool): Whether the twin is registered in the twin registry.
 
     Relationships:
         twin (Twin): The twin being registered.
-        enablement_service_stack (EnablementServiceStack): The enablement service stack used for registration.
+        twin_registry (TwinRegistry): The twin registry used for registration.
 
     Table Name:
         twin_registration
 
     """
     twin_id: int = Field(foreign_key="twin.id", primary_key=True, description=TWIN_ID_DESCRIPTION)
-    enablement_service_stack_id: int = Field(foreign_key="enablement_service_stack.id", primary_key=True, description="The ID of the associated enablement service stack.")
-    dtr_registered: bool = Field(index=True, default=False, description="Whether the twin is registered in the DTR.")
+    twin_registry_id: int = Field(foreign_key="twin_registry.id", primary_key=True, description="The ID of the associated twin registry.")
+    dtr_registered: bool = Field(index=True, default=False, description="Whether the twin is registered in the twin registry.")
 
     # Relationships
     twin: Twin = Relationship(back_populates="twin_registrations")
-    enablement_service_stack: EnablementServiceStack = Relationship(back_populates="twin_registrations")
+    twin_registry: TwinRegistry = Relationship(back_populates="twin_registrations")
 
     __tablename__ = "twin_registration"

--- a/ichub-backend/models/metadata_database/provider/models.py
+++ b/ichub-backend/models/metadata_database/provider/models.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/services/provider/sharing_management.py
+++ b/ichub-backend/models/services/provider/sharing_management.py
@@ -36,7 +36,6 @@ class SharingBase(BaseModel):
 
 class ShareCatalogPart(SharingBase, CatalogPartBase):
     """Class that stores the information required by request in the sharing functionalit, for catalog parts"""
-    pass
 
 class SharedPartBase(BaseModel):
     business_partner_number: str = Field(alias="businessPartnerNumber", description="The business partner number of the business partner with which the catalog part is shared.")

--- a/ichub-backend/models/services/provider/sharing_management.py
+++ b/ichub-backend/models/services/provider/sharing_management.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/services/provider/system_management.py
+++ b/ichub-backend/models/services/provider/system_management.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/models/services/provider/system_management.py
+++ b/ichub-backend/models/services/provider/system_management.py
@@ -1,0 +1,85 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from typing import Optional, Dict, Any
+from pydantic import BaseModel, Field
+
+class BpnlBase(BaseModel):
+    bpnl: str = Field(..., description="The BPNL (Business Partner Number) of the legal entity.")
+
+class LegalEntityBase(BpnlBase):
+    pass
+
+class LegalEntityCreate(LegalEntityBase):
+    pass
+
+class LegalEntityUpdate(BaseModel):
+    bpnl: Optional[str] = Field(None, description="The BPNL of the legal entity.")
+
+class LegalEntityRead(LegalEntityBase):
+    pass
+
+class ConnectorControlPlaneBase(BaseModel):
+    name: str = Field(..., description="Name of the Connector service")
+    connection_settings: Optional[Dict[str, Any]] = Field(None, description="Connection settings as JSON")
+
+class ConnectorControlPlaneCreate(ConnectorControlPlaneBase, BpnlBase):
+    pass
+
+class ConnectorControlPlaneUpdate(BaseModel):
+    name: Optional[str] = Field(None, description="Name of the Connector service")
+    connection_settings: Optional[Dict[str, Any]] = Field(None, description="Connection settings as JSON")
+
+class ConnectorControlPlaneRead(ConnectorControlPlaneBase):
+    legal_entity: LegalEntityRead = Field(alias="legalEntity", description="The legal entity associated with the Connector service")
+
+class TwinRegistryBase(BaseModel):
+    name: str = Field(..., description="Name of the Twin Registry")
+    connection_settings: Optional[Dict[str, Any]] = Field(None, description="Connection settings as JSON")
+
+class TwinRegistryCreate(TwinRegistryBase):
+    pass
+
+class TwinRegistryUpdate(BaseModel):
+    name: Optional[str] = Field(None, description="Name of the Twin Registry")
+    connection_settings: Optional[Dict[str, Any]] = Field(None, description="Connection settings as JSON")
+
+class TwinRegistryRead(TwinRegistryBase):
+    pass
+
+class EnablementServiceStackBase(BaseModel):
+    name: str = Field(..., description="Name of the enablement service stack")
+    settings: Optional[Dict[str, Any]] = Field(None, description="Settings for the enablement service stack as JSON")
+
+class EnablementServiceStackCreate(EnablementServiceStackBase):
+    connector_name: str = Field(alias="connectorControlPlaneName", description="Name of the Connector Control Plane associated with the stack")
+    twin_registry_name: str = Field(alias="twinRegistryName", description="Name of the Twin Registry associated with the stack")
+
+class EnablementServiceStackUpdate(BaseModel):
+    name: Optional[str] = Field(None, description="Name of the enablement service stack")
+    # Add other updatable fields as needed
+
+class EnablementServiceStackRead(EnablementServiceStackBase):
+    connector_control_plane: ConnectorControlPlaneRead = Field(alias="connectorControlPlane", description="The Connector service associated with the stack")
+    twin_registry: TwinRegistryRead = Field(alias="twinRegistry", description="The Twin Registry associated with the stack")

--- a/ichub-backend/models/services/provider/system_management.py
+++ b/ichub-backend/models/services/provider/system_management.py
@@ -67,19 +67,3 @@ class TwinRegistryUpdate(BaseModel):
 
 class TwinRegistryRead(TwinRegistryBase):
     pass
-
-class EnablementServiceStackBase(BaseModel):
-    name: str = Field(..., description="Name of the enablement service stack")
-    settings: Optional[Dict[str, Any]] = Field(None, description="Settings for the enablement service stack as JSON")
-
-class EnablementServiceStackCreate(EnablementServiceStackBase):
-    connector_name: str = Field(alias="connectorControlPlaneName", description="Name of the Connector Control Plane associated with the stack")
-    twin_registry_name: str = Field(alias="twinRegistryName", description="Name of the Twin Registry associated with the stack")
-
-class EnablementServiceStackUpdate(BaseModel):
-    name: Optional[str] = Field(None, description="Name of the enablement service stack")
-    # Add other updatable fields as needed
-
-class EnablementServiceStackRead(EnablementServiceStackBase):
-    connector_control_plane: ConnectorControlPlaneRead = Field(alias="connectorControlPlane", description="The Connector service associated with the stack")
-    twin_registry: TwinRegistryRead = Field(alias="twinRegistry", description="The Twin Registry associated with the stack")

--- a/ichub-backend/models/services/provider/twin_management.py
+++ b/ichub-backend/models/services/provider/twin_management.py
@@ -66,11 +66,9 @@ class TwinsAspectRegistrationMode(enum.Enum):
     DISPATCHED = 2
     """No extra asset has been generated within the Eclipse Dataspace Connector for the aspect document - instead there is a bundle asset that points to a dispatching service"""
 
-
 class TwinAspectRegistration(BaseModel):
-    """Represents the registration of a twin aspect within an enablement service stack."""
+    """Represents the registration of a twin aspect within a DTR."""
 
-    enablement_service_stack_name: str = Field(alias="enablementServiceStackName", description="The name of the enablement service stack where the twin aspect is registered.")
     status: TwinAspectRegistrationStatus = Field(description="The current status of the aspect registration process.")
     mode: TwinsAspectRegistrationMode = Field(description="The current mode of the aspect registration process.")
     created_date: datetime = Field(alias="createdDate", description="The date when the aspect was initially registered.")
@@ -79,13 +77,12 @@ class TwinAspectRegistration(BaseModel):
 class TwinAspectRead(BaseModel):
     semantic_id: str = Field(alias="semanticId", description="The semantic ID of the aspect determining the structure of the associated payload data.")
     submodel_id: UUID = Field(alias="submodelId", description="The ID of the submodel descriptor within the DTR shell descriptor for the associated twin.")
-    registrations: Optional[Dict[str, TwinAspectRegistration]] = Field(description="A map of registration information for the aspect in different enablement service stacks. The key is the name of the enablement service stack.", default={})
+    registrations: Optional[Dict[str, TwinAspectRegistration]] = Field(description="A map of registration information for the aspect in different twin registries. The key is the name of the twin registry.", default={})
 
 class TwinAspectCreate(BaseModel):
     global_id: UUID = Field(alias="globalId", description="The Catena-X ID / global ID of the digital twin to which the new aspect belongs.")
     semantic_id: str = Field(alias="semanticId", description="The semantic ID of the new aspect determining the structure of the associated payload data.")
     submodel_id: Optional[UUID] = Field(alias="submodelId", description="The optional ID of the submodel descriptor within the DTR shell descriptor for the associated twin. If not specified, a new UUID will be created automatically.", default=None) 
-    #enablement_service_stack_name: str = Field(alias="enablementServiceStackName", description="The name of the enablement service stack where the twin aspect should be registered.")
     payload: Dict[str, Any] = Field(description="The payload data of the new aspect. This is a JSON object that contains the actual data of the aspect. The structure of this object is determined by the semantic ID of the aspect.")
 
 class TwinRead(BaseModel):
@@ -103,9 +100,10 @@ class TwinCreateBase(BaseModel):
     global_id: Optional[UUID] = Field(alias="globalId", description="Optionally the Catena-X ID / global ID of the digital twin to create. If not specified, a new UUID will be created automatically.", default=None)
     dtr_aas_id: Optional[UUID] = Field(alias="dtrAasId", description="Optionally the shell descriptor ID ('AAS ID') of the digital twin in the Digital Twin Registry. If not specified, a new UUID will be created automatically.", default=None)
     id_short: Optional[str] = Field(alias="idShort", description="Optionally the idShort of the digital twin in the Digital Twin Registry. If not specified, a default value 'Twin-{globalId}' will be used.", default=None)
+
 class TwinDetailsReadBase(BaseModel):
     additional_context: Optional[Dict[str, Any]] = Field(alias="additionalContext", description="Additional context information about the digital twin. This can include various metadata or properties associated with the twin. Intended for handling twins by third party apps.", default=None)
-    registrations: Optional[Dict[str, bool]] = Field(description="A map of registration information for the digital twin in different enablement service stacks. The key is the name of the enablement service stack.", default=None)
+    registrations: Optional[Dict[str, bool]] = Field(description="A map of registration information for the digital twin in different DTRs. The key is the name of the DTR.", default=None)
     all_aspects: Optional[List[TwinAspectRead]] = Field(alias="allAspects", description="A complete list of all aspect information for the digital twin, including multiple aspects with the same semantic ID.", default=None)
     aspects: Optional[Dict[str, TwinAspectRead]] = Field(description="A map of aspect information for the digital twin. The key is the semantic ID of the aspect. The value is a TwinAspectRead object containing details about the aspect. For backward compatibility, only the first aspect of each semantic type is included.", default=None)
 

--- a/ichub-backend/models/services/provider/twin_management.py
+++ b/ichub-backend/models/services/provider/twin_management.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -51,25 +51,33 @@ class SharingService:
     def get_shared_partners(self, manufacturer_id:str, manufacturer_part_id:str) -> List[SharedPartner]:
         pass
     
-    def share_catalog_part(self, catalog_part_to_share: ShareCatalogPart) -> SharedPartBase:
+    def share_catalog_part(self,
+        catalog_part_to_share: ShareCatalogPart,
+        db_twin_registry_id: int = 1,
+        db_connector_control_plane_id: int = 1
+        ) -> SharedPartBase:
+        
         shared_at = datetime.now(timezone.utc)
         with RepositoryManagerFactory.create() as repo:
             # Step 1: Retrieve the catalog part from the repository
             db_catalog_part = self._get_catalog_part(repo, catalog_part_to_share)
-            # Step 2: Get or create the enablement service stack for the manufacturer
-            ## Note: this is not used at the moment
-            db_enablement_service_stack = self.twin_management_service.get_or_create_enablement_stack(repo, catalog_part_to_share.manufacturer_id)
-            # Step 3: Get or create the business partner entity
+            
+            # Step 2: Get or create the business partner entity
             db_business_partner = self._get_or_create_business_partner(repo, catalog_part_to_share)
-            # Step 4: Get or create the data exchange agreement for the business partner
+            
+            # Step 3: Get or create the data exchange agreement for the business partner
             db_data_exchange_agreement = self._get_or_create_data_exchange_agreement(repo, db_business_partner)
-            # Step 5: Get or create the partner catalog part
+            
+            # Step 4: Get or create the partner catalog part
             db_partner_catalog_parts:Dict[str, BusinessPartnerRead] = self._get_or_create_partner_catalog_parts(repo, catalog_part_to_share.customer_part_id, db_catalog_part, db_business_partner)
-            # Step 6: Create and retrieve the catalog part twin
-            db_twin = self._create_and_get_twin(repo, catalog_part_to_share)
-            # Step 7: Ensure a twin exchange exists between the twin and the data exchange agreement
+            
+            # Step 5: Create and retrieve the catalog part twin
+            db_twin = self._create_and_get_twin(repo, catalog_part_to_share, db_twin_registry_id)
+            
+            # Step 8: Ensure a twin exchange exists between the twin and the data exchange agreement
             self._ensure_twin_exchange(repo, db_twin, db_data_exchange_agreement)
-            # Step 8: Create the part twin aspect with part type information (if already not created)
+            
+            # Step 9: Create the part twin aspect with part type information (if already not created)
             part_type_info_doc = self._create_part_type_information_aspect_doc(
                 global_id=db_twin.global_id,
                 manufacturer_part_id=catalog_part_to_share.manufacturer_part_id,
@@ -81,7 +89,9 @@ class SharingService:
                     globalId=db_twin.global_id,
                     semanticId=SEM_ID_PART_TYPE_INFORMATION_V1,
                     payload=part_type_info_doc
-                )
+                ),
+                db_twin_registry_id=db_twin_registry_id,
+                db_connector_control_plane_id=db_connector_control_plane_id
             )
             # Step 9: Return the shared part information
             return SharedPartBase(
@@ -183,14 +193,18 @@ class SharingService:
         repo.refresh(db_partner_catalog_part)
         return db_partner_catalog_part
 
-    def _create_and_get_twin(self, repo: RepositoryManager, catalog_part_to_share: ShareCatalogPart) -> Twin:
+    def _create_and_get_twin(self,
+        repo: RepositoryManager,
+        catalog_part_to_share: ShareCatalogPart,
+        db_twin_registry_id: int
+        ) -> Twin:
         """
         Create a catalog part twin and retrieve its database representation.
         """
         twin_read = self.twin_management_service.create_catalog_part_twin(CatalogPartTwinCreate(
             manufacturerId=catalog_part_to_share.manufacturer_id,
-            manufacturerPartId=catalog_part_to_share.manufacturer_part_id,
-        ))
+            manufacturerPartId=catalog_part_to_share.manufacturer_part_id
+        ), db_twin_registry_id=db_twin_registry_id)
         db_twin = repo.twin_repository.find_by_global_id(twin_read.global_id)
         return db_twin
 

--- a/ichub-backend/services/provider/system_management_service.py
+++ b/ichub-backend/services/provider/system_management_service.py
@@ -1,0 +1,330 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from typing import List, Optional
+
+from connector import connector_manager
+from dtr import dtr_provider_manager
+from managers.config.config_manager import ConfigManager
+from managers.enablement_services.provider.dtr_provider_manager import DtrProviderManager
+from managers.enablement_services.provider.connector_provider_manager import ConnectorProviderManager
+
+from models.services.provider.system_management import (
+    ConnectorControlPlaneCreate,
+    ConnectorControlPlaneRead,
+    ConnectorControlPlaneUpdate,
+    TwinRegistryCreate,
+    TwinRegistryRead,
+    TwinRegistryUpdate,
+    EnablementServiceStackCreate,
+    EnablementServiceStackRead,
+    EnablementServiceStackUpdate,
+    LegalEntityCreate,
+    LegalEntityRead,
+    LegalEntityUpdate,
+)
+from managers.metadata_database.manager import RepositoryManagerFactory
+from models.metadata_database.provider.models import (
+    ConnectorControlPlane,
+    TwinRegistry,
+    EnablementServiceStack,
+    LegalEntity
+)
+
+from tools.exceptions import NotAvailableError
+
+class SystemManagementService:
+    """
+    Service class for managing EnablementServiceStack entities.
+    """
+    def create_enablement_service_stack(self, stack_create: EnablementServiceStackCreate) -> EnablementServiceStackRead:
+        with RepositoryManagerFactory.create() as repo:
+            db_enablement_service_stacks = repo.enablement_service_stack_repository.get_by_name(stack_create.name)
+            if db_enablement_service_stacks:
+                raise ValueError(f"EnablementServiceStack with name {stack_create.name} already exists.")
+
+            db_connector_control_plane = repo.connector_control_plane_repository.get_by_name(stack_create.connector_name)
+            if not db_connector_control_plane:
+                raise ValueError(f"ConnectorControlPlane with name {stack_create.connector_name} not found.")
+
+            db_twin_registry = repo.twin_registry_repository.get_by_name(stack_create.dtr_name)
+            if not db_twin_registry:
+                raise ValueError(f"TwinRegistry with name {stack_create.dtr_name} not found.")
+
+            db_stack = EnablementServiceStack(
+                name=stack_create.name,
+                connector_control_plane_id=db_connector_control_plane.id,
+                twin_registry_id=db_twin_registry.id,
+                settings=stack_create.settings)
+            
+            repo.enablement_service_stack_repository.create(db_stack)
+            repo.commit()
+        
+            ## Create a asset in the connector for the digital twin registry.
+            # TODO: will all customers want to have that? Maybe introduce a parameter for that?
+            edc_manager = self.get_connector_manager(db_connector_control_plane)
+
+            dtr_config = db_twin_registry.connection_settings # Get the DTR connection settings from the DB
+            asset_config = dtr_config.get("asset_config")
+            
+            dtr_asset_id, _, _, _ = edc_manager.register_dtr_offer(
+                base_dtr_url=dtr_config.get("hostname"),
+                uri=dtr_config.get("uri"),
+                api_path=dtr_config.get("apiPath"),
+                dtr_policy_config=dtr_config.get("policy"),
+                dct_type=asset_config.get("dct_type"),
+                existing_asset_id=asset_config.get("existing_asset_id", None)
+            )
+
+            # Update the Connector connection settings with the generated asset id for the DTR
+            db_connector_control_plane.connection_settings["dtr_asset_id"] = dtr_asset_id
+            repo.commit()
+        
+        return EnablementServiceStackRead.model_validate(db_stack)
+
+    def get_enablement_service_stack(self, stack_id: int) -> Optional[EnablementServiceStackRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_stack = repo.enablement_service_stack_repository.find_by_id(stack_id)
+            if db_stack:
+                return EnablementServiceStackRead.model_validate(db_stack)
+            return None
+
+    def get_enablement_service_stacks(self) -> List[EnablementServiceStackRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_stacks = repo.enablement_service_stack_repository.find_all()
+            return [EnablementServiceStackRead.model_validate(stack) for stack in db_stacks]
+
+    def update_enablement_service_stack(self, stack_id: int, stack_update: EnablementServiceStackUpdate) -> Optional[EnablementServiceStackRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_stack = repo.enablement_service_stack_repository.find_by_id(stack_id)
+            if not db_stack:
+                return None
+            for field, value in stack_update.model_dump(exclude_unset=True).items():
+                setattr(db_stack, field, value)
+            repo.commit()
+            return EnablementServiceStackRead.model_validate(db_stack)
+
+    def delete_enablement_service_stack(self, stack_id: int) -> bool:
+        with RepositoryManagerFactory.create() as repo:
+            try:
+                repo.enablement_service_stack_repository.delete(stack_id)
+                repo.commit()
+                return True
+            except ValueError:
+                return False
+
+    def create_connector_control_plane(self, connector_create: ConnectorControlPlaneCreate) -> ConnectorControlPlaneRead:
+        with RepositoryManagerFactory.create() as repo:
+            legal_entity = repo.legal_entity_repository.get_by_bpnl(connector_create.bpnl)
+            if not legal_entity or legal_entity.id is None:
+                raise ValueError("LegalEntity with given BPNL not found or has no ID")
+            db_connector = ConnectorControlPlane(
+                name=connector_create.name,
+                connection_settings=connector_create.connection_settings,
+                legal_entity_id=legal_entity.id
+            )
+            repo.connector_control_plane_repository.create(db_connector)
+            repo.commit()
+            return ConnectorControlPlaneRead(
+                name=db_connector.name,
+                connection_settings=db_connector.connection_settings,
+                legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
+            )
+
+    def get_connector_control_plane(self, connector_id: int) -> Optional[ConnectorControlPlaneRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_connector = repo.connector_control_plane_repository.find_by_id(connector_id)
+            if db_connector:
+                legal_entity = repo.legal_entity_repository.find_by_id(db_connector.legal_entity_id)
+                if legal_entity:
+                    return ConnectorControlPlaneRead(
+                        name=db_connector.name,
+                        connection_settings=db_connector.connection_settings,
+                        legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
+                    )
+            return None
+
+    def retrieve_connector_control_planes(self) -> List[ConnectorControlPlaneRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_connectors = repo.connector_control_plane_repository.find_all()
+            result = []
+            for connector in db_connectors:
+                legal_entity = repo.legal_entity_repository.find_by_id(connector.legal_entity_id)
+                if legal_entity:
+                    result.append(ConnectorControlPlaneRead(
+                        name=connector.name,
+                        connection_settings=connector.connection_settings,
+                        legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
+                    ))
+            return result
+
+    def update_connector_control_plane(self, connector_id: int, connector_update: ConnectorControlPlaneUpdate) -> Optional[ConnectorControlPlaneRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_connector = repo.connector_control_plane_repository.find_by_id(connector_id)
+            if not db_connector:
+                return None
+            for field, value in connector_update.model_dump(exclude_unset=True).items():
+                setattr(db_connector, field, value)
+            repo.commit()
+            legal_entity = repo.legal_entity_repository.find_by_id(db_connector.legal_entity_id)
+            if legal_entity:
+                return ConnectorControlPlaneRead(
+                    name=db_connector.name,
+                    connection_settings=db_connector.connection_settings,
+                    legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
+                )
+            return None
+
+    def delete_connector_control_plane(self, connector_id: int) -> bool:
+        with RepositoryManagerFactory.create() as repo:
+            try:
+                repo.connector_control_plane_repository.delete(connector_id)
+                repo.commit()
+                return True
+            except ValueError:
+                return False
+
+    def create_twin_registry(self, dtr_create: TwinRegistryCreate) -> TwinRegistryRead:
+        with RepositoryManagerFactory.create() as repo:
+            db_dtr = TwinRegistry(**dtr_create.model_dump(by_alias=False))
+            repo.twin_registry_repository.create(db_dtr)
+            repo.commit()
+            return TwinRegistryRead.model_validate(db_dtr)
+
+    def get_twin_registry(self, dtr_id: int) -> Optional[TwinRegistryRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_dtr = repo.twin_registry_repository.find_by_id(dtr_id)
+            if db_dtr:
+                return TwinRegistryRead.model_validate(db_dtr)
+            return None
+
+    def get_twin_registries(self) -> List[TwinRegistryRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_dtrs = repo.twin_registry_repository.find_all()
+            return [TwinRegistryRead.model_validate(dtr) for dtr in db_dtrs]
+
+    def update_twin_registry(self, dtr_id: int, dtr_update: TwinRegistryUpdate) -> Optional[TwinRegistryRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_dtr = repo.twin_registry_repository.find_by_id(dtr_id)
+            if not db_dtr:
+                return None
+            for field, value in dtr_update.model_dump(exclude_unset=True).items():
+                setattr(db_dtr, field, value)
+            repo.commit()
+            return TwinRegistryRead.model_validate(db_dtr)
+
+    def delete_twin_registry(self, dtr_id: int) -> bool:
+        with RepositoryManagerFactory.create() as repo:
+            try:
+                repo.twin_registry_repository.delete(dtr_id)
+                repo.commit()
+                return True
+            except ValueError:
+                return False
+
+    def create_legal_entity(self, legal_entity_create: LegalEntityCreate) -> LegalEntityRead:
+        with RepositoryManagerFactory.create() as repo:
+            db_legal_entity = LegalEntity(**legal_entity_create.model_dump(by_alias=False))
+            repo.legal_entity_repository.create(db_legal_entity)
+            repo.commit()
+            return LegalEntityRead(bpnl=db_legal_entity.bpnl)
+
+    def get_legal_entity(self, legal_entity_id: int) -> Optional[LegalEntityRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_legal_entity = repo.legal_entity_repository.find_by_id(legal_entity_id)
+            if db_legal_entity:
+                return LegalEntityRead(bpnl=db_legal_entity.bpnl)
+            return None
+
+    def get_legal_entities(self) -> List[LegalEntityRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_legal_entities = repo.legal_entity_repository.find_all()
+            return [LegalEntityRead(bpnl=le.bpnl) for le in db_legal_entities]
+
+    def update_legal_entity(self, legal_entity_id: int, legal_entity_update: LegalEntityUpdate) -> Optional[LegalEntityRead]:
+        with RepositoryManagerFactory.create() as repo:
+            db_legal_entity = repo.legal_entity_repository.find_by_id(legal_entity_id)
+            if not db_legal_entity:
+                return None
+            for field, value in legal_entity_update.model_dump(exclude_unset=True).items():
+                setattr(db_legal_entity, field, value)
+            repo.commit()
+            return LegalEntityRead(bpnl=db_legal_entity.bpnl)
+
+    def delete_legal_entity(self, legal_entity_id: int) -> bool:
+        with RepositoryManagerFactory.create() as repo:
+            try:
+                repo.legal_entity_repository.delete(legal_entity_id)
+                repo.commit()
+                return True
+            except ValueError:
+                return False
+
+    @staticmethod
+    def get_dtr_manager(db_twin_registry: TwinRegistry) -> DtrProviderManager:
+        """
+        Get the DtrProviderManager.
+        """
+        if db_twin_registry is None:
+            raise NotAvailableError("TwinRegistry is None, cannot create DtrProviderManager.")  
+        
+        if db_twin_registry.is_default:
+            return dtr_provider_manager
+        
+        # TODO: create connection based on config in the database
+        raise NotAvailableError("DtrProviderManager for the given TwinRegistry is not available.")
+
+    @staticmethod
+    def get_connector_manager(db_connector_control_plane: ConnectorControlPlane) -> ConnectorProviderManager:
+        """
+        Get the ConnectorManager.
+        """
+        if db_connector_control_plane is None:
+            raise NotAvailableError("ConnectorControlPlane is None, cannot create ConnectorProviderManager.")
+        
+        if db_connector_control_plane.is_default:
+            return connector_manager.provider
+        
+        # TODO: later we can configure the manager via the connection settings from the DB here
+        # TODO: implement caching
+        raise NotAvailableError("ConnectorProviderManager for the given ConnectorControlPlane is not available.")
+    
+    @staticmethod
+    def ensure_dtr_asset_registration() -> None:
+        """
+        Ensure that the Digital Twin Registry asset is registered.
+        TODO: have a discussion when a DTR asset should be registered in a certain Control Plane. Basically it's a decision of each participant.
+        """
+        dtr_config = ConfigManager.get_config("provider.digitalTwinRegistry")
+        asset_config = dtr_config.get("asset_config")
+        dtr_asset_id, _, _, _ = connector_manager.provider.register_dtr_offer(
+            base_dtr_url=dtr_config.get("hostname"),
+            uri=dtr_config.get("uri"),
+            api_path=dtr_config.get("apiPath"),
+            dtr_policy_config=dtr_config.get("policy"),
+            dct_type=asset_config.get("dct_type"),
+            existing_asset_id=asset_config.get("existing_asset_id", None)
+        )
+        if not dtr_asset_id:
+            raise NotAvailableError("The Digital Twin Registry was not able to be registered, or was not found in the Connector!")

--- a/ichub-backend/services/provider/system_management_service.py
+++ b/ichub-backend/services/provider/system_management_service.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/services/provider/system_management_service.py
+++ b/ichub-backend/services/provider/system_management_service.py
@@ -37,9 +37,6 @@ from models.services.provider.system_management import (
     TwinRegistryCreate,
     TwinRegistryRead,
     TwinRegistryUpdate,
-    EnablementServiceStackCreate,
-    EnablementServiceStackRead,
-    EnablementServiceStackUpdate,
     LegalEntityCreate,
     LegalEntityRead,
     LegalEntityUpdate,
@@ -48,152 +45,85 @@ from managers.metadata_database.manager import RepositoryManagerFactory
 from models.metadata_database.provider.models import (
     ConnectorControlPlane,
     TwinRegistry,
-    EnablementServiceStack,
     LegalEntity
 )
 
 from tools.exceptions import NotAvailableError
 
+
 class SystemManagementService:
-    """
-    Service class for managing EnablementServiceStack entities.
-    """
-    def create_enablement_service_stack(self, stack_create: EnablementServiceStackCreate) -> EnablementServiceStackRead:
+
+    def create_connector_control_plane(
+        self, connector_create: ConnectorControlPlaneCreate
+    ) -> ConnectorControlPlaneRead:
         with RepositoryManagerFactory.create() as repo:
-            db_enablement_service_stacks = repo.enablement_service_stack_repository.get_by_name(stack_create.name)
-            if db_enablement_service_stacks:
-                raise ValueError(f"EnablementServiceStack with name {stack_create.name} already exists.")
-
-            db_connector_control_plane = repo.connector_control_plane_repository.get_by_name(stack_create.connector_name)
-            if not db_connector_control_plane:
-                raise ValueError(f"ConnectorControlPlane with name {stack_create.connector_name} not found.")
-
-            db_twin_registry = repo.twin_registry_repository.get_by_name(stack_create.dtr_name)
-            if not db_twin_registry:
-                raise ValueError(f"TwinRegistry with name {stack_create.dtr_name} not found.")
-
-            db_stack = EnablementServiceStack(
-                name=stack_create.name,
-                connector_control_plane_id=db_connector_control_plane.id,
-                twin_registry_id=db_twin_registry.id,
-                settings=stack_create.settings)
-            
-            repo.enablement_service_stack_repository.create(db_stack)
-            repo.commit()
-        
-            ## Create a asset in the connector for the digital twin registry.
-            # TODO: will all customers want to have that? Maybe introduce a parameter for that?
-            edc_manager = self.get_connector_manager(db_connector_control_plane)
-
-            dtr_config = db_twin_registry.connection_settings # Get the DTR connection settings from the DB
-            asset_config = dtr_config.get("asset_config")
-            
-            dtr_asset_id, _, _, _ = edc_manager.register_dtr_offer(
-                base_dtr_url=dtr_config.get("hostname"),
-                uri=dtr_config.get("uri"),
-                api_path=dtr_config.get("apiPath"),
-                dtr_policy_config=dtr_config.get("policy"),
-                dct_type=asset_config.get("dct_type"),
-                existing_asset_id=asset_config.get("existing_asset_id", None)
-            )
-
-            # Update the Connector connection settings with the generated asset id for the DTR
-            db_connector_control_plane.connection_settings["dtr_asset_id"] = dtr_asset_id
-            repo.commit()
-        
-        return EnablementServiceStackRead.model_validate(db_stack)
-
-    def get_enablement_service_stack(self, stack_id: int) -> Optional[EnablementServiceStackRead]:
-        with RepositoryManagerFactory.create() as repo:
-            db_stack = repo.enablement_service_stack_repository.find_by_id(stack_id)
-            if db_stack:
-                return EnablementServiceStackRead.model_validate(db_stack)
-            return None
-
-    def get_enablement_service_stacks(self) -> List[EnablementServiceStackRead]:
-        with RepositoryManagerFactory.create() as repo:
-            db_stacks = repo.enablement_service_stack_repository.find_all()
-            return [EnablementServiceStackRead.model_validate(stack) for stack in db_stacks]
-
-    def update_enablement_service_stack(self, stack_id: int, stack_update: EnablementServiceStackUpdate) -> Optional[EnablementServiceStackRead]:
-        with RepositoryManagerFactory.create() as repo:
-            db_stack = repo.enablement_service_stack_repository.find_by_id(stack_id)
-            if not db_stack:
-                return None
-            for field, value in stack_update.model_dump(exclude_unset=True).items():
-                setattr(db_stack, field, value)
-            repo.commit()
-            return EnablementServiceStackRead.model_validate(db_stack)
-
-    def delete_enablement_service_stack(self, stack_id: int) -> bool:
-        with RepositoryManagerFactory.create() as repo:
-            try:
-                repo.enablement_service_stack_repository.delete(stack_id)
-                repo.commit()
-                return True
-            except ValueError:
-                return False
-
-    def create_connector_control_plane(self, connector_create: ConnectorControlPlaneCreate) -> ConnectorControlPlaneRead:
-        with RepositoryManagerFactory.create() as repo:
-            legal_entity = repo.legal_entity_repository.get_by_bpnl(connector_create.bpnl)
+            legal_entity = repo.legal_entity_repository.get_by_bpnl(
+                connector_create.bpnl)
             if not legal_entity or legal_entity.id is None:
-                raise ValueError("LegalEntity with given BPNL not found or has no ID")
+                raise ValueError(
+                    "LegalEntity with given BPNL not found or has no ID")
             db_connector = ConnectorControlPlane(
                 name=connector_create.name,
                 connection_settings=connector_create.connection_settings,
-                legal_entity_id=legal_entity.id
-            )
+                legal_entity_id=legal_entity.id)
             repo.connector_control_plane_repository.create(db_connector)
             repo.commit()
             return ConnectorControlPlaneRead(
                 name=db_connector.name,
                 connection_settings=db_connector.connection_settings,
-                legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
-            )
+                legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl))
 
-    def get_connector_control_plane(self, connector_id: int) -> Optional[ConnectorControlPlaneRead]:
+    def get_connector_control_plane(
+            self, connector_id: int) -> Optional[ConnectorControlPlaneRead]:
         with RepositoryManagerFactory.create() as repo:
-            db_connector = repo.connector_control_plane_repository.find_by_id(connector_id)
+            db_connector = repo.connector_control_plane_repository.find_by_id(
+                connector_id)
             if db_connector:
-                legal_entity = repo.legal_entity_repository.find_by_id(db_connector.legal_entity_id)
+                legal_entity = repo.legal_entity_repository.find_by_id(
+                    db_connector.legal_entity_id)
                 if legal_entity:
                     return ConnectorControlPlaneRead(
                         name=db_connector.name,
                         connection_settings=db_connector.connection_settings,
-                        legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
-                    )
+                        legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl))
             return None
 
-    def retrieve_connector_control_planes(self) -> List[ConnectorControlPlaneRead]:
+    def retrieve_connector_control_planes(
+            self) -> List[ConnectorControlPlaneRead]:
         with RepositoryManagerFactory.create() as repo:
             db_connectors = repo.connector_control_plane_repository.find_all()
             result = []
             for connector in db_connectors:
-                legal_entity = repo.legal_entity_repository.find_by_id(connector.legal_entity_id)
+                legal_entity = repo.legal_entity_repository.find_by_id(
+                    connector.legal_entity_id)
                 if legal_entity:
-                    result.append(ConnectorControlPlaneRead(
-                        name=connector.name,
-                        connection_settings=connector.connection_settings,
-                        legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
-                    ))
+                    result.append(
+                        ConnectorControlPlaneRead(
+                            name=connector.name,
+                            connection_settings=connector.connection_settings,
+                            legalEntity=LegalEntityRead(
+                                bpnl=legal_entity.bpnl)))
             return result
 
-    def update_connector_control_plane(self, connector_id: int, connector_update: ConnectorControlPlaneUpdate) -> Optional[ConnectorControlPlaneRead]:
+    def update_connector_control_plane(
+        self, connector_id: int, connector_update: ConnectorControlPlaneUpdate
+    ) -> Optional[ConnectorControlPlaneRead]:
         with RepositoryManagerFactory.create() as repo:
-            db_connector = repo.connector_control_plane_repository.find_by_id(connector_id)
+            db_connector = repo.connector_control_plane_repository.find_by_id(
+                connector_id)
             if not db_connector:
                 return None
-            for field, value in connector_update.model_dump(exclude_unset=True).items():
+            for field, value in connector_update.model_dump(
+                    exclude_unset=True).items():
                 setattr(db_connector, field, value)
             repo.commit()
-            legal_entity = repo.legal_entity_repository.find_by_id(db_connector.legal_entity_id)
+            legal_entity = repo.legal_entity_repository.find_by_id(
+                db_connector.legal_entity_id)
             if legal_entity:
                 return ConnectorControlPlaneRead(
                     name=db_connector.name,
                     connection_settings=db_connector.connection_settings,
-                    legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl)
-                )
+                    legalEntity=LegalEntityRead(bpnl=legal_entity.bpnl))
             return None
 
     def delete_connector_control_plane(self, connector_id: int) -> bool:
@@ -205,7 +135,8 @@ class SystemManagementService:
             except ValueError:
                 return False
 
-    def create_twin_registry(self, dtr_create: TwinRegistryCreate) -> TwinRegistryRead:
+    def create_twin_registry(
+            self, dtr_create: TwinRegistryCreate) -> TwinRegistryRead:
         with RepositoryManagerFactory.create() as repo:
             db_dtr = TwinRegistry(**dtr_create.model_dump(by_alias=False))
             repo.twin_registry_repository.create(db_dtr)
@@ -224,12 +155,15 @@ class SystemManagementService:
             db_dtrs = repo.twin_registry_repository.find_all()
             return [TwinRegistryRead.model_validate(dtr) for dtr in db_dtrs]
 
-    def update_twin_registry(self, dtr_id: int, dtr_update: TwinRegistryUpdate) -> Optional[TwinRegistryRead]:
+    def update_twin_registry(
+            self, dtr_id: int,
+            dtr_update: TwinRegistryUpdate) -> Optional[TwinRegistryRead]:
         with RepositoryManagerFactory.create() as repo:
             db_dtr = repo.twin_registry_repository.find_by_id(dtr_id)
             if not db_dtr:
                 return None
-            for field, value in dtr_update.model_dump(exclude_unset=True).items():
+            for field, value in dtr_update.model_dump(
+                    exclude_unset=True).items():
                 setattr(db_dtr, field, value)
             repo.commit()
             return TwinRegistryRead.model_validate(db_dtr)
@@ -243,16 +177,20 @@ class SystemManagementService:
             except ValueError:
                 return False
 
-    def create_legal_entity(self, legal_entity_create: LegalEntityCreate) -> LegalEntityRead:
+    def create_legal_entity(
+            self, legal_entity_create: LegalEntityCreate) -> LegalEntityRead:
         with RepositoryManagerFactory.create() as repo:
-            db_legal_entity = LegalEntity(**legal_entity_create.model_dump(by_alias=False))
+            db_legal_entity = LegalEntity(**legal_entity_create.model_dump(
+                by_alias=False))
             repo.legal_entity_repository.create(db_legal_entity)
             repo.commit()
             return LegalEntityRead(bpnl=db_legal_entity.bpnl)
 
-    def get_legal_entity(self, legal_entity_id: int) -> Optional[LegalEntityRead]:
+    def get_legal_entity(self,
+                         legal_entity_id: int) -> Optional[LegalEntityRead]:
         with RepositoryManagerFactory.create() as repo:
-            db_legal_entity = repo.legal_entity_repository.find_by_id(legal_entity_id)
+            db_legal_entity = repo.legal_entity_repository.find_by_id(
+                legal_entity_id)
             if db_legal_entity:
                 return LegalEntityRead(bpnl=db_legal_entity.bpnl)
             return None
@@ -262,12 +200,16 @@ class SystemManagementService:
             db_legal_entities = repo.legal_entity_repository.find_all()
             return [LegalEntityRead(bpnl=le.bpnl) for le in db_legal_entities]
 
-    def update_legal_entity(self, legal_entity_id: int, legal_entity_update: LegalEntityUpdate) -> Optional[LegalEntityRead]:
+    def update_legal_entity(
+            self, legal_entity_id: int, legal_entity_update: LegalEntityUpdate
+    ) -> Optional[LegalEntityRead]:
         with RepositoryManagerFactory.create() as repo:
-            db_legal_entity = repo.legal_entity_repository.find_by_id(legal_entity_id)
+            db_legal_entity = repo.legal_entity_repository.find_by_id(
+                legal_entity_id)
             if not db_legal_entity:
                 return None
-            for field, value in legal_entity_update.model_dump(exclude_unset=True).items():
+            for field, value in legal_entity_update.model_dump(
+                    exclude_unset=True).items():
                 setattr(db_legal_entity, field, value)
             repo.commit()
             return LegalEntityRead(bpnl=db_legal_entity.bpnl)
@@ -287,29 +229,37 @@ class SystemManagementService:
         Get the DtrProviderManager.
         """
         if db_twin_registry is None:
-            raise NotAvailableError("TwinRegistry is None, cannot create DtrProviderManager.")  
-        
+            raise NotAvailableError(
+                "TwinRegistry is None, cannot create DtrProviderManager.")
+
         if db_twin_registry.is_default:
             return dtr_provider_manager
-        
+
         # TODO: create connection based on config in the database
-        raise NotAvailableError("DtrProviderManager for the given TwinRegistry is not available.")
+        raise NotAvailableError(
+            "DtrProviderManager for the given TwinRegistry is not available.")
 
     @staticmethod
-    def get_connector_manager(db_connector_control_plane: ConnectorControlPlane) -> ConnectorProviderManager:
+    def get_connector_manager(
+        db_connector_control_plane: ConnectorControlPlane
+    ) -> ConnectorProviderManager:
         """
         Get the ConnectorManager.
         """
         if db_connector_control_plane is None:
-            raise NotAvailableError("ConnectorControlPlane is None, cannot create ConnectorProviderManager.")
-        
+            raise NotAvailableError(
+                "ConnectorControlPlane is None, cannot create ConnectorProviderManager."
+            )
+
         if db_connector_control_plane.is_default:
             return connector_manager.provider
-        
+
         # TODO: later we can configure the manager via the connection settings from the DB here
         # TODO: implement caching
-        raise NotAvailableError("ConnectorProviderManager for the given ConnectorControlPlane is not available.")
-    
+        raise NotAvailableError(
+            "ConnectorProviderManager for the given ConnectorControlPlane is not available."
+        )
+
     @staticmethod
     def ensure_dtr_asset_registration() -> None:
         """
@@ -324,7 +274,8 @@ class SystemManagementService:
             api_path=dtr_config.get("apiPath"),
             dtr_policy_config=dtr_config.get("policy"),
             dct_type=asset_config.get("dct_type"),
-            existing_asset_id=asset_config.get("existing_asset_id", None)
-        )
+            existing_asset_id=asset_config.get("existing_asset_id", None))
         if not dtr_asset_id:
-            raise NotAvailableError("The Digital Twin Registry was not able to be registered, or was not found in the Connector!")
+            raise NotAvailableError(
+                "The Digital Twin Registry was not able to be registered, or was not found in the Connector!"
+            )

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -24,14 +24,10 @@
 #################################################################################
 
 from typing import Optional, Dict, Any, List
-from uuid import UUID, uuid4
+from uuid import UUID
 from datetime import datetime, timezone
 
-from connector import connector_manager
-from dtr import dtr_provider_manager
-
 from managers.submodels.submodel_document_generator import SubmodelDocumentGenerator, SEM_ID_PART_TYPE_INFORMATION_V1, SEM_ID_SERIAL_PART_V3
-from managers.config.config_manager import ConfigManager
 from managers.metadata_database.manager import RepositoryManagerFactory, RepositoryManager
 from managers.enablement_services.submodel_service_manager import SubmodelServiceManager
 from models.services.provider.part_management import SerializedPartQuery
@@ -48,17 +44,18 @@ from models.services.provider.twin_management import (
     TwinRead,
     TwinAspectCreate,
     TwinAspectRead,
-    TwinAspectRegistration,
+    TwinAspectRegistration as SvcTwinAspectRegistration,
     TwinAspectRegistrationStatus,
     TwinsAspectRegistrationMode,
     TwinDetailsReadBase,
 )
-from models.metadata_database.provider.models import CatalogPart, EnablementServiceStack, Twin, BusinessPartner, TwinAspect, TwinAspectRegistration
-from tools.exceptions import NotFoundError, NotAvailableError
+from models.metadata_database.provider.models import BusinessPartner, TwinAspect, TwinAspectRegistration, CatalogPart, Twin, TwinRegistry, ConnectorControlPlane
+from tools.exceptions import InvalidError, NotFoundError, NotAvailableError
 
 from managers.config.log_manager import LoggingManager
 
-from services.provider.part_management_service import PartManagementService
+from .part_management_service import PartManagementService
+from .system_management_service import SystemManagementService
 
 logger = LoggingManager.get_logger(__name__)
 
@@ -81,23 +78,12 @@ class TwinManagementService:
         trimmed = str(value).strip()
         return trimmed if trimmed else None
 
-    def get_or_create_enablement_stack(self, repo: RepositoryManager, manufacturer_id: str) -> EnablementServiceStack:
-        """
-        Retrieve or create an EnablementServiceStack for the given manufacturer ID.
-        """
+    def create_catalog_part_twin(self,
+        create_input: CatalogPartTwinCreate,
+        auto_create_part_type_information: Optional[bool] = None,
+        db_twin_registry_id: Optional[int] = None,
+        db_connector_control_plane_id: Optional[int] = None) -> TwinRead:
         
-        db_enablement_service_stacks = repo.enablement_service_stack_repository.find_by_legal_entity_bpnl(legal_entity_bpnl=manufacturer_id)
-        if not db_enablement_service_stacks:
-            db_legal_entity = repo.legal_entity_repository.get_by_bpnl(bpnl=manufacturer_id)
-            db_enablement_service_stack = repo.enablement_service_stack_repository.create(
-                EnablementServiceStack(name=uuid4(), legal_entity_id=db_legal_entity.id))
-            repo.commit()
-            repo.refresh(db_enablement_service_stack)
-        else:
-            db_enablement_service_stack = db_enablement_service_stacks[0]
-        return db_enablement_service_stack
-    
-    def create_catalog_part_twin(self, create_input: CatalogPartTwinCreate, auto_create_part_type_information: bool = False) -> TwinRead:
         with RepositoryManagerFactory.create() as repo:
             # Step 1: Retrieve the catalog part entity according to the catalog part data (manufacturer_id, manufacturer_part_id)
             db_catalog_parts = repo.catalog_part_repository.find_by_manufacturer_id_manufacturer_part_id(
@@ -110,9 +96,8 @@ class TwinManagementService:
             else:
                 db_catalog_part, _ = db_catalog_parts[0]
 
-            # Step 2: Retrieve the enablement service stack entity from the DB according to the given name
-            # (if not there => raise error)
-            db_enablement_service_stack = self.get_or_create_enablement_stack(repo=repo, manufacturer_id=create_input.manufacturer_id)
+            # Step 2: Retrieve the twin registry entity from the DB according to the given name
+            db_twin_registry = TwinManagementService._get_digital_twin_registry(repo, db_twin_registry_id)
 
             # Step 3a: Load existing twin metadata from the DB (if there)
             if db_catalog_part.twin_id:
@@ -130,16 +115,16 @@ class TwinManagementService:
                 db_catalog_part.twin_id = db_twin.id
                 repo.commit()
 
-            # Step 4: Try to find the twin registration for the twin id and enablement service stack id
+            # Step 4: Try to find the twin registration for the twin id and twin registry id
             # (if not there => create it now, setting the dtr_registered flag to False)
-            db_twin_registration = repo.twin_registration_repository.get_by_twin_id_enablement_service_stack_id(
+            db_twin_registration = repo.twin_registration_repository.get_by_twin_id_twin_registry_id(
                 db_twin.id,
-                db_enablement_service_stack.id
+                db_twin_registry.id    
             )
             if not db_twin_registration:
                 db_twin_registration = repo.twin_registration_repository.create_new(
                     twin_id=db_twin.id,
-                    enablement_service_stack_id=db_enablement_service_stack.id
+                    twin_registry_id=db_twin_registry.id
                 )
                 repo.commit()
                 repo.refresh(db_twin_registration)
@@ -149,9 +134,11 @@ class TwinManagementService:
             # (if False => we need to register the twin in the DTR using the industry core SDK, then
             #  update the twin registration entity with the dtr_registered flag to True)
             
+            dtr_provider_manager = SystemManagementService.get_dtr_manager(db_twin_registry)
+            
             customer_part_ids = {partner_catalog_part.customer_part_id: partner_catalog_part.business_partner.bpnl 
                                     for partner_catalog_part in db_catalog_part.partner_catalog_parts}
-
+            
             _id_short = None
             if(create_input.id_short):
                 _id_short = create_input.id_short
@@ -196,8 +183,10 @@ class TwinManagementService:
                     TwinAspectCreate(
                         globalId= db_twin.global_id,
                         semanticId= SEM_ID_PART_TYPE_INFORMATION_V1,
-                        payload= part_type_info_doc
-                    )                    
+                        payload= part_type_info_doc,
+                    ),
+                    db_twin_registry_id,
+                    db_connector_control_plane_id                    
                 )
             
             return TwinRead(
@@ -295,7 +284,12 @@ class TwinManagementService:
 
         return result
 
-    def create_serialized_part_twin(self, create_input: SerializedPartTwinCreate, auto_create_serial_part_aspect: bool = False, enablement_service_stack_name: str = 'EDC/DTR Default') -> TwinRead:
+    def create_serialized_part_twin(self,
+        create_input: SerializedPartTwinCreate,
+        auto_create_serial_part_aspect: Optional[bool] = False,
+        db_twin_registry_id: Optional[int] = None,
+        db_connector_control_plane_id: Optional[int] = None) -> TwinRead:
+
         with RepositoryManagerFactory.create() as repo:
             # Step 1: Retrieve the catalog part entity according to the catalog part data (manufacturer_id, manufacturer_part_id)
             db_serialized_parts = repo.serialized_part_repository.find(
@@ -311,10 +305,9 @@ class TwinManagementService:
             if not db_serialized_part.partner_catalog_part:
                 raise NotAvailableError("Serialized Part is not linked to a Catalog Part of a Business Partner.")
             
-            # Step 2: Retrieve the enablement service stack entity from the DB according to the given manufacturer ID
-            # This will create one if it doesn't exist
-            db_enablement_service_stack = self.get_or_create_enablement_stack(repo=repo, manufacturer_id=create_input.manufacturer_id)
-            
+            # Step 2: Retrieve the twin registry entity from the DB according to the given name
+            db_twin_registry = TwinManagementService._get_digital_twin_registry(repo, db_twin_registry_id)
+    
             # Step 3a: Load existing twin metadata from the DB (if there)
             if db_serialized_part.twin_id:
                 db_twin = repo.twin_repository.find_by_id(db_serialized_part.twin_id)
@@ -331,16 +324,16 @@ class TwinManagementService:
                 db_serialized_part.twin_id = db_twin.id
                 repo.commit()
 
-            # Step 4: Try to find the twin registration for the twin id and enablement service stack id
+            # Step 4: Try to find the twin registration for the twin id and twin registry id
             # (if not there => create it now, setting the dtr_registered flag to False)
-            db_twin_registration = repo.twin_registration_repository.get_by_twin_id_enablement_service_stack_id(
+            db_twin_registration = repo.twin_registration_repository.get_by_twin_id_twin_registry_id(
                 db_twin.id,
-                db_enablement_service_stack.id
+                db_twin_registry.id
             )
             if not db_twin_registration:
                 db_twin_registration = repo.twin_registration_repository.create_new(
                     twin_id=db_twin.id,
-                    enablement_service_stack_id=db_enablement_service_stack.id
+                    twin_registry_id=db_twin_registry.id
                 )
                 repo.commit()
 
@@ -362,6 +355,8 @@ class TwinManagementService:
                 if _cat:
                     asset_type_value = _cat
 
+            dtr_provider_manager = SystemManagementService.get_dtr_manager(db_twin_registry)
+                
             dtr_provider_manager.create_or_update_shell_descriptor(
                 global_id=db_twin.global_id,
                 aas_id=db_twin.aas_id,
@@ -400,7 +395,9 @@ class TwinManagementService:
                         globalId=db_twin.global_id,
                         semanticId=SEM_ID_SERIAL_PART_V3,
                         payload=serial_part_doc
-                    )
+                    ),
+                    db_twin_registry_id,
+                    db_connector_control_plane_id
                 )
 
             return TwinRead(
@@ -512,7 +509,26 @@ class TwinManagementService:
 
         return result
 
-    def create_twin_aspect(self, twin_aspect_create: TwinAspectCreate) -> TwinAspectRead:
+    def get_twin_registrations(self, global_id: UUID) -> Dict[int, bool]:
+        """
+        Get the twin registrations for a given twin global ID.
+        Returns a dictionary mapping twin registry IDs to their DTR registration status.
+        """
+
+        with RepositoryManagerFactory.create() as repo:
+            db_twin = repo.twin_repository.find_by_global_id(global_id, include_registrations=True)
+            if not db_twin:
+                raise NotFoundError(f"Twin for global ID '{global_id}' not found.")
+
+            return {
+                db_twin_registration.twin_registry_id: db_twin_registration.dtr_registered
+                for db_twin_registration in db_twin.twin_registrations
+            }
+
+    def create_twin_aspect(self,
+        twin_aspect_create: TwinAspectCreate,
+        db_twin_registry_id: Optional[int] = None,
+        db_connector_control_plane_id: Optional[int] = None) -> TwinAspectRead:
         """
         Create a new twin aspect for a give twin.
         """
@@ -520,18 +536,29 @@ class TwinManagementService:
         with RepositoryManagerFactory.create() as repo:
             
             # Step 1: Retrieve the twin entity according to the global_id
-            db_twin = repo.twin_repository.find_by_global_id(twin_aspect_create.global_id)
+            db_twin = repo.twin_repository.find_by_global_id(twin_aspect_create.global_id, include_registrations=True)
             if not db_twin:
                 raise NotFoundError(f"Twin for global ID '{twin_aspect_create.global_id}' not found.")
 
-            # Step 2: Get associated manufacturer id
+            # Step 1a: Get associated manufacturer id
             manufacturer_id = self._get_manufacturer_id_from_twin(db_twin)
 
-            # Step 3: Retrieve the enablement service stack entity from the DB according to the given manufacturer ID
-            # (if not there => raise error)
-            # TODO: later the stack needs to be passed as an argument
-            db_enablement_service_stack = self.get_or_create_enablement_stack(repo=repo, manufacturer_id=manufacturer_id)
-            
+            # Step 2a: Retrieve the twin registry entity from the DB according to the given name
+            db_twin_registry = TwinManagementService._get_digital_twin_registry(repo, db_twin_registry_id)
+
+            # Step 2b: Retrieve the connector control plane entity from the DB according to the given name
+            db_connector_control_plane = TwinManagementService._get_connector_control_plane(
+                repo, db_connector_control_plane_id, join_legal_entity=True
+            )
+           
+            # Check if there is a twin_registration for the given twin registry and throw an error if not
+            if not any(reg.twin_registry_id == db_twin_registry.id for reg in db_twin.twin_registrations):
+                raise NotFoundError(f"Twin registration for twin registry ID '{db_twin_registry.id}' not found.")
+
+            # Consistency check of the manufacturer id with the connector control plane
+            if manufacturer_id != db_connector_control_plane.legal_entity.bpnl:
+                raise InvalidError(f"Manufacturer ID '{manufacturer_id}' does not match with connector control plane's manufacturer ID '{db_connector_control_plane.legal_entity.bpnl}'.")
+
             # Step 3: Retrieve a potentially existing twin aspect entity for the given twin_id and semantic_id
             db_twin_aspect = repo.twin_aspect_repository.get_by_twin_id_semantic_id(
                 db_twin.id,
@@ -542,17 +569,18 @@ class TwinManagementService:
                 # Step 3a: Create a new twin aspect entity in the database
                 db_twin_aspect = self._create_twin_aspect_entity_db(twin_aspect_create, repo, db_twin)
 
-            # Step 4: Check if there is already a registration for the given enablement service stack and create it if not
+            # Step 4: Check if there is already a registration for the given twin registry and create it if not
             db_twin_aspect_registration = self._get_or_create_twin_aspect_registration(
-                repo, db_twin_aspect, db_enablement_service_stack
+                repo, db_twin_aspect, db_twin_registry, db_connector_control_plane
             )
 
             # Step 4b: Ensure DTR asset is registered
-            self._ensure_dtr_asset_registration()
+            # TODO: make this a more explicit operation out of System Management Service
+            SystemManagementService.ensure_dtr_asset_registration()
 
             # Step 5: Handle the submodel service
             self._handle_submodel_service_upload(
-                repo, db_twin_aspect_registration, db_enablement_service_stack, db_twin_aspect, twin_aspect_create
+                repo, db_twin_aspect_registration, db_twin_aspect, db_connector_control_plane, twin_aspect_create
             )
             
             # Step 6: Handle the EDC registration
@@ -561,11 +589,14 @@ class TwinManagementService:
             # Step 7: Handle the DTR registration
             self._handle_dtr_registration(repo, db_twin_aspect_registration, db_twin, db_twin_aspect, asset_id)
 
-            return self._create_twin_aspect_read_response(db_twin_aspect, db_enablement_service_stack, db_twin_aspect_registration)
+            return self._create_twin_aspect_read_response(db_twin_aspect, db_twin_registry, db_connector_control_plane, db_twin_aspect_registration)
         
-    def create_or_update_twin_aspect_not_default(self, twin_aspect_create: TwinAspectCreate) -> TwinAspectRead:
+    def create_or_update_twin_aspect_not_default(self,
+        twin_aspect_create: TwinAspectCreate,
+        db_twin_registry_id: Optional[int] = None,
+        db_connector_control_plane_id: Optional[int] = None) -> TwinAspectRead:
         """
-        Create or update a twin aspect for a give twin without using the default enablement service stack.
+        Create or update a twin aspect for a give twin without using the default Twin Registry and Connector Control Plane.
         """
 
         with RepositoryManagerFactory.create() as repo:
@@ -578,16 +609,23 @@ class TwinManagementService:
             # Step 2: Get associated manufacturer id
             manufacturer_id = self._get_manufacturer_id_from_twin(db_twin)
 
-            # Step 3: Retrieve the enablement service stack entity from the DB according to the given manufacturer ID
-            # (if not there => raise error)
-            # TODO: later the stack needs to be passed as an argument
-            db_enablement_service_stack = self.get_or_create_enablement_stack(repo=repo, manufacturer_id=manufacturer_id)
+            # Step 3a: Retrieve the twin registry entity from the DB according to the given name
+            db_twin_registry = TwinManagementService._get_digital_twin_registry(repo, db_twin_registry_id)
+
+            # Step 3b: Retrieve the connector control plane entity from the DB according to the given name
+            db_connector_control_plane = TwinManagementService._get_connector_control_plane(
+                repo, db_connector_control_plane_id, join_legal_entity=True
+            )
+
+            # Consistency check of the manufacturer id with the connector control plane
+            if manufacturer_id != db_connector_control_plane.legal_entity.bpnl:
+                raise InvalidError(f"Manufacturer ID '{manufacturer_id}' does not match with connector control plane's manufacturer ID '{db_connector_control_plane.manufacturer_id}'.")
             
-            # Step 3a: Create a new twin aspect entity in the database if a submodel_id is not provided
+            # Step 4a: Create a new twin aspect entity in the database if a submodel_id is not provided
             if not twin_aspect_create.submodel_id:
                 db_twin_aspect = self._create_twin_aspect_entity_db(twin_aspect_create, repo, db_twin)
 
-            # Step 3b: Retrieve a potentially existing twin aspect entity for the given twin_id, semantic_id and submodel_id. If not found, create it. Otherwise, update it.
+            # Step 4b: Retrieve a potentially existing twin aspect entity for the given twin_id, semantic_id and submodel_id. If not found, create it. Otherwise, update it.
             else:
                 db_twin_aspect = repo.twin_aspect_repository.get_by_twin_id_semantic_id_submodel_id(
                     db_twin.id,
@@ -599,75 +637,65 @@ class TwinManagementService:
                 else:
                     # Update existing twin aspect
                     self._handle_submodel_service_update(
-                        repo, db_twin_aspect.registrations[0], db_enablement_service_stack, db_twin_aspect, twin_aspect_create
+                        repo, db_twin_aspect.twin_aspect_registrations[0], db_twin_aspect, db_connector_control_plane, twin_aspect_create
                     )
                     repo.commit()
                     repo.refresh(db_twin_aspect)
-                    return self._create_twin_aspect_read_response(db_twin_aspect, db_enablement_service_stack, db_twin_aspect.registrations[0])
+                    return self._create_twin_aspect_read_response(db_twin_aspect, db_twin_registry, db_connector_control_plane, db_twin_aspect.twin_aspect_registrations[0])
             
 
-            # Step 4: Check if there is already a registration for the given enablement service stack and create it if not
+            # Step 5a: Check if there is already a registration for the given Twin Registry stack and create it if not
             db_twin_aspect_registration = self._get_or_create_twin_aspect_registration(
-                repo, db_twin_aspect, db_enablement_service_stack
+                repo, db_twin_aspect, db_twin_registry, db_connector_control_plane
             )
 
-            # Step 4b: Ensure DTR asset is registered
-            self._ensure_dtr_asset_registration()
+            # Step 5b: Ensure DTR asset is registered
+            # TODO: make this a more explicit operation out of System Management Service
+            SystemManagementService.ensure_dtr_asset_registration()
 
-            # Step 5: Handle the submodel service
+            # Step 6: Handle the submodel service
             self._handle_submodel_service_upload(
-                repo, db_twin_aspect_registration, db_enablement_service_stack, db_twin_aspect, twin_aspect_create
+                repo, db_twin_aspect_registration, db_twin_aspect, db_connector_control_plane,twin_aspect_create
             )
             
-            # Step 6: Handle the EDC registration
+            # Step 7: Handle the EDC registration
             asset_id = self._handle_edc_registration(repo, db_twin_aspect_registration, db_twin_aspect)
             
-            # Step 7: Handle the DTR registration
+            # Step 8: Handle the DTR registration
             self._handle_dtr_registration(repo, db_twin_aspect_registration, db_twin, db_twin_aspect, asset_id)
 
-            return self._create_twin_aspect_read_response(db_twin_aspect, db_enablement_service_stack, db_twin_aspect_registration)
+            return self._create_twin_aspect_read_response(db_twin_aspect, db_twin_registry, db_connector_control_plane, db_twin_aspect_registration)
 
-    def _get_or_create_twin_aspect_registration(self, repo: RepositoryManager, db_twin_aspect: TwinAspect, db_enablement_service_stack: EnablementServiceStack) -> TwinAspectRegistration:
+    def _get_or_create_twin_aspect_registration(self, repo: RepositoryManager, db_twin_aspect: TwinAspect, db_twin_registry: TwinRegistry, db_connector_control_plane: ConnectorControlPlane) -> TwinAspectRegistration:
         """
-        Get or create a twin aspect registration for the given enablement service stack.
+        Get or create a twin aspect registration for the given Twin Registry and Connector Control Plane.
         """
-        db_twin_aspect_registration = db_twin_aspect.find_registration_by_stack_id(
-            db_enablement_service_stack.id
+        db_twin_aspect_registration = db_twin_aspect.find_registration_by_twin_registry_id(
+            db_twin_registry.id
         )
         if not db_twin_aspect_registration:
             db_twin_aspect_registration = repo.twin_aspect_registration_repository.create_new(
                 twin_aspect_id=db_twin_aspect.id,
-                enablement_service_stack_id=db_enablement_service_stack.id,
+                twin_registry_id=db_twin_registry.id,
+                connector_control_plane_id=db_connector_control_plane.id,
                 registration_mode=TwinsAspectRegistrationMode.DISPATCHED.value, 
             )
             repo.commit()
             repo.refresh(db_twin_aspect_registration)
             repo.refresh(db_twin_aspect)
+        
+        # Consistency check for the control plane
+        elif db_twin_aspect_registration.connector_control_plane_id != db_connector_control_plane.id:
+            raise InvalidError("Twin aspect registration already exists with a different Connector Control Plane.")
+ 
         return db_twin_aspect_registration
 
-    def _ensure_dtr_asset_registration(self) -> None:
-        """
-        Ensure that the Digital Twin Registry asset is registered.
-        """
-        dtr_config = ConfigManager.get_config("provider.digitalTwinRegistry")
-        asset_config = dtr_config.get("asset_config")
-        dtr_asset_id, _, _, _ = connector_manager.provider.register_dtr_offer(
-            base_dtr_url=dtr_config.get("hostname"),
-            uri=dtr_config.get("uri"),
-            api_path=dtr_config.get("apiPath"),
-            dtr_policy_config=dtr_config.get("policy"),
-            dct_type=asset_config.get("dct_type"),
-            existing_asset_id=asset_config.get("existing_asset_id", None)
-        )
-        if not dtr_asset_id:
-            raise NotAvailableError("The Digital Twin Registry was not able to be registered, or was not found in the Connector!")
-
-    def _handle_submodel_service_upload(self, repo: RepositoryManager, db_twin_aspect_registration: TwinAspectRegistration, db_enablement_service_stack: EnablementServiceStack, db_twin_aspect: TwinAspect, twin_aspect_create: TwinAspectCreate) -> None:
+    def _handle_submodel_service_upload(self, repo: RepositoryManager, db_twin_aspect_registration: TwinAspectRegistration, db_twin_aspect: TwinAspect, db_connector_control_plane: ConnectorControlPlane, twin_aspect_create: TwinAspectCreate) -> None:
         """
         Handle the upload of the twin aspect payload to the submodel service.
         """
         if db_twin_aspect_registration.status < TwinAspectRegistrationStatus.STORED.value:
-            submodel_service_manager = _create_submodel_service_manager(db_enablement_service_stack.connection_settings)
+            submodel_service_manager = _create_submodel_service_manager()
             
             # Upload the payload to the submodel service
             submodel_service_manager.upload_twin_aspect_document(
@@ -681,12 +709,12 @@ class TwinManagementService:
             repo.commit()
             repo.refresh(db_twin_aspect_registration)
     
-    def _handle_submodel_service_update(self, repo: RepositoryManager, db_twin_aspect_registration: TwinAspectRegistration, db_enablement_service_stack: EnablementServiceStack, db_twin_aspect: TwinAspect, twin_aspect_create: TwinAspectCreate) -> None:
+    def _handle_submodel_service_update(self, repo: RepositoryManager, db_twin_aspect_registration: TwinAspectRegistration, db_twin_aspect: TwinAspect, db_connector_control_plane: ConnectorControlPlane, twin_aspect_create: TwinAspectCreate) -> None:
         """
         Handle the update of the twin aspect payload to the submodel service.
         """
         if db_twin_aspect_registration.status == TwinAspectRegistrationStatus.STORED.value:
-            submodel_service_manager = _create_submodel_service_manager(db_enablement_service_stack.connection_settings)
+            submodel_service_manager = _create_submodel_service_manager()
             
             # Update the payload to the submodel service
             submodel_service_manager.upload_twin_aspect_document(
@@ -704,7 +732,9 @@ class TwinManagementService:
         """
         Handle the EDC registration for the twin aspect and return the asset ID.
         """
-        asset_id, usage_policy_id, access_policy_id, contract_id = connector_manager.provider.register_submodel_bundle_circular_offer(
+        connector_manager_provider = SystemManagementService.get_connector_manager(db_twin_aspect_registration.connector_control_plane)
+
+        asset_id, usage_policy_id, access_policy_id, contract_id = connector_manager_provider.register_submodel_bundle_circular_offer(
             semantic_id=db_twin_aspect.semantic_id
         )
         
@@ -720,14 +750,22 @@ class TwinManagementService:
         """
         Handle the DTR registration for the twin aspect.
         """
+        dtr_provider_manager = SystemManagementService.get_dtr_manager(db_twin_aspect_registration.twin_registry)
+        connector_provider_manager = SystemManagementService.get_connector_manager(db_twin_aspect_registration.connector_control_plane)
+
         if db_twin_aspect_registration.status < TwinAspectRegistrationStatus.DTR_REGISTERED.value:               
+            href_url = f"{connector_provider_manager.connector_dataplane_hostname}{connector_provider_manager.connector_dataplane_public_path}"
+            dsp_endpoint_url = f"{connector_provider_manager.connector_controlplane_hostname}{connector_provider_manager.connector_controlplane_catalog_path}"
+
             # Register the submodel in the DTR (if necessary)
             try:
                 dtr_provider_manager.create_submodel_descriptor(
                     aas_id=db_twin.aas_id,
                     submodel_id=db_twin_aspect.submodel_id,
                     semantic_id=db_twin_aspect.semantic_id,
-                    connector_asset_id=asset_id
+                    connector_asset_id=asset_id,
+                    dsp_endpoint_url=dsp_endpoint_url,
+                    href_url=href_url
                 )
                 # Update the registration status to DTR_REGISTERED only on success
                 db_twin_aspect_registration.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
@@ -736,22 +774,21 @@ class TwinManagementService:
                 logger.error(f"Failed to create submodel descriptor: {e}")
                 raise e  # Re-raise the exception to prevent twin creation from completing
 
-    def _create_twin_aspect_read_response(self, db_twin_aspect: TwinAspect, db_enablement_service_stack: EnablementServiceStack, db_twin_aspect_registration: TwinAspectRegistration) -> TwinAspectRead:
+    def _create_twin_aspect_read_response(self, db_twin_aspect: TwinAspect, db_twin_registry: TwinRegistry, db_connector_control_plane: ConnectorControlPlane, db_twin_aspect_registration: TwinAspectRegistration) -> TwinAspectRead:
         """
         Create and return the TwinAspectRead response object.
         """
-        registration_data = {
-            "enablementServiceStackName": db_enablement_service_stack.name,
-            "status": TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
-            "mode": TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
-            "createdDate": db_twin_aspect_registration.created_date,
-            "modifiedDate": db_twin_aspect_registration.modified_date
-        }
+        registration_data = SvcTwinAspectRegistration(
+            status=TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
+            mode=TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
+            createdDate=db_twin_aspect_registration.created_date,
+            modifiedDate=db_twin_aspect_registration.modified_date
+        )
         
         return TwinAspectRead(
             semanticId=db_twin_aspect.semantic_id,
             submodelId=db_twin_aspect.submodel_id,
-            registrations={db_enablement_service_stack.name: registration_data}
+            registrations={db_twin_registry.name: registration_data}
         )
 
     def _create_twin_aspect_entity_db(self, twin_aspect_create: TwinAspectCreate, repo: RepositoryManager, db_twin: Twin) -> TwinAspect:
@@ -796,29 +833,29 @@ class TwinManagementService:
     @staticmethod
     def _build_catalog_part_twin_details(db_twin: Twin) -> Optional[CatalogPartTwinDetailsRead]:
             
-            db_catalog_part = db_twin.catalog_part
-            twin_result = CatalogPartTwinDetailsRead(
-                globalId=db_twin.global_id,
-                dtrAasId=db_twin.aas_id,
-                createdDate=db_twin.created_date,
-                modifiedDate=db_twin.modified_date,
-                manufacturerId=db_catalog_part.legal_entity.bpnl,
-                manufacturerPartId=db_catalog_part.manufacturer_part_id,
-                name=db_catalog_part.name,
-                category=TwinManagementService._none_if_empty(db_catalog_part.category),
-                bpns=db_catalog_part.bpns,
-                additionalContext=db_twin.additional_context,
-                customerPartIds={partner_catalog_part.customer_part_id: BusinessPartnerRead(
-                    name=partner_catalog_part.business_partner.name,
-                    bpnl=partner_catalog_part.business_partner.bpnl
-                ) for partner_catalog_part in db_catalog_part.partner_catalog_parts}
-            )
+        db_catalog_part = db_twin.catalog_part
+        twin_result = CatalogPartTwinDetailsRead(
+            globalId=db_twin.global_id,
+            dtrAasId=db_twin.aas_id,
+            createdDate=db_twin.created_date,
+            modifiedDate=db_twin.modified_date,
+            manufacturerId=db_catalog_part.legal_entity.bpnl,
+            manufacturerPartId=db_catalog_part.manufacturer_part_id,
+            name=db_catalog_part.name,
+            category=TwinManagementService._none_if_empty(db_catalog_part.category),
+            bpns=db_catalog_part.bpns,
+            additionalContext=db_twin.additional_context,
+            customerPartIds={partner_catalog_part.customer_part_id: BusinessPartnerRead(
+                name=partner_catalog_part.business_partner.name,
+                bpnl=partner_catalog_part.business_partner.bpnl
+            ) for partner_catalog_part in db_catalog_part.partner_catalog_parts}
+        )
 
-            TwinManagementService._fill_shares(db_twin, twin_result)
-            TwinManagementService._fill_registrations(db_twin, twin_result)
-            TwinManagementService._fill_aspects(db_twin, twin_result)
+        TwinManagementService._fill_shares(db_twin, twin_result)
+        TwinManagementService._fill_registrations(db_twin, twin_result)
+        TwinManagementService._fill_aspects(db_twin, twin_result)
 
-            return twin_result
+        return twin_result
 
     @staticmethod
     def _build_serialized_part_twin(db_twin: Twin, details: bool = False) -> SerializedPartTwinRead | SerializedPartTwinDetailsRead:
@@ -871,7 +908,7 @@ class TwinManagementService:
     @staticmethod   
     def _fill_registrations(db_twin: Twin, twin_result: TwinDetailsReadBase):
         twin_result.registrations = {
-                db_twin_registration.enablement_service_stack.name: db_twin_registration.dtr_registered
+                db_twin_registration.twin_registry.name: db_twin_registration.dtr_registered
                     for db_twin_registration in db_twin.twin_registrations
             }
 
@@ -885,14 +922,15 @@ class TwinManagementService:
             # Build registrations dictionary separately
             registrations = {}
             for db_twin_aspect_registration in db_twin_aspect.twin_aspect_registrations:
-                registration_data = {
-                    "enablementServiceStackName": db_twin_aspect_registration.enablement_service_stack.name,
-                    "status": TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
-                    "mode": TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
-                    "createdDate": db_twin_aspect_registration.created_date,
-                    "modifiedDate": db_twin_aspect_registration.modified_date
-                }
-                registrations[db_twin_aspect_registration.enablement_service_stack.name] = registration_data
+                registration_data = SvcTwinAspectRegistration(
+                    twinRegistryName=db_twin_aspect_registration.twin_registry.name,
+                    connectorControlPlaneName=db_twin_aspect_registration.connector_control_plane.name,
+                    status=TwinAspectRegistrationStatus(db_twin_aspect_registration.status),
+                    mode=TwinsAspectRegistrationMode(db_twin_aspect_registration.registration_mode),
+                    createdDate=db_twin_aspect_registration.created_date,
+                    modifiedDate=db_twin_aspect_registration.modified_date
+                )
+                registrations[db_twin_aspect_registration.twin_registry.name] = registration_data
             
             aspect_read = TwinAspectRead(
                 semanticId=db_twin_aspect.semantic_id,
@@ -929,34 +967,69 @@ class TwinManagementService:
         db_twin: Twin,
         db_business_partner: BusinessPartner
     ) -> bool:
-            # Step 1: Retrieve the first data exchange agreement entity for the business partner
-            # (this will will later be replaced with an explicit mechanism choose a specific data exchange agreement)
-            db_data_exchange_agreements = repo.data_exchange_agreement_repository.get_by_business_partner_id(
-                db_business_partner.id
+        
+        # Step 1: Retrieve the first data exchange agreement entity for the business partner
+        # (this will will later be replaced with an explicit mechanism choose a specific data exchange agreement)
+        db_data_exchange_agreements = repo.data_exchange_agreement_repository.get_by_business_partner_id(
+            db_business_partner.id
+        )
+        if not db_data_exchange_agreements:
+            raise NotFoundError(f"No data exchange agreement found for business partner '{db_business_partner.bpnl}'.")
+        db_data_exchange_agreement = db_data_exchange_agreements[0] # Get the first one for now
+        
+        # Step 2: Check if there is already a twin exchange entity for the twin and data exchange agreement and create it if not
+        db_twin_exchange = repo.twin_exchange_repository.get_by_twin_id_data_exchange_agreement_id(
+            db_twin.id,
+            db_data_exchange_agreement.id
+        )
+        if not db_twin_exchange:
+            db_twin_exchange = repo.twin_exchange_repository.create_new(
+                twin_id=db_twin.id,
+                data_exchange_agreement_id=db_data_exchange_agreement.id
             )
-            if not db_data_exchange_agreements:
-                raise NotFoundError(f"No data exchange agreement found for business partner '{db_business_partner.bpnl}'.")
-            db_data_exchange_agreement = db_data_exchange_agreements[0] # Get the first one for now
-            
-            # Step 2: Check if there is already a twin exchange entity for the twin and data exchange agreement and create it if not
-            db_twin_exchange = repo.twin_exchange_repository.get_by_twin_id_data_exchange_agreement_id(
-                db_twin.id,
-                db_data_exchange_agreement.id
-            )
-            if not db_twin_exchange:
-                db_twin_exchange = repo.twin_exchange_repository.create_new(
-                    twin_id=db_twin.id,
-                    data_exchange_agreement_id=db_data_exchange_agreement.id
-                )
-                repo.commit()
-                return True
-            else:
-                return False
+            repo.commit()
+            return True
+        else:
+            return False
+        
+    @staticmethod
+    def _get_digital_twin_registry(repo: RepositoryManager, db_twin_registry_id: Optional[int] = None) -> TwinRegistry:
+        """
+        Helper method to retrieve the default digital twin registry from the database.
+        """
+        if db_twin_registry_id is None:
+            result = repo.twin_registry_repository.get_default()
+            if not result:
+                raise NotFoundError("Default digital twin registry not found.")
+            return result
+        
+        else:
+            result = repo.twin_registry_repository.find_by_id(db_twin_registry_id)
+            if not result:
+                raise NotFoundError(f"Twin registry with ID '{db_twin_registry_id}' not found.")
+            return result
+    
+    @staticmethod
+    def _get_connector_control_plane(repo: RepositoryManager, db_connector_control_plane_id: Optional[int] = None, join_legal_entity: bool = False) -> ConnectorControlPlane:
+        """
+        Helper method to retrieve the default connector control plane from the database.
+        """
+        if db_connector_control_plane_id is None:
+            result = repo.connector_control_plane_repository.get_default(join_legal_entity=join_legal_entity)
+            if not result:
+                raise NotFoundError("Default connector control plane not found.")
+            return result
+        
+        else:
+            result = repo.connector_control_plane_repository.get_by_id(db_connector_control_plane_id, join_legal_entity=join_legal_entity)
+            if not result:
+                raise NotFoundError(f"Connector control plane with ID '{db_connector_control_plane_id}' not found.")
+            return result
 
-
-def _create_submodel_service_manager(connection_settings: Optional[Dict[str, Any]]) -> SubmodelServiceManager:
+def _create_submodel_service_manager(connection_settings: Optional[Dict[str, Any]] = None) -> SubmodelServiceManager:
     """
     Create a new instance of the SubmodelServiceManager class.
     """
-    # TODO: later we can configure the manager via the connection settings from the DB here
+    # TODO: later we can configure the manager via the settings from the DB here
+    # TODO: !!!! design decision: do we allow only one submodel service ??? If no, we need to change to init logic to work with the DB params
     return SubmodelServiceManager()

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -2,7 +2,7 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025 LKS Next
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/tests/services/provider/test_sharing_service.py
+++ b/ichub-backend/tests/services/provider/test_sharing_service.py
@@ -73,7 +73,9 @@ class TestSharingService:
             manufacturerId="BPNL123456789012",
             manufacturerPartId="PART001",
             businessPartnerNumber="BPNL987654321098",
-            customerPartId="CUST001"
+            customerPartId="CUST001",
+            twinRegistryName="TestRegistry",
+            connectorControlPlaneName="TestControlPlane"
         )
 
     @pytest.fixture
@@ -176,7 +178,6 @@ class TestSharingService:
         mock_create_part_type_info.return_value = {"test": "document"}
         
         # Mock twin management service methods
-        self.service.twin_management_service.get_or_create_enablement_stack = Mock()
         self.service.twin_management_service.create_twin_aspect = Mock()
         self.service.twin_management_service.get_catalog_part_twin_details_id = Mock()
         
@@ -397,7 +398,7 @@ class TestSharingService:
         mock_repo.twin_repository.find_by_global_id.return_value = sample_twin_db
         
         # Act
-        result = self.service._create_and_get_twin(mock_repo, sample_share_catalog_part)
+        result = self.service._create_and_get_twin(mock_repo, sample_share_catalog_part, 1)
         
         # Assert
         assert result == sample_twin_db
@@ -495,7 +496,6 @@ class TestSharingService:
             mock_create_part_type_info.return_value = {"test": "document"}
             
             # Mock twin management service
-            self.service.twin_management_service.get_or_create_enablement_stack = Mock()
             self.service.twin_management_service.create_twin_aspect = Mock()
             self.service.twin_management_service.get_catalog_part_twin_details_id = Mock()
             
@@ -518,7 +518,9 @@ class TestSharingService:
                 manufacturerId="BPNL123456789012",
                 manufacturerPartId="PART001",
                 businessPartnerNumber="BPNL987654321098",
-                customerPartId="CUST001"
+                customerPartId="CUST001",
+                twinRegistryName="TestRegistry",
+                connectorControlPlaneName="TestControlPlane"
             )
             
             # Act
@@ -563,7 +565,6 @@ class TestSharingService:
             # Mock part type info document
             mock_create_part_type_info.return_value = {"test": "document"}
 
-            self.service.twin_management_service.get_or_create_enablement_stack = Mock()
             self.service.twin_management_service.create_twin_aspect = Mock()
             self.service.twin_management_service.get_catalog_part_twin_details_id = Mock()
             
@@ -584,7 +585,9 @@ class TestSharingService:
                 manufacturerId="BPNL123456789012",
                 manufacturerPartId="PART001",
                 businessPartnerNumber="BPNL987654321098",
-                customerPartId="CUST001"
+                customerPartId="CUST001",
+                twinRegistryName="TestRegistry",
+                connectorControlPlaneName="TestControlPlane"
             )
             
             # Act

--- a/ichub-backend/tests/services/provider/test_sharing_service.py
+++ b/ichub-backend/tests/services/provider/test_sharing_service.py
@@ -2,6 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/tests/services/provider/test_system_management_service.py
+++ b/ichub-backend/tests/services/provider/test_system_management_service.py
@@ -1,0 +1,108 @@
+###############################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import sys
+
+# Mock problematic imports
+mock_modules = [
+    'tractusx_sdk',
+    'tractusx_sdk.dataspace',
+    'tractusx_sdk.dataspace.managers',
+    'tractusx_sdk.dataspace.managers.connection',
+    'tractusx_sdk.dataspace.services',
+    'tractusx_sdk.dataspace.services.discovery',
+    'tractusx_sdk.dataspace.services.connector',
+    'tractusx_sdk.dataspace.services.connector.base_edc_service',
+    'tractusx_sdk.dataspace.core',
+    'tractusx_sdk.dataspace.core.dsc_manager',
+    'tractusx_sdk.dataspace.core.exception',
+    'tractusx_sdk.dataspace.core.exception.connector_error',
+    'tractusx_sdk.dataspace.tools',
+    'tractusx_sdk.dataspace.tools.op',
+    'managers.enablement_services.submodel_service_manager',
+    'managers.enablement_services.dtr_manager',
+    'managers.enablement_services.connector_manager',
+    'managers.enablement_services',
+    'managers.enablement_services.provider',
+    'managers.enablement_services.consumer',
+    'managers.submodels.submodel_document_generator',
+    'managers.config.config_manager',
+    'managers.config.log_manager',
+    'managers.metadata_database.manager',
+    'tools.exceptions',
+    'database',
+    'connector',
+]
+
+for module in mock_modules:
+    sys.modules[module] = MagicMock()
+
+from services.provider.system_management_service import SystemManagementService
+
+class TestSystemManagementService:
+    """Test cases for SystemManagementService."""
+
+    def setup_method(self):
+        """Setup method called before each test."""
+        self.service = SystemManagementService()
+
+    @patch('services.provider.system_management_service.ConfigManager')
+    @patch('services.provider.system_management_service.connector_manager')
+    def test_ensure_dtr_asset_registration_success(self, mock_connector, mock_config):
+        """Test successful DTR asset registration."""
+        # Arrange
+        mock_config.get_config.return_value = {
+            "hostname": "http://test-dtr",
+            "uri": "/api",
+            "apiPath": "/v3",
+            "policy": {},
+            "asset_config": {"dct_type": "test", "existing_asset_id": None}
+        }
+        mock_connector.provider.register_dtr_offer.return_value = ("dtr_asset_id", None, None, None)
+
+        # Act
+        self.service.ensure_dtr_asset_registration()
+
+        # Assert
+        mock_connector.provider.register_dtr_offer.assert_called_once()
+
+    @patch('services.provider.system_management_service.ConfigManager')
+    @patch('services.provider.system_management_service.connector_manager')
+    def test_ensure_dtr_asset_registration_failure(self, mock_connector, mock_config):
+        """Test DTR asset registration failure."""
+        # Arrange
+        mock_config.get_config.return_value = {
+            "hostname": "http://test-dtr",
+            "uri": "/api",
+            "apiPath": "/v3",
+            "policy": {},
+            "asset_config": {"dct_type": "test", "existing_asset_id": None}
+        }
+        mock_connector.provider.register_dtr_offer.return_value = (None, None, None, None)  # Failure
+
+        # Act & Assert
+        with pytest.raises(Exception):  # Should raise NotAvailableError
+            self.service.ensure_dtr_asset_registration()

--- a/ichub-backend/tests/services/provider/test_system_management_service.py
+++ b/ichub-backend/tests/services/provider/test_system_management_service.py
@@ -1,8 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 LKS NEXT
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -220,6 +220,26 @@ class TestTwinManagementService:
 
         return control_plane
 
+    @pytest.fixture
+    def patched_aspect_registration_managers(self):
+        """Patch manager wrappers with reusable connector and DTR mocks for aspect registration tests."""
+        mock_connector_provider = Mock()
+        mock_connector_provider.connector_dataplane_hostname = "https://edc.example"
+        mock_connector_provider.connector_dataplane_public_path = "/api/public"
+        mock_connector_provider.connector_controlplane_hostname = "https://edc.example"
+        mock_connector_provider.connector_controlplane_catalog_path = "/api/catalog"
+        mock_connector_provider.register_submodel_bundle_circular_offer.return_value = (
+            "asset_id", "policy_id", "access_id", "contract_id"
+        )
+
+        mock_dtr_manager = Mock()
+        mock_dtr_manager.create_submodel_descriptor.return_value = Mock()
+
+        with patch('services.provider.twin_management_service.SystemManagementService.ensure_dtr_asset_registration', return_value=None), \
+             patch('services.provider.twin_management_service.SystemManagementService.get_connector_manager', return_value=mock_connector_provider), \
+             patch('services.provider.twin_management_service.SystemManagementService.get_dtr_manager', return_value=mock_dtr_manager):
+            yield mock_connector_provider, mock_dtr_manager
+
     def test_service_initialization(self):
         """Test that the service initializes correctly."""
         service = TwinManagementService()
@@ -630,14 +650,15 @@ class TestTwinManagementService:
         # Assert
         assert result is not None
 
-    @patch('services.provider.system_management_service.ConfigManager')
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
-    @patch('services.provider.system_management_service.connector_manager')
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_create_twin_aspect_new_aspect(self, mock_repo_factory, mock_connector,
-                                         mock_submodel_manager, mock_config, mock_twin, mock_digital_twin_registry,
-                                         mock_connector_control_plane, sample_global_id, sample_semantic_id, sample_payload):
+    def test_create_twin_aspect_new_aspect(self, mock_repo_factory, mock_submodel_manager,
+                                         mock_twin, mock_digital_twin_registry,
+                                         mock_connector_control_plane, sample_global_id, sample_semantic_id, sample_payload,
+                                         patched_aspect_registration_managers):
         """Test creating a new twin aspect."""
+        _ = patched_aspect_registration_managers
+
         # Arrange
         twin_aspect_create = TwinAspectCreate(
             globalId=sample_global_id,
@@ -677,19 +698,6 @@ class TestTwinManagementService:
         mock_registration.twin_registry = mock_digital_twin_registry
         mock_repo.twin_aspect_registration_repository.create_new.return_value = mock_registration
         
-        # Mock configuration
-        mock_config.get_config.return_value = {
-            "hostname": "http://test-dtr",
-            "uri": "/api",
-            "apiPath": "/v3",
-            "policy": {},
-            "asset_config": {"dct_type": "test", "existing_asset_id": None}
-        }
-        
-        # Mock connector and DTR responses
-        mock_connector.provider.register_dtr_offer.return_value = ("dtr_asset_id", None, None, None)
-        mock_connector.provider.register_submodel_bundle_circular_offer.return_value = ("asset_id", "policy_id", "access_id", "contract_id")
-        
         # Mock submodel service manager
         mock_submodel_service = Mock()
         mock_submodel_manager.return_value = mock_submodel_service
@@ -706,14 +714,15 @@ class TestTwinManagementService:
             mock_repo.twin_aspect_repository.create_new.assert_called_once()
             mock_submodel_service.upload_twin_aspect_document.assert_called_once()
 
-    @patch('services.provider.system_management_service.ConfigManager')
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
-    @patch('services.provider.system_management_service.connector_manager')
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_create_or_update_twin_aspect_not_default_new(self, mock_repo_factory, mock_connector,mock_submodel_manager, mock_config, 
+    def test_create_or_update_twin_aspect_not_default_new(self, mock_repo_factory, mock_submodel_manager,
                                                         mock_twin, mock_digital_twin_registry, mock_connector_control_plane,
-                                                        sample_global_id, sample_semantic_id, sample_payload):
+                                                        sample_global_id, sample_semantic_id, sample_payload,
+                                                        patched_aspect_registration_managers):
         """Test creating a new twin aspect using the non-default method."""
+        _ = patched_aspect_registration_managers
+
         # Arrange
         twin_aspect_create = TwinAspectCreate(
             globalId=sample_global_id,
@@ -748,19 +757,6 @@ class TestTwinManagementService:
         # Mock the find_registration_by_twin_registry_id to return None (new registration)
         mock_new_aspect2.find_registration_by_twin_registry_id.return_value = None
         
-        # Mock configuration
-        mock_config.get_config.return_value = {
-            "hostname": "http://test-dtr",
-            "uri": "/api",
-            "apiPath": "/v3",
-            "policy": {},
-            "asset_config": {"dct_type": "test", "existing_asset_id": None}
-        }
-        
-        # Mock connector and DTR responses
-        mock_connector.provider.register_dtr_offer.return_value = ("dtr_asset_id", None, None, None)
-        mock_connector.provider.register_submodel_bundle_circular_offer.return_value = ("asset_id", "policy_id", "access_id", "contract_id")
-        
         # Mock submodel service manager
         mock_submodel_service = Mock()
         mock_submodel_manager.return_value = mock_submodel_service
@@ -780,8 +776,11 @@ class TestTwinManagementService:
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
     def test_create_or_update_twin_aspect_not_default_update_existing(self, mock_submodel_manager, mock_repo_factory, mock_twin, 
                                                                     mock_digital_twin_registry, mock_connector_control_plane,
-                                                                    sample_global_id, sample_semantic_id, sample_payload):
+                                                                    sample_global_id, sample_semantic_id, sample_payload,
+                                                                    patched_aspect_registration_managers):
         """Test updating an existing twin aspect using the non-default method."""
+        _ = patched_aspect_registration_managers
+
         # Arrange
         submodel_id = UUID("12345678-1234-1234-1234-123456789012")
         twin_aspect_create = TwinAspectCreate(

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -185,17 +185,6 @@ class TestTwinManagementService:
         return catalog_part
 
     @pytest.fixture
-    def mock_enablement_service_stack(self):
-        """Mock enablement service stack entity."""
-        stack = Mock()
-        stack.id = 1
-        stack.name = "EDC/DTR Default"
-        stack.connection_settings = {}
-        stack.legal_entity = Mock()
-        stack.legal_entity.bpnl = "BPNL123456789012"
-        return stack
-
-    @pytest.fixture
     def mock_digital_twin_registry(self):
         """Mock digital twin registry entity."""
         registry = Mock()

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -2,6 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2025 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -193,49 +195,40 @@ class TestTwinManagementService:
         stack.legal_entity.bpnl = "BPNL123456789012"
         return stack
 
+    @pytest.fixture
+    def mock_digital_twin_registry(self):
+        """Mock digital twin registry entity."""
+        registry = Mock()
+        registry.id = 1
+        registry.name = "TestRegistry"
+        registry.version = "0.4"
+        registry.connection_settings = {}
+        return registry
+    
+    @pytest.fixture
+    def mock_connector_control_plane(self):
+        """Mock connector control plane entity."""
+
+        legal_entity = Mock()
+        legal_entity.id = 1
+        legal_entity.bpnl = "BPNL123456789012"
+
+        control_plane = Mock()
+        control_plane.id = 1
+        control_plane.name = "TestConnector"
+        control_plane.legal_entity = legal_entity
+
+        return control_plane
+
     def test_service_initialization(self):
         """Test that the service initializes correctly."""
         service = TwinManagementService()
         assert service.submodel_document_generator is not None
 
+    @patch('services.provider.system_management_service.dtr_provider_manager')
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_get_or_create_enablement_stack_existing(self, mock_repo_factory, mock_enablement_service_stack):
-        """Test retrieving existing enablement service stack."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo_factory.return_value.__enter__.return_value = mock_repo
-        mock_repo.enablement_service_stack_repository.find_by_legal_entity_bpnl.return_value = [mock_enablement_service_stack]
-
-        # Act
-        result = self.service.get_or_create_enablement_stack(mock_repo, "BPNL123456789012")
-
-        # Assert
-        assert result == mock_enablement_service_stack
-        mock_repo.enablement_service_stack_repository.find_by_legal_entity_bpnl.assert_called_once_with(legal_entity_bpnl="BPNL123456789012")
-
-    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_get_or_create_enablement_stack_new(self, mock_repo_factory, mock_enablement_service_stack):
-        """Test creating new enablement service stack."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo_factory.return_value.__enter__.return_value = mock_repo
-        mock_repo.enablement_service_stack_repository.find_by_legal_entity_bpnl.return_value = []
-        mock_repo.legal_entity_repository.get_by_bpnl.return_value = Mock(id=1)
-        mock_repo.enablement_service_stack_repository.create.return_value = mock_enablement_service_stack
-
-        # Act
-        result = self.service.get_or_create_enablement_stack(mock_repo, "BPNL123456789012")
-
-        # Assert
-        assert result == mock_enablement_service_stack
-        mock_repo.enablement_service_stack_repository.create.assert_called_once()
-        mock_repo.commit.assert_called()
-        mock_repo.refresh.assert_called_once()
-
-    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    @patch('services.provider.twin_management_service.dtr_provider_manager')
-    def test_create_catalog_part_twin_success(self, mock_dtr_provider, mock_repo_factory, 
-                                            mock_catalog_part, mock_twin, mock_enablement_service_stack,
+    def test_create_catalog_part_twin_success(self, mock_repo_factory, mock_dtr_provider,
+                                            mock_catalog_part, mock_twin, mock_digital_twin_registry,
                                             sample_global_id, sample_aas_id, sample_manufacturer_id, 
                                             sample_manufacturer_part_id):
         """Test successful catalog part twin creation."""
@@ -251,18 +244,18 @@ class TestTwinManagementService:
         mock_repo_factory.return_value.__enter__.return_value = mock_repo
         mock_repo.catalog_part_repository.find_by_manufacturer_id_manufacturer_part_id.return_value = [(mock_catalog_part, None)]
         mock_repo.twin_repository.create_new.return_value = mock_twin
-        mock_repo.twin_registration_repository.get_by_twin_id_enablement_service_stack_id.return_value = None
+        mock_repo.twin_registration_repository.get_by_twin_id_twin_registry_id.return_value = None
         mock_repo.twin_registration_repository.create_new.return_value = Mock(dtr_registered=False)
-
+        mock_repo.twin_registry_repository.get_default.return_value = mock_digital_twin_registry
+        
         # Act
-        with patch.object(self.service, 'get_or_create_enablement_stack', return_value=mock_enablement_service_stack):
-            result = self.service.create_catalog_part_twin(create_input)
+        result = self.service.create_catalog_part_twin(create_input)
 
-            # Assert
-            assert isinstance(result, TwinRead)
-            assert result.global_id == sample_global_id
-            mock_repo.catalog_part_repository.find_by_manufacturer_id_manufacturer_part_id.assert_called_once()
-            mock_dtr_provider.create_or_update_shell_descriptor.assert_called_once()
+        # Assert
+        assert isinstance(result, TwinRead)
+        assert result.global_id == sample_global_id
+        mock_repo.catalog_part_repository.find_by_manufacturer_id_manufacturer_part_id.assert_called_once()
+        mock_dtr_provider.create_or_update_shell_descriptor.assert_called_once()
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
     def test_create_catalog_part_twin_not_found(self, mock_repo_factory, sample_manufacturer_id, sample_manufacturer_part_id):
@@ -331,8 +324,9 @@ class TestTwinManagementService:
             # Step 6: DTR shell must be refreshed after the exchange is created
             mock_create_twin.assert_called_once()
 
+    @patch('services.provider.system_management_service.dtr_provider_manager')
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_create_serialized_part_twin_success(self, mock_repo_factory, mock_twin, mock_enablement_service_stack,
+    def test_create_serialized_part_twin_success(self, mock_repo_factory, mock_dtr_provider, mock_twin,
                                                 sample_manufacturer_id, sample_manufacturer_part_id, 
                                                 sample_part_instance_id, sample_global_id, sample_aas_id):
         """Test successful serialized part twin creation."""
@@ -342,7 +336,7 @@ class TestTwinManagementService:
             manufacturerPartId=sample_manufacturer_part_id,
             partInstanceId=sample_part_instance_id,
             globalId=sample_global_id,
-            dtrAasId=sample_aas_id
+            dtrAasId=sample_aas_id,
         )
 
         mock_serialized_part = Mock()
@@ -354,6 +348,7 @@ class TestTwinManagementService:
         mock_catalog_part.category = "product"
         mock_catalog_part.name = "Test Part"
         mock_catalog_part.description = "Test Description"
+        mock_catalog_part.bpns = "BPNS123456789012"
         
         # Create mock business partner
         mock_business_partner = Mock()
@@ -367,22 +362,26 @@ class TestTwinManagementService:
         
         mock_serialized_part.partner_catalog_part = mock_partner_catalog_part
 
+        # Create mock twin registry
+        mock_digital_twin_registry = Mock()
+        mock_digital_twin_registry.id = 1
+        mock_digital_twin_registry.name = "TestRegistry"
+
         mock_repo = Mock()
         mock_repo_factory.return_value.__enter__.return_value = mock_repo
         mock_repo.serialized_part_repository.find.return_value = [mock_serialized_part]
-        mock_repo.enablement_service_stack_repository.find_by_legal_entity_bpnl.return_value = [mock_enablement_service_stack]
         mock_repo.twin_repository.create_new.return_value = mock_twin
-        mock_repo.twin_registration_repository.get_by_twin_id_enablement_service_stack_id.return_value = None
+        mock_repo.twin_registration_repository.get_by_twin_id_twin_registry_id.return_value = None
         mock_repo.twin_registration_repository.create_new.return_value = Mock(dtr_registered=False)
+        mock_repo.twin_registry_repository.get_default.return_value = mock_digital_twin_registry
 
         # Act
-        with patch('services.provider.twin_management_service.dtr_provider_manager') as mock_dtr_provider:
-            result = self.service.create_serialized_part_twin(create_input)
+        result = self.service.create_serialized_part_twin(create_input)
 
-            # Assert
-            assert isinstance(result, TwinRead)
-            assert result.global_id == sample_global_id
-            mock_dtr_provider.create_or_update_shell_descriptor.assert_called_once()
+        # Assert
+        assert isinstance(result, TwinRead)
+        assert result.global_id == sample_global_id
+        mock_dtr_provider.create_or_update_shell_descriptor.assert_called_once()
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
     def test_get_serialized_part_twins_success(self, mock_repo_factory, mock_twin):
@@ -539,13 +538,13 @@ class TestTwinManagementService:
         assert len(twin_result.shares) == 1
         assert twin_result.shares[0].name == "Test Agreement"
 
-    def test_fill_registrations(self, mock_twin):
+    def test_fill_registrations(self, mock_twin, mock_digital_twin_registry):
         """Test filling registrations in twin result."""
         # Arrange
         mock_registration = Mock()
-        mock_registration.enablement_service_stack = Mock()
-        mock_registration.enablement_service_stack.name = "EDC/DTR Default"
+        mock_registration.twin_registry = mock_digital_twin_registry
         mock_registration.dtr_registered = True
+
         mock_twin.twin_registrations = [mock_registration]
 
         twin_result = Mock()
@@ -555,14 +554,14 @@ class TestTwinManagementService:
         TwinManagementService._fill_registrations(mock_twin, twin_result)
 
         # Assert
-        assert twin_result.registrations["EDC/DTR Default"] is True
+        assert twin_result.registrations["TestRegistry"] is True
 
-    def test_fill_aspects(self, mock_twin):
+    def test_fill_aspects(self, mock_twin, mock_digital_twin_registry, mock_connector_control_plane):
         """Test filling aspects in twin result."""
         # Arrange
         mock_aspect_registration = Mock()
-        mock_aspect_registration.enablement_service_stack = Mock()
-        mock_aspect_registration.enablement_service_stack.name = "EDC/DTR Default"
+        mock_aspect_registration.twin_registry = mock_digital_twin_registry
+        mock_aspect_registration.connector_control_plane = mock_connector_control_plane
         mock_aspect_registration.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
         mock_aspect_registration.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_aspect_registration.created_date = datetime.now()
@@ -613,13 +612,13 @@ class TestTwinManagementService:
     def test_dtr_integration_available(self):
         """Test that DTR provider manager is available for integration."""
         # This test ensures that the DTR integration is properly imported and available
-        from services.provider.twin_management_service import dtr_provider_manager
+        from services.provider.system_management_service import dtr_provider_manager
         assert dtr_provider_manager is not None
 
     def test_connector_integration_available(self):
         """Test that connector manager is available for integration."""
         # This test ensures that the connector integration is properly imported and available
-        from services.provider.twin_management_service import connector_manager
+        from services.provider.system_management_service import connector_manager
         assert connector_manager is not None
 
     def test_create_submodel_service_manager(self):
@@ -631,14 +630,13 @@ class TestTwinManagementService:
         # Assert
         assert result is not None
 
-    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    @patch('services.provider.twin_management_service.connector_manager')
-    @patch('services.provider.twin_management_service.dtr_provider_manager')
+    @patch('services.provider.system_management_service.ConfigManager')
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
-    @patch('services.provider.twin_management_service.ConfigManager')
-    def test_create_twin_aspect_new_aspect(self, mock_config, mock_submodel_manager, mock_dtr_provider, 
-                                         mock_connector, mock_repo_factory, mock_twin, mock_enablement_service_stack,
-                                         sample_global_id, sample_semantic_id, sample_payload):
+    @patch('services.provider.system_management_service.connector_manager')
+    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
+    def test_create_twin_aspect_new_aspect(self, mock_repo_factory, mock_connector,
+                                         mock_submodel_manager, mock_config, mock_twin, mock_digital_twin_registry,
+                                         mock_connector_control_plane, sample_global_id, sample_semantic_id, sample_payload):
         """Test creating a new twin aspect."""
         # Arrange
         twin_aspect_create = TwinAspectCreate(
@@ -649,14 +647,26 @@ class TestTwinManagementService:
         
         mock_repo = Mock()
         mock_repo_factory.return_value.__enter__.return_value = mock_repo
+        
+        # Setup twin with registration
+        mock_twin_registration = Mock()
+        mock_twin_registration.twin_registry_id = mock_digital_twin_registry.id
+        mock_twin.twin_registrations = [mock_twin_registration]
+        
         mock_repo.twin_repository.find_by_global_id.return_value = mock_twin
         mock_repo.twin_aspect_repository.get_by_twin_id_semantic_id.return_value = None
         
+        # Setup twin registry mock
+        mock_repo.twin_registry_repository.find_by_id.return_value = mock_digital_twin_registry
+        
+        # Setup connector control plane mock
+        mock_repo.connector_control_plane_repository.get_by_id.return_value = mock_connector_control_plane
+
         mock_new_aspect = Mock()
         mock_new_aspect.id = 1
         mock_new_aspect.semantic_id = sample_semantic_id
         mock_new_aspect.submodel_id = UUID("12345678-1234-1234-1234-123456789012")
-        mock_new_aspect.find_registration_by_stack_id.return_value = None
+        mock_new_aspect.find_registration_by_twin_registry_id.return_value = None
         mock_repo.twin_aspect_repository.create_new.return_value = mock_new_aspect
         
         mock_registration = Mock()
@@ -664,10 +674,8 @@ class TestTwinManagementService:
         mock_registration.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_registration.created_date = datetime.now()
         mock_registration.modified_date = datetime.now()
+        mock_registration.twin_registry = mock_digital_twin_registry
         mock_repo.twin_aspect_registration_repository.create_new.return_value = mock_registration
-        
-        # Mock the find_registration_by_stack_id to return the registration after creation
-        mock_new_aspect.find_registration_by_stack_id.return_value = mock_registration
         
         # Mock configuration
         mock_config.get_config.return_value = {
@@ -686,24 +694,24 @@ class TestTwinManagementService:
         mock_submodel_service = Mock()
         mock_submodel_manager.return_value = mock_submodel_service
         
-        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value="BPNL123456789012"):
-            with patch.object(self.service, 'get_or_create_enablement_stack', return_value=mock_enablement_service_stack):
-                # Act
-                result = self.service.create_twin_aspect(twin_aspect_create)
-                
-                # Assert
-                assert isinstance(result, TwinAspectRead)
-                assert result.semantic_id == sample_semantic_id
-                mock_repo.twin_aspect_repository.create_new.assert_called_once()
-                mock_submodel_service.upload_twin_aspect_document.assert_called_once()
+        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value=mock_connector_control_plane.legal_entity.bpnl):
+            # Act
+            result = self.service.create_twin_aspect(twin_aspect_create,
+                                                     mock_digital_twin_registry.id,
+                                                     mock_connector_control_plane.id)
+            
+            # Assert
+            assert isinstance(result, TwinAspectRead)
+            assert result.semantic_id == sample_semantic_id
+            mock_repo.twin_aspect_repository.create_new.assert_called_once()
+            mock_submodel_service.upload_twin_aspect_document.assert_called_once()
 
-    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    @patch('services.provider.twin_management_service.connector_manager')
-    @patch('services.provider.twin_management_service.dtr_provider_manager')
+    @patch('services.provider.system_management_service.ConfigManager')
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
-    @patch('services.provider.twin_management_service.ConfigManager')
-    def test_create_or_update_twin_aspect_not_default_new(self, mock_config, mock_submodel_manager, mock_dtr_provider, 
-                                                        mock_connector, mock_repo_factory, mock_twin, mock_enablement_service_stack,
+    @patch('services.provider.system_management_service.connector_manager')
+    @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
+    def test_create_or_update_twin_aspect_not_default_new(self, mock_repo_factory, mock_connector,mock_submodel_manager, mock_config, 
+                                                        mock_twin, mock_digital_twin_registry, mock_connector_control_plane,
                                                         sample_global_id, sample_semantic_id, sample_payload):
         """Test creating a new twin aspect using the non-default method."""
         # Arrange
@@ -720,7 +728,6 @@ class TestTwinManagementService:
         mock_new_aspect2.id = 1
         mock_new_aspect2.semantic_id = sample_semantic_id
         mock_new_aspect2.submodel_id = UUID("12345678-1234-1234-1234-123456789012")
-        mock_new_aspect2.find_registration_by_stack_id.return_value = None
         mock_repo.twin_aspect_repository.create_new.return_value = mock_new_aspect2
         
         mock_registration = Mock()
@@ -728,10 +735,18 @@ class TestTwinManagementService:
         mock_registration.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_registration.created_date = datetime.now()
         mock_registration.modified_date = datetime.now()
+        mock_registration.twin_registry = mock_digital_twin_registry
+        mock_registration.connector_control_plane_id = mock_connector_control_plane.id
         mock_repo.twin_aspect_registration_repository.create_new.return_value = mock_registration
+
+        # Setup twin registry mock
+        mock_repo.twin_registry_repository.find_by_id.return_value = mock_digital_twin_registry
         
-        # Mock the find_registration_by_stack_id to return the registration after creation
-        mock_new_aspect2.find_registration_by_stack_id.return_value = mock_registration
+        # Setup connector control plane mock
+        mock_repo.connector_control_plane_repository.get_by_id.return_value = mock_connector_control_plane
+
+        # Mock the find_registration_by_twin_registry_id to return None (new registration)
+        mock_new_aspect2.find_registration_by_twin_registry_id.return_value = None
         
         # Mock configuration
         mock_config.get_config.return_value = {
@@ -750,20 +765,21 @@ class TestTwinManagementService:
         mock_submodel_service = Mock()
         mock_submodel_manager.return_value = mock_submodel_service
         
-        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value="BPNL123456789012"):
-            with patch.object(self.service, 'get_or_create_enablement_stack', return_value=mock_enablement_service_stack):
-                # Act
-                result = self.service.create_or_update_twin_aspect_not_default(twin_aspect_create)
-                
-                # Assert
-                assert isinstance(result, TwinAspectRead)
-                assert result.semantic_id == sample_semantic_id
-                mock_repo.twin_aspect_repository.create_new.assert_called_once()
+        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value=mock_connector_control_plane.legal_entity.bpnl):
+            # Act
+            result = self.service.create_or_update_twin_aspect_not_default(twin_aspect_create,
+                                                                           mock_digital_twin_registry.id,
+                                                                           mock_connector_control_plane.id)
+            
+            # Assert
+            assert isinstance(result, TwinAspectRead)
+            assert result.semantic_id == sample_semantic_id
+            mock_repo.twin_aspect_repository.create_new.assert_called_once()
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
     @patch('services.provider.twin_management_service._create_submodel_service_manager')
-    def test_create_or_update_twin_aspect_not_default_update_existing(self, mock_submodel_manager, mock_repo_factory, 
-                                                                    mock_twin, mock_enablement_service_stack,
+    def test_create_or_update_twin_aspect_not_default_update_existing(self, mock_submodel_manager, mock_repo_factory, mock_twin, 
+                                                                    mock_digital_twin_registry, mock_connector_control_plane,
                                                                     sample_global_id, sample_semantic_id, sample_payload):
         """Test updating an existing twin aspect using the non-default method."""
         # Arrange
@@ -785,30 +801,38 @@ class TestTwinManagementService:
         mock_registration.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_registration.created_date = datetime.now()
         mock_registration.modified_date = datetime.now()
-        mock_existing_aspect.registrations = [mock_registration]
+        mock_registration.twin_registry = mock_digital_twin_registry
+        mock_existing_aspect.twin_aspect_registrations = [mock_registration]
         
         mock_repo = Mock()
         mock_repo_factory.return_value.__enter__.return_value = mock_repo
         mock_repo.twin_repository.find_by_global_id.return_value = mock_twin
         mock_repo.twin_aspect_repository.get_by_twin_id_semantic_id_submodel_id.return_value = mock_existing_aspect
         
+        # Setup twin registry mock
+        mock_repo.twin_registry_repository.find_by_id.return_value = mock_digital_twin_registry
+        
+        # Setup connector control plane mock
+        mock_repo.connector_control_plane_repository.get_by_id.return_value = mock_connector_control_plane
+
         # Mock submodel service manager
         mock_submodel_service = Mock()
         mock_submodel_manager.return_value = mock_submodel_service
         
-        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value="BPNL123456789012"):
-            with patch.object(self.service, 'get_or_create_enablement_stack', return_value=mock_enablement_service_stack):
-                # Act
-                result = self.service.create_or_update_twin_aspect_not_default(twin_aspect_create)
-                
-                # Assert
-                assert isinstance(result, TwinAspectRead)
-                assert result.semantic_id == sample_semantic_id
-                mock_submodel_service.upload_twin_aspect_document.assert_called_once()
+        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value=mock_connector_control_plane.legal_entity.bpnl):
+            # Act
+            result = self.service.create_or_update_twin_aspect_not_default(twin_aspect_create,
+                                                                           mock_digital_twin_registry.id,
+                                                                           mock_connector_control_plane.id)
+            
+            # Assert
+            assert isinstance(result, TwinAspectRead)
+            assert result.semantic_id == sample_semantic_id
+            mock_submodel_service.upload_twin_aspect_document.assert_called_once()
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
     def test_create_or_update_twin_aspect_not_default_update_wrong_status(self, mock_repo_factory, mock_twin, 
-                                                                        mock_enablement_service_stack,
+                                                                        mock_digital_twin_registry, mock_connector_control_plane,
                                                                         sample_global_id, sample_semantic_id, sample_payload):
         """Test updating an existing twin aspect with wrong status raises error."""
         # Arrange
@@ -834,26 +858,25 @@ class TestTwinManagementService:
         mock_repo.twin_repository.find_by_global_id.return_value = mock_twin
         mock_repo.twin_aspect_repository.get_by_twin_id_semantic_id_submodel_id.return_value = mock_existing_aspect
         
-        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value="BPNL123456789012"):
-            with patch.object(self.service, 'get_or_create_enablement_stack', return_value=mock_enablement_service_stack):
-                # Act & Assert
-                with pytest.raises(Exception):  # Should raise NotAvailableError
-                    self.service.create_or_update_twin_aspect_not_default(twin_aspect_create)
-
-    def test_fill_aspects_multiple_submodels_same_type(self, mock_twin):
+        with patch.object(self.service, '_get_manufacturer_id_from_twin', return_value=mock_connector_control_plane.legal_entity.bpnl):
+            # Act & Assert
+            with pytest.raises(Exception):  # Should raise NotAvailableError
+                self.service.create_or_update_twin_aspect_not_default(twin_aspect_create)
+    
+    def test_fill_aspects_multiple_submodels_same_type(self, mock_twin, mock_digital_twin_registry, mock_connector_control_plane):
         """Test filling aspects with multiple submodels of the same semantic type."""
         # Arrange
         mock_aspect_registration1 = Mock()
-        mock_aspect_registration1.enablement_service_stack = Mock()
-        mock_aspect_registration1.enablement_service_stack.name = "EDC/DTR Default"
+        mock_aspect_registration1.twin_registry = mock_digital_twin_registry
+        mock_aspect_registration1.connector_control_plane = mock_connector_control_plane
         mock_aspect_registration1.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
         mock_aspect_registration1.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_aspect_registration1.created_date = datetime.now()
         mock_aspect_registration1.modified_date = datetime.now()
 
         mock_aspect_registration2 = Mock()
-        mock_aspect_registration2.enablement_service_stack = Mock()
-        mock_aspect_registration2.enablement_service_stack.name = "EDC/DTR Default"
+        mock_aspect_registration2.twin_registry = mock_digital_twin_registry
+        mock_aspect_registration2.connector_control_plane = mock_connector_control_plane
         mock_aspect_registration2.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
         mock_aspect_registration2.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_aspect_registration2.created_date = datetime.now()
@@ -892,20 +915,20 @@ class TestTwinManagementService:
 
 
 
-    def test_fill_aspects_different_semantic_types(self, mock_twin):
+    def test_fill_aspects_different_semantic_types(self, mock_twin, mock_digital_twin_registry, mock_connector_control_plane):
         """Test filling aspects with different semantic types."""
         # Arrange
         mock_aspect_registration1 = Mock()
-        mock_aspect_registration1.enablement_service_stack = Mock()
-        mock_aspect_registration1.enablement_service_stack.name = "EDC/DTR Default"
+        mock_aspect_registration1.twin_registry = mock_digital_twin_registry
+        mock_aspect_registration1.connector_control_plane = mock_connector_control_plane
         mock_aspect_registration1.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
         mock_aspect_registration1.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_aspect_registration1.created_date = datetime.now()
         mock_aspect_registration1.modified_date = datetime.now()
 
         mock_aspect_registration2 = Mock()
-        mock_aspect_registration2.enablement_service_stack = Mock()
-        mock_aspect_registration2.enablement_service_stack.name = "EDC/DTR Default"
+        mock_aspect_registration2.twin_registry = mock_digital_twin_registry
+        mock_aspect_registration2.connector_control_plane = mock_connector_control_plane
         mock_aspect_registration2.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value
         mock_aspect_registration2.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_aspect_registration2.created_date = datetime.now()
@@ -944,29 +967,30 @@ class TestTwinManagementService:
         assert mock_aspect2.semantic_id in twin_result.aspects
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_get_or_create_twin_aspect_registration_existing(self, mock_repo_factory, mock_enablement_service_stack):
+    def test_get_or_create_twin_aspect_registration_existing(self, mock_repo_factory, mock_digital_twin_registry, mock_connector_control_plane):
         """Test getting an existing twin aspect registration."""
         # Arrange
         mock_aspect = Mock()
         mock_existing_registration = Mock()
-        mock_aspect.find_registration_by_stack_id.return_value = mock_existing_registration
+        mock_existing_registration.connector_control_plane_id = mock_connector_control_plane.id
+        mock_aspect.find_registration_by_twin_registry_id.return_value = mock_existing_registration
 
         mock_repo = Mock()
         mock_repo_factory.return_value.__enter__.return_value = mock_repo
 
         # Act
-        result = self.service._get_or_create_twin_aspect_registration(mock_repo, mock_aspect, mock_enablement_service_stack)
+        result = self.service._get_or_create_twin_aspect_registration(mock_repo, mock_aspect, mock_digital_twin_registry, mock_connector_control_plane)
 
         # Assert
         assert result == mock_existing_registration
-        mock_aspect.find_registration_by_stack_id.assert_called_once_with(mock_enablement_service_stack.id)
+        mock_aspect.find_registration_by_twin_registry_id.assert_called_once_with(mock_digital_twin_registry.id)
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_get_or_create_twin_aspect_registration_new(self, mock_repo_factory, mock_enablement_service_stack):
+    def test_get_or_create_twin_aspect_registration_new(self, mock_repo_factory, mock_digital_twin_registry, mock_connector_control_plane):
         """Test creating a new twin aspect registration."""
         # Arrange
         mock_aspect = Mock()
-        mock_aspect.find_registration_by_stack_id.return_value = None
+        mock_aspect.find_registration_by_twin_registry_id.return_value = None
         mock_new_registration = Mock()
 
         mock_repo = Mock()
@@ -974,7 +998,7 @@ class TestTwinManagementService:
         mock_repo.twin_aspect_registration_repository.create_new.return_value = mock_new_registration
 
         # Act
-        result = self.service._get_or_create_twin_aspect_registration(mock_repo, mock_aspect, mock_enablement_service_stack)
+        result = self.service._get_or_create_twin_aspect_registration(mock_repo, mock_aspect, mock_digital_twin_registry, mock_connector_control_plane)
 
         # Assert
         assert result == mock_new_registration
@@ -982,45 +1006,7 @@ class TestTwinManagementService:
         mock_repo.commit.assert_called()
         mock_repo.refresh.assert_called()
 
-    @patch('services.provider.twin_management_service.ConfigManager')
-    @patch('services.provider.twin_management_service.connector_manager')
-    def test_ensure_dtr_asset_registration_success(self, mock_connector, mock_config):
-        """Test successful DTR asset registration."""
-        # Arrange
-        mock_config.get_config.return_value = {
-            "hostname": "http://test-dtr",
-            "uri": "/api",
-            "apiPath": "/v3",
-            "policy": {},
-            "asset_config": {"dct_type": "test", "existing_asset_id": None}
-        }
-        mock_connector.provider.register_dtr_offer.return_value = ("dtr_asset_id", None, None, None)
-
-        # Act
-        self.service._ensure_dtr_asset_registration()
-
-        # Assert
-        mock_connector.provider.register_dtr_offer.assert_called_once()
-
-    @patch('services.provider.twin_management_service.ConfigManager')
-    @patch('services.provider.twin_management_service.connector_manager')
-    def test_ensure_dtr_asset_registration_failure(self, mock_connector, mock_config):
-        """Test DTR asset registration failure."""
-        # Arrange
-        mock_config.get_config.return_value = {
-            "hostname": "http://test-dtr",
-            "uri": "/api",
-            "apiPath": "/v3",
-            "policy": {},
-            "asset_config": {"dct_type": "test", "existing_asset_id": None}
-        }
-        mock_connector.provider.register_dtr_offer.return_value = (None, None, None, None)  # Failure
-
-        # Act & Assert
-        with pytest.raises(Exception):  # Should raise NotAvailableError
-            self.service._ensure_dtr_asset_registration()
-
-    def test_create_twin_aspect_read_response(self, mock_enablement_service_stack):
+    def test_create_twin_aspect_read_response(self, mock_digital_twin_registry, mock_connector_control_plane):
         """Test creating twin aspect read response."""
         # Arrange
         mock_aspect = Mock()
@@ -1034,16 +1020,16 @@ class TestTwinManagementService:
         mock_registration.modified_date = datetime.now()
 
         # Act
-        result = self.service._create_twin_aspect_read_response(mock_aspect, mock_enablement_service_stack, mock_registration)
+        result = self.service._create_twin_aspect_read_response(mock_aspect, mock_digital_twin_registry, mock_connector_control_plane, mock_registration)
 
         # Assert
         assert isinstance(result, TwinAspectRead)
         assert result.semantic_id == mock_aspect.semantic_id
         assert result.submodel_id == mock_aspect.submodel_id
-        assert mock_enablement_service_stack.name in result.registrations
+        assert mock_digital_twin_registry.name in result.registrations
 
     @patch('services.provider.twin_management_service.RepositoryManagerFactory.create')
-    def test_create_twin_aspect_entity_db(self, mock_repo_factory, mock_twin, sample_global_id, sample_semantic_id):
+    def test_create_twin_aspect_entity_db(self, mock_repo_factory, mock_twin, mock_digital_twin_registry, mock_connector_control_plane, sample_global_id, sample_semantic_id):
         """Test creating twin aspect entity in database."""
         # Arrange
         twin_aspect_create = TwinAspectCreate(

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -2,7 +2,7 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2025 LKS NEXT
-# Copyright (c) 2025 DRÄXLMAIER Group
+# Copyright (c) 2025,2026 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #

--- a/ichub-backend/tools/constants.py
+++ b/ichub-backend/tools/constants.py
@@ -56,6 +56,7 @@ VAN_DESCRIPTION = "The optional VAN (Vehicle Assembly Number) of the serialized 
 
 # ==================== API VERSIONS =========================
 API_V1 = "v1"
+API_V2 = "v2"
 
 # ==================== USE CASE =========================
 CCM = "CCM"

--- a/ichub-backend/tools/constants.py
+++ b/ichub-backend/tools/constants.py
@@ -2,6 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 DRÄXLMAIER Group
+# (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
## WHAT

Introduce new service "System Management" that can handle multiple Connectors and DTRs in combination.

Extend/update existing APIs to strictly consider this new relationship.

Part 1 contents:

- Add Twin Registry and Connector Control plane as mangeable entities in the backend
- Prepare services and endpoints to allow specifying the chosen Registry and Connector
- In a first iteration support only the pre-configured ones as the default ones; allow real adding of new ones in the database in a later iteraion
- No frontend adjustment yet - existing endpoints should stay backward compatible

Part 1 NON contents:
- Treatment of data plane and submodel services
- Switch from config-file based configuration to real database-based configuration of connectivity (currently there is a fallback implememtation that goes to the config-file if a control plane / DTR with "default" setting is used)
- Frontend implmentation

## WHY

Basic requirement to IC-Hub. Drivers are CX-Next TAP7.4 but also stakeholders that have already today a more complex system landscape.

## Supports issue
- https://github.com/eclipse-tractusx/industry-core-hub/issues/424