### PR TITLE
fix: replace bitnami repository by bitnamilegacy

### DIFF
--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: industry-core-hub
 type: application
 appVersion: "0.1.0"
-version: 0.2.3
+version: 0.2.4
 description: A Helm chart for Eclipse Tractus-X - Industry Core Hub
 home: https://github.com/eclipse-tractusx/industry-core-hub
 sources:
@@ -31,7 +31,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.x.x
+    version: 15.2.1
   - condition: pgadmin4.enabled
     name: pgadmin4
     repository: https://helm.runix.net

--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 15.2.1
+    version: 12.12.x
   - condition: pgadmin4.enabled
     name: pgadmin4
     repository: https://helm.runix.net

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -409,6 +409,11 @@ postgresql:
   enabled: true
   fullnameOverride: ""
   nameOverride: ""
+  image:
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   auth:
     # -- Database name
     database: "ichub-postgres"

--- a/docs/admin/migration-guide.md
+++ b/docs/admin/migration-guide.md
@@ -1,0 +1,40 @@
+# Migration Guide
+
+This migration guide is based on the `chartVersion` of the chart. If you don't rely on the provided helm chart, consider the changes of the chart as mentioned below manually.
+
+> [!WARNING]
+> Bitnami does change their update and versioning policy starting with 2025-08-28. To install the existing charts with its bitnami dependencies, please consider to manually specify the properties `image.repository` and `image.tag` specifying for the following dependencies:
+> 
+> - postgresql (image: bitnamilegacy/postgresql:15.4.0-debian-11-r45)
+> 
+> You have the following options to specify the container image:
+> 
+> 1. Specify in `values.yaml` below `postgresql`.
+> 
+> ```yaml
+> postgresql: 
+>   image: 
+>     repository: bitnamilegacy/postgresql
+>     tag: 15.4.0-debian-11-r45
+> ```
+> 
+> 2. Set during installation.
+> 
+> ```bash
+> helm install puris -n tractusx-dev/puris \
+>   --set postgresql.image.repository=bitnamilegacy/postgresql
+>   --set postgresql.image.tag=15.4.0-debian-11-r45
+> ```
+> 
+> Notes:
+> 
+> - Deploying an older version of the software may have used an older postgresql version. This is NOT applicable for the PURIS charts.
+> - The community is working out on how to resolve the issue.
+
+# NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+* SPDX-License-Identifier: CC-BY-4.0
+* SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+* Source URL: <https://github.com/eclipse-tractusx/tractus-x-umbrella>


### PR DESCRIPTION
## WHAT

This PR updates the chart versions for several Helm charts and introduces a temporary workaround for PostgreSQL image configuration in the values.yaml files.

* Added explicit configuration for the PostgreSQL image repository and tag in `values.yaml` to use `bitnamilegacy/postgresql:15.4.0-debian-11-r45` as a workaround for compatibility until the team aligns on new PostgreSQL charts.

## WHY

To ensure compatibility and deployment stability after the deprecation of the Bitnami image repository.

Closes #305