### PR TITLE
Serialized parts display and management

### DIFF
--- a/ichub-frontend/index.html
+++ b/ichub-frontend/index.html
@@ -38,7 +38,7 @@
       // Do NOT change ENV attributes without changing them in scripts/inject-dynamic-env.sh as well
       const ENV = {
         REQUIRE_HTTPS_URL_PATTERN: "true",
-        ICHUB_BACKEND_URL: "https://backend-ichub.int.catena-x.net",
+        ICHUB_BACKEND_URL: "https://backend-ichub.int.catena-x.net/v1",
         PARTICIPANT_ID: "BPNL0000000093Q7"
       }
     </script>

--- a/ichub-frontend/package-lock.json
+++ b/ichub-frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^6.4.5",
         "@mui/material": "^6.4.5",
         "@mui/x-charts": "^8.3.1",
+        "@mui/x-data-grid": "^8.11.0",
         "axios": "^1.9.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -113,9 +114,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1896,6 +1897,119 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/@mui/x-data-grid": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-8.11.0.tgz",
+      "integrity": "sha512-08U4Nm5bZca0AFyz3twQh2N2vR3RTjY5vQMBEDeHy4XxNxsWuV5ZGbh2hR7vP9o1oBdMXEOkEQmm2+kUh4Busg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "@mui/x-internals": "8.11.0",
+        "@mui/x-virtualizer": "0.1.4",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/types": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/utils": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/x-internals": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.11.0.tgz",
+      "integrity": "sha512-SFPMLMkNWSEOxIgKMQ9RqEL01klb1lwIdd4f4d18fJNrJOlTxeIDWd6eVllS5sRLdKVsE5FC1802V+yLe6W+pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/@mui/x-internals": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.3.1.tgz",
@@ -1962,6 +2076,103 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/x-virtualizer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mui/x-virtualizer/-/x-virtualizer-0.1.4.tgz",
+      "integrity": "sha512-UHW4yuCo4KpRvSvVsBxx//8wifN8kQZ7P0KPOfy2hu935iAXtRUNMVGGN8kbKyxVpDYQLXBz80doYAJnja61Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "@mui/x-internals": "8.11.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/types": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/utils": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/x-internals": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.11.0.tgz",
+      "integrity": "sha512-SFPMLMkNWSEOxIgKMQ9RqEL01klb1lwIdd4f4d18fJNrJOlTxeIDWd6eVllS5sRLdKVsE5FC1802V+yLe6W+pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@mui/utils": "^7.3.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2901,9 +3112,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -5008,9 +5219,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
     "node_modules/react-player": {

--- a/ichub-frontend/package.json
+++ b/ichub-frontend/package.json
@@ -18,6 +18,7 @@
     "@mui/icons-material": "^6.4.5",
     "@mui/material": "^6.4.5",
     "@mui/x-charts": "^8.3.1",
+    "@mui/x-data-grid": "^8.11.0",
     "axios": "^1.9.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/ichub-frontend/src/assets/styles/components/_CustomDataGrid.scss
+++ b/ichub-frontend/src/assets/styles/components/_CustomDataGrid.scss
@@ -20,8 +20,14 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-@forward 'CustomCardList';
-@forward 'Dialog';
-@forward 'SharedTable';
-@forward 'InstanceTable';
-@forward 'CustomDataGrid';
+@use "../config/variables" as *;
+@use '../config/mixins';
+
+.custom-data-grid {
+  color: $brand-text;
+
+  * {
+    background-color: $brand-dark-gray !important;
+    color: $brand-text !important;
+  }
+}

--- a/ichub-frontend/src/components/general/ShareDialog.tsx
+++ b/ichub-frontend/src/components/general/ShareDialog.tsx
@@ -104,14 +104,14 @@ const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errorResponse = (axiosError as any).response;
 
-      if (errorResponse) {
-        if (errorResponse.status === 422 && errorResponse.data && errorResponse.data.detail && Array.isArray(errorResponse.data.detail) && errorResponse.data.detail.length > 0) {
-          errorMessage = errorResponse.data.detail[0].msg || JSON.stringify(errorResponse.data.detail[0]) || 'Validation failed.';
-        } else if (errorResponse.data && errorResponse.data.message) {
-          errorMessage = errorResponse.data.message;
-        } else if (errorResponse.data) {
-          errorMessage = JSON.stringify(errorResponse.data);
-        }
+      if (errorResponse?.status === 422) {
+        errorMessage = errorResponse?.data?.detail?.[0]?.msg
+                      ?? JSON.stringify(errorResponse?.data?.detail?.[0])
+                      ?? 'Validation failed.';
+      } else if (errorResponse?.data?.message) {
+        errorMessage = errorResponse.data.message;
+      } else if (errorResponse?.data) {
+        errorMessage = JSON.stringify(errorResponse.data);
       }
       setApiErrorMessage(errorMessage);
     }

--- a/ichub-frontend/src/components/general/ShareDialog.tsx
+++ b/ichub-frontend/src/components/general/ShareDialog.tsx
@@ -62,7 +62,7 @@ const ShareDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
     }
   }, [open, partData]);
 
-  const handleBpnlChange = (_event: any, value: string | null) => {
+  const handleBpnlChange = (_event: React.SyntheticEvent, value: string | null) => {
     setBpnl(value ??'');
     setError(false); // Clear validation error on change
     setApiErrorMessage(''); // Clear API error on change

--- a/ichub-frontend/src/features/catalog-management/api.ts
+++ b/ichub-frontend/src/features/catalog-management/api.ts
@@ -24,6 +24,7 @@ import axios from 'axios';
 import { getIchubBackendUrl } from '../../services/EnvironmentService';
 import { ApiPartData } from '../../types/product';
 import { CatalogPartTwinCreateType, TwinReadType } from '../../types/twin';
+import { SerializedParts } from '../../types/serializedParts';
 
 const CATALOG_PART_MANAGEMENT_BASE_PATH = '/part-management/catalog-part';
 const SHARE_CATALOG_PART_BASE_PATH = '/share/catalog-part';
@@ -70,3 +71,12 @@ export const registerCatalogPartTwin = async (
   );
   return response.data;
 };
+
+// to test
+import instanceData from "../../tests/payloads/instance-data.json";
+export const fetchSerializedParts = async (): Promise<SerializedParts[]> => {
+  const rows = instanceData;
+  return rows;
+  const response = await axios.get<SerializedParts[]>(`${backendUrl}/part-management/serialized-parts`);
+  return response.data;
+}

--- a/ichub-frontend/src/features/catalog-management/api.ts
+++ b/ichub-frontend/src/features/catalog-management/api.ts
@@ -27,6 +27,7 @@ import { CatalogPartTwinCreateType, TwinReadType } from '../../types/twin';
 import { SerializedParts } from '../../types/serializedParts';
 
 const CATALOG_PART_MANAGEMENT_BASE_PATH = '/part-management/catalog-part';
+const SERIALIZED_PART_READ_BASE_PATH = '/part-management/serialized-part';
 const SHARE_CATALOG_PART_BASE_PATH = '/share/catalog-part';
 const TWIN_MANAGEMENT_BASE_PATH = '/twin-management/catalog-part-twin';
 const backendUrl = getIchubBackendUrl();
@@ -72,11 +73,18 @@ export const registerCatalogPartTwin = async (
   return response.data;
 };
 
-// to test
-import instanceData from "../../tests/payloads/instance-data.json";
-export const fetchSerializedParts = async (): Promise<SerializedParts[]> => {
-  const rows = instanceData;
-  return rows;
-  const response = await axios.get<SerializedParts[]>(`${backendUrl}/part-management/serialized-parts`);
+export const fetchAllSerializedParts = async (): Promise<SerializedParts[]> => {
+  const response = await axios.get<SerializedParts[]>(`${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`);
   return response.data;
 }
+
+export const fetchSerializedParts = async (manufacturerId: string, manufacturerPartId: string ): Promise<SerializedParts[]> => {
+  const response = await axios.post<SerializedParts[]>(
+    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}/query`,
+    {
+      manufacturerId,
+      manufacturerPartId,
+    }
+  );
+  return response.data;
+};

--- a/ichub-frontend/src/features/catalog-management/api.ts
+++ b/ichub-frontend/src/features/catalog-management/api.ts
@@ -24,7 +24,7 @@ import axios from 'axios';
 import { getIchubBackendUrl } from '../../services/EnvironmentService';
 import { ApiPartData } from '../../types/product';
 import { CatalogPartTwinCreateType, TwinReadType } from '../../types/twin';
-import { SerializedParts } from '../../types/serializedParts';
+import { SerializedParts, AddSerializedPartRequest } from '../../types/serializedParts';
 
 const CATALOG_PART_MANAGEMENT_BASE_PATH = '/part-management/catalog-part';
 const SERIALIZED_PART_READ_BASE_PATH = '/part-management/serialized-part';
@@ -87,4 +87,11 @@ export const fetchSerializedParts = async (manufacturerId: string, manufacturerP
     }
   );
   return response.data;
+};
+
+export const addSerializedPart = async (payload: AddSerializedPartRequest ) => {
+  const response = await axios.post<SerializedParts>(
+    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`, payload
+  );
+  return response;
 };

--- a/ichub-frontend/src/features/catalog-management/api.ts
+++ b/ichub-frontend/src/features/catalog-management/api.ts
@@ -24,10 +24,8 @@ import axios from 'axios';
 import { getIchubBackendUrl } from '../../services/EnvironmentService';
 import { ApiPartData } from '../../types/product';
 import { CatalogPartTwinCreateType, TwinReadType } from '../../types/twin';
-import { SerializedParts, AddSerializedPartRequest } from '../../types/serializedParts';
 
 const CATALOG_PART_MANAGEMENT_BASE_PATH = '/part-management/catalog-part';
-const SERIALIZED_PART_READ_BASE_PATH = '/part-management/serialized-part';
 const SHARE_CATALOG_PART_BASE_PATH = '/share/catalog-part';
 const TWIN_MANAGEMENT_BASE_PATH = '/twin-management/catalog-part-twin';
 const backendUrl = getIchubBackendUrl();
@@ -71,27 +69,4 @@ export const registerCatalogPartTwin = async (
     twinData
   );
   return response.data;
-};
-
-export const fetchAllSerializedParts = async (): Promise<SerializedParts[]> => {
-  const response = await axios.get<SerializedParts[]>(`${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`);
-  return response.data;
-}
-
-export const fetchSerializedParts = async (manufacturerId: string, manufacturerPartId: string ): Promise<SerializedParts[]> => {
-  const response = await axios.post<SerializedParts[]>(
-    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}/query`,
-    {
-      manufacturerId,
-      manufacturerPartId,
-    }
-  );
-  return response.data;
-};
-
-export const addSerializedPart = async (payload: AddSerializedPartRequest ) => {
-  const response = await axios.post<SerializedParts>(
-    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`, payload
-  );
-  return response;
 };

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
@@ -35,7 +35,7 @@ import Box from '@mui/material/Box';
 
 import { ProductDetailDialogProps } from '../../../../types/dialogViewer';
 import PageNotification from '../../../../components/general/PageNotification';
-import { addSerializedPart } from '../../api';
+import { addSerializedPart } from '../../../serialized-parts/api';
 
 const AddSerializedPartDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
     const [formData, setFormData] = useState({

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
@@ -36,6 +36,7 @@ import Box from '@mui/material/Box';
 import { ProductDetailDialogProps } from '../../../../types/dialogViewer';
 import PageNotification from '../../../../components/general/PageNotification';
 import { addSerializedPart } from '../../../serialized-parts/api';
+import { AxiosError } from '../../../../types/axiosError';
 
 const AddSerializedPartDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
     const [formData, setFormData] = useState({
@@ -72,7 +73,7 @@ const AddSerializedPartDialog = ({ open, onClose, partData }: ProductDetailDialo
             setTimeout(() => { window.location.reload(); }, 1500);
         } catch (err) {
             console.error("Error adding serialized part:", err);
-            const error = err as any;
+            const error = err as AxiosError;
             const errorMessage = error.response?.data?.message || error.message || 'Unknown error';
             setNotification({
                 open: true,

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/AddSerializedPartDialog.tsx
@@ -1,0 +1,147 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+import { useState } from 'react';
+import { Button, Icon } from '@catena-x/portal-shared-components';
+
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+import TextField from '@mui/material/TextField';
+import Grid2 from '@mui/material/Grid2';
+import Box from '@mui/material/Box';
+
+import { ProductDetailDialogProps } from '../../../../types/dialogViewer';
+import PageNotification from '../../../../components/general/PageNotification';
+import { addSerializedPart } from '../../api';
+
+const AddSerializedPartDialog = ({ open, onClose, partData }: ProductDetailDialogProps) => {
+    const [formData, setFormData] = useState({
+        businessPartnerNumber: '',
+        manufacturerId: partData?.manufacturerId ?? '',
+        manufacturerPartId: partData?.manufacturerPartId ?? '',
+        partInstanceId: '',
+        van: '',
+        customerPartId: '',
+    });
+
+    const [notification, setNotification] = useState<{
+        open: boolean;
+        severity: 'success' | 'error';
+        title: string;
+    } | null>(null);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setFormData((prev) => ({
+            ...prev,
+            [e.target.name]: e.target.value,
+        }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            await addSerializedPart(formData);
+            setNotification({
+                open: true,
+                severity: 'success',
+                title: 'Serialized part created successfully',
+            });
+            setTimeout(() => { window.location.reload(); }, 1500);
+        } catch (err) {
+            console.error("Error adding serialized part:", err);
+            const error = err as any;
+            const errorMessage = error.response?.data?.message || error.message || 'Unknown error';
+            setNotification({
+                open: true,
+                severity: 'error',
+                title: `Failed to create serialized part: ${errorMessage}`,
+            });
+            setTimeout(() => setNotification(null), 6000);
+        }
+    };
+
+    return (
+        <Dialog open={open} maxWidth="xl" className='custom-dialog'>
+            <PageNotification notification={notification} />
+            <DialogTitle sx={{ m: 0, p: 2 }}>Add a serialized part</DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={onClose}
+                sx={(theme) => ({
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: theme.palette.grey[500],
+                })}
+                >
+                <CloseIcon />
+            </IconButton>
+            <Box component="form" onSubmit={handleSubmit}>
+                <DialogContent dividers>
+                    <Grid2 container spacing={2}>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="Manufacturer ID" name="manufacturerId"
+                                value={formData.manufacturerId} disabled/>
+                        </Grid2>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="Manufacturer Part ID" name="manufacturerPartId"
+                                value={formData.manufacturerPartId} disabled />
+                        </Grid2>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="Business Partner Number" name="businessPartnerNumber"
+                                value={formData.businessPartnerNumber} onChange={handleChange} required/>
+                        </Grid2>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="Part Instance ID" name="partInstanceId"
+                                value={formData.partInstanceId} onChange={handleChange} required />
+                        </Grid2>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="VAN" name="van"
+                                value={formData.van} onChange={handleChange} required />
+                        </Grid2>
+                        <Grid2 size={{ sm: 6, xs: 12 }}>
+                            <TextField fullWidth label="Customer Part ID" name="customerPartId"
+                                value={formData.customerPartId} onChange={handleChange} required />
+                        </Grid2>
+                    </Grid2>
+                </DialogContent>
+
+                <DialogActions>
+                    <Button className="close-button" variant="outlined" size="small" onClick={onClose}>
+                        <Icon fontSize="16" iconName="Close" />
+                        <span className="close-button-content">CLOSE</span>
+                    </Button>
+                    <Button className="action-button" variant="outlined" size="small" type="submit">
+                        <Icon fontSize="16" iconName="Save" />
+                        <span className="action-button-content">SAVE</span>
+                    </Button>
+                </DialogActions>
+            </Box>
+        </Dialog>
+    )
+}
+
+export default AddSerializedPartDialog

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -56,13 +56,7 @@ function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
 
 type Order = 'asc' | 'desc';
 
-function getComparator<Key extends keyof any>(
-  order: Order,
-  orderBy: Key,
-): (
-  a: { [key in Key]: number | string },
-  b: { [key in Key]: number | string },
-) => number {
+function getComparator( order: Order, orderBy: keyof SerializedParts,): (a: SerializedParts, b: SerializedParts) => number {
   return order === 'desc'
     ? (a, b) => descendingComparator(a, b, orderBy)
     : (a, b) => -descendingComparator(a, b, orderBy);
@@ -316,10 +310,7 @@ export default function InstanceProductsTable() {
     <Paper sx={{ width: '100%', mb: 2 }}>
       <InstanceProductsTableToolbar numSelected={selected.length} />
       <TableContainer>
-        <Table
-          aria-labelledby="tableTitle"
-          size='small'
-        >
+        <Table aria-labelledby="tableTitle" size='small'>
           <InstanceProductsTableHead
             numSelected={selected.length}
             order={order}
@@ -352,14 +343,7 @@ export default function InstanceProductsTable() {
                       }}
                     />
                   </TableCell>
-                  <TableCell
-                    component="th"
-                    id={labelId}
-                    scope="row"
-                    padding="none"
-                  >
-                    {row.uuid}
-                  </TableCell>
+                  <TableCell component="th" id={labelId} scope="row" padding="none">{row.uuid}</TableCell>
                   <TableCell align="right">{row.partInstanceId}</TableCell>
                   <TableCell align="right">{row.submodels}</TableCell>
                   <TableCell align="right">{row.status}</TableCell>
@@ -371,11 +355,7 @@ export default function InstanceProductsTable() {
               );
             })}
             {emptyRows > 0 && (
-              <TableRow
-                style={{
-                  height: 33 * emptyRows,
-                }}
-              >
+              <TableRow style={{ height: 33 * emptyRows,}} >
                 <TableCell colSpan={6} />
               </TableRow>
             )}

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -41,8 +41,8 @@ import FilterListIcon from '@mui/icons-material/FilterList';
 import { visuallyHidden } from '@mui/utils';
 
 
-import { SerializedParts } from '../../../../types/serializedParts';
-import { fetchSerializedParts } from '../../api';
+import { SerializedPart } from '../../../serialized-parts/types';
+import { fetchSerializedParts } from '../../../serialized-parts/api';
 import { PartType } from '../../../../types/product';
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
@@ -57,7 +57,7 @@ function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
 
 type Order = 'asc' | 'desc';
 
-function getComparator( order: Order, orderBy: keyof SerializedParts,): (a: SerializedParts, b: SerializedParts) => number {
+function getComparator( order: Order, orderBy: keyof SerializedPart,): (a: SerializedPart, b: SerializedPart) => number {
   return order === 'desc'
     ? (a, b) => descendingComparator(a, b, orderBy)
     : (a, b) => -descendingComparator(a, b, orderBy);
@@ -65,7 +65,7 @@ function getComparator( order: Order, orderBy: keyof SerializedParts,): (a: Seri
 
 interface HeadCell {
   disablePadding: boolean;
-  id: keyof SerializedParts;
+  id: keyof SerializedPart;
   label: string;
   numeric: boolean;
 }
@@ -129,7 +129,7 @@ const headCells: readonly HeadCell[] = [
 
 interface InstanceProductsTableProps {
   numSelected: number;
-  onRequestSort: (event: React.MouseEvent<unknown>, property: keyof SerializedParts) => void;
+  onRequestSort: (event: React.MouseEvent<unknown>, property: keyof SerializedPart) => void;
   onSelectAllClick: (event: React.ChangeEvent<HTMLInputElement>) => void;
   order: Order;
   orderBy: string;
@@ -140,7 +140,7 @@ function InstanceProductsTableHead(props: Readonly<InstanceProductsTableProps>) 
   const { onSelectAllClick, order, orderBy, numSelected, rowCount, onRequestSort } =
     props;
   const createSortHandler =
-    (property: keyof SerializedParts) => (event: React.MouseEvent<unknown>) => {
+    (property: keyof SerializedPart) => (event: React.MouseEvent<unknown>) => {
       onRequestSort(event, property);
     };
 
@@ -235,10 +235,10 @@ function InstanceProductsTableToolbar(props: Readonly<InstanceProductsTableToolb
 }
 export default function InstanceProductsTable({ part }: { part: PartType | null }) {
   const [order, setOrder] = useState<Order>('asc');
-  const [orderBy, setOrderBy] = useState<keyof SerializedParts>('customerPartId');
+  const [orderBy, setOrderBy] = useState<keyof SerializedPart>('customerPartId');
   const [selected, setSelected] = useState<readonly number[]>([]);
   const [page, setPage] = useState(0);
-  const [rows, setRows] = useState<SerializedParts[]>([]);
+  const [rows, setRows] = useState<SerializedPart[]>([]);
   const [rowsPerPage, setRowsPerPage] = useState(5);
 
   useEffect(() => {
@@ -264,7 +264,7 @@ export default function InstanceProductsTable({ part }: { part: PartType | null 
 
   const handleRequestSort = (
     _event: React.MouseEvent<unknown>,
-    property: keyof SerializedParts,
+    property: keyof SerializedPart,
   ) => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -245,7 +245,11 @@ export default function InstanceProductsTable({ part }: { part: PartType }) {
     const loadData = async () => {
       try {
         const data = await fetchSerializedParts(part.manufacturerId!, part.manufacturerPartId!);
-        setRows(data);
+        const rowsWithId = data.map((row, index) => ({
+          ...row,
+          id: index,
+        }));
+        setRows(rowsWithId);
       } catch (error) {
         console.error("Error fetching instance products:", error);
       }

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -233,7 +233,7 @@ function InstanceProductsTableToolbar(props: Readonly<InstanceProductsTableToolb
     </Toolbar>
   );
 }
-export default function InstanceProductsTable({ part }: { part: PartType }) {
+export default function InstanceProductsTable({ part }: { part: PartType | null }) {
   const [order, setOrder] = useState<Order>('asc');
   const [orderBy, setOrderBy] = useState<keyof SerializedParts>('customerPartId');
   const [selected, setSelected] = useState<readonly number[]>([]);

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -242,6 +242,10 @@ export default function InstanceProductsTable({ part }: { part: PartType | null 
   const [rowsPerPage, setRowsPerPage] = useState(5);
 
   useEffect(() => {
+    if (!part) {
+      setRows([]);
+      return;
+    }
     const loadData = async () => {
       try {
         const data = await fetchSerializedParts(part.manufacturerId!, part.manufacturerPartId!);

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -129,7 +129,7 @@ interface InstanceProductsTableProps {
   rowCount: number;
 }
 
-function InstanceProductsTableHead(props: InstanceProductsTableProps) {
+function InstanceProductsTableHead(props: Readonly<InstanceProductsTableProps>) {
   const { onSelectAllClick, order, orderBy, numSelected, rowCount, onRequestSort } =
     props;
   const createSortHandler =
@@ -178,7 +178,7 @@ function InstanceProductsTableHead(props: InstanceProductsTableProps) {
 interface InstanceProductsTableToolbarProps {
   numSelected: number;
 }
-function InstanceProductsTableToolbar(props: InstanceProductsTableToolbarProps) {
+function InstanceProductsTableToolbar(props: Readonly<InstanceProductsTableToolbarProps>) {
   const { numSelected } = props;
   return (
     <Toolbar
@@ -328,8 +328,6 @@ export default function InstanceProductsTable() {
                 <TableRow
                   hover
                   onClick={(event) => handleClick(event, row.id)}
-                  role="checkbox"
-                  aria-checked={isItemSelected}
                   tabIndex={-1}
                   key={row.id}
                   selected={isItemSelected}
@@ -338,6 +336,10 @@ export default function InstanceProductsTable() {
                   <TableCell padding="checkbox">
                     <Checkbox
                       checked={isItemSelected}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        handleClick(event, row.id)
+                      }}
                       inputProps={{
                         'aria-labelledby': labelId,
                       }}

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -43,6 +43,7 @@ import { visuallyHidden } from '@mui/utils';
 
 import { SerializedParts } from '../../../../types/serializedParts';
 import { fetchSerializedParts } from '../../api';
+import { PartType } from '../../../../types/product';
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
   if (b[orderBy] < a[orderBy]) {
@@ -71,10 +72,28 @@ interface HeadCell {
 
 const headCells: readonly HeadCell[] = [
   {
-    id: 'uuid',
+    id: 'customerPartId',
     numeric: false,
     disablePadding: true,
-    label: 'UUID',
+    label: 'Customer Part ID',
+  },
+  {
+    id: 'businessPartner',
+    numeric: false,
+    disablePadding: false,
+    label: 'Business Partner',
+  },
+  {
+    id: 'manufacturerId',
+    numeric: false,
+    disablePadding: false,
+    label: 'Manufacturer ID',
+  },
+  {
+    id: 'manufacturerPartId',
+    numeric: false,
+    disablePadding: false,
+    label: 'Manufacturer Part ID',
   },
   {
     id: 'partInstanceId',
@@ -83,40 +102,28 @@ const headCells: readonly HeadCell[] = [
     label: 'Part Instance ID',
   },
   {
-    id: 'submodels',
-    numeric: true,
-    disablePadding: false,
-    label: 'Submodels',
-  },
-  {
-    id: 'status',
+    id: 'name',
     numeric: false,
     disablePadding: false,
-    label: 'Status',
+    label: 'Name',
   },
   {
-    id: 'type',
+    id: 'category',
     numeric: false,
     disablePadding: false,
-    label: 'Type',
+    label: 'Category',
   },
   {
-    id: 'created',
+    id: 'bpns',
     numeric: false,
     disablePadding: false,
-    label: 'Created at',
+    label: 'BPNS',
   },
   {
-    id: 'updated',
+    id: 'van',
     numeric: false,
     disablePadding: false,
-    label: 'Updated at',
-  },
-  {
-    id: 'manufacturer',
-    numeric: false,
-    disablePadding: false,
-    label: 'Manufacturer',
+    label: 'VAN',
   },
 ];
 
@@ -226,9 +233,9 @@ function InstanceProductsTableToolbar(props: Readonly<InstanceProductsTableToolb
     </Toolbar>
   );
 }
-export default function InstanceProductsTable() {
+export default function InstanceProductsTable({ part }: { part: PartType }) {
   const [order, setOrder] = useState<Order>('asc');
-  const [orderBy, setOrderBy] = useState<keyof SerializedParts>('uuid');
+  const [orderBy, setOrderBy] = useState<keyof SerializedParts>('customerPartId');
   const [selected, setSelected] = useState<readonly number[]>([]);
   const [page, setPage] = useState(0);
   const [rows, setRows] = useState<SerializedParts[]>([]);
@@ -237,8 +244,7 @@ export default function InstanceProductsTable() {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const data = await fetchSerializedParts();
-        console.log(data);
+        const data = await fetchSerializedParts(part.manufacturerId!, part.manufacturerPartId!);
         setRows(data);
       } catch (error) {
         console.error("Error fetching instance products:", error);
@@ -345,14 +351,15 @@ export default function InstanceProductsTable() {
                       }}
                     />
                   </TableCell>
-                  <TableCell component="th" id={labelId} scope="row" padding="none">{row.uuid}</TableCell>
+                  <TableCell component="th" id={labelId} scope="row" padding="none">{row.customerPartId}</TableCell>
+                  <TableCell align="right">{row.businessPartner.name}</TableCell>
+                  <TableCell align="right">{row.manufacturerId}</TableCell>
+                  <TableCell align="right">{row.manufacturerPartId}</TableCell>
                   <TableCell align="right">{row.partInstanceId}</TableCell>
-                  <TableCell align="right">{row.submodels}</TableCell>
-                  <TableCell align="right">{row.status}</TableCell>
-                  <TableCell align="right">{row.type}</TableCell>
-                  <TableCell align="right">{row.created}</TableCell>
-                  <TableCell align="right">{row.updated}</TableCell>
-                  <TableCell align="right">{row.manufacturer}</TableCell>
+                  <TableCell align="right">{row.name}</TableCell>
+                  <TableCell align="right">{row.category}</TableCell>
+                  <TableCell align="right">{row.bpns}</TableCell>
+                  <TableCell align="right">{row.van}</TableCell>
                 </TableRow>
               );
             })}

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -260,7 +260,7 @@ export default function InstanceProductsTable({ part }: { part: PartType | null 
     };
 
     loadData();
-  }, []);
+  }, [part]);
 
   const handleRequestSort = (
     _event: React.MouseEvent<unknown>,

--- a/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -214,7 +214,7 @@ function InstanceProductsTableToolbar(props: Readonly<InstanceProductsTableToolb
           id="tableTitle"
           component="div"
         >
-          Instance Products(5 of 52.0213 Digital Twins)
+          Serialized Parts
         </Typography>
       )}
       {numSelected > 0 ? (

--- a/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-list/ProductCard.tsx
@@ -51,7 +51,7 @@ export interface CardDecisionProps {
   isDiscovery?: boolean;
 }
 
-export enum ButtonEvents {
+enum ButtonEvents {
   SHARE,
   MORE,
   REGISTER, 

--- a/ichub-frontend/src/features/main.tsx
+++ b/ichub-frontend/src/features/main.tsx
@@ -25,11 +25,13 @@ import {
     Storefront,
     FindInPage,
     People,
-    Assignment
+    Assignment,
+    Dashboard
   } from '@mui/icons-material';
   
   export const features = [
     { icon: <Storefront />, path: '/catalog', disabled: false },
+    { icon: <Dashboard />, path: '/serialized-parts', disabled: false },
     { icon: <People />, path: '/shared', disabled: false },
     { icon: <FindInPage />, path: '/discover-parts', disabled: false },
     { icon: <Assignment />, path: '/status', disabled: true }

--- a/ichub-frontend/src/features/serialized-parts/api.ts
+++ b/ichub-frontend/src/features/serialized-parts/api.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import axios from 'axios';
+import { getIchubBackendUrl } from '../../services/EnvironmentService';
+import { SerializedPart, AddSerializedPartRequest } from './types';
+
+const SERIALIZED_PART_READ_BASE_PATH = '/part-management/serialized-part';
+const backendUrl = getIchubBackendUrl();
+
+export const fetchAllSerializedParts = async (): Promise<SerializedPart[]> => {
+  const response = await axios.get<SerializedPart[]>(`${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`);
+  return response.data;
+}
+
+export const fetchSerializedParts = async (manufacturerId: string, manufacturerPartId: string ): Promise<SerializedPart[]> => {
+  const response = await axios.post<SerializedPart[]>(
+    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}/query`,
+    {
+      manufacturerId,
+      manufacturerPartId,
+    }
+  );
+  return response.data;
+};
+
+export const addSerializedPart = async (payload: AddSerializedPartRequest ) => {
+  const response = await axios.post<SerializedPart>(
+    `${backendUrl}${SERIALIZED_PART_READ_BASE_PATH}`, payload
+  );
+  return response;
+};

--- a/ichub-frontend/src/features/serialized-parts/components/SerializedPartsTable.tsx
+++ b/ichub-frontend/src/features/serialized-parts/components/SerializedPartsTable.tsx
@@ -1,0 +1,207 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+import {
+  Box,
+  Typography,
+} from '@mui/material';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { SerializedPart } from '../types';
+
+interface SerializedPartsTableProps {
+  parts: SerializedPart[];
+  onView?: (part: SerializedPart) => void;
+}
+
+const SerializedPartsTable = ({ parts }: SerializedPartsTableProps) => {
+
+  // Transform data for DataGrid
+  const rows = parts.map((part, index) => ({
+    id: part.id || `part-${index}`,
+    customerPartId: part.customerPartId,
+    businessPartnerName: part.businessPartner.name,
+    businessPartnerBpnl: part.businessPartner.bpnl,
+    manufacturerId: part.manufacturerId,
+    manufacturerPartId: part.manufacturerPartId,
+    partInstanceId: part.partInstanceId || '',
+    name: part.name,
+    category: part.category,
+    bpns: part.bpns,
+    van: part.van
+  }));
+
+  // Define columns for DataGrid
+  const columns: GridColDef[] = [
+    {
+      field: 'customerPartId',
+      headerName: 'Customer Part ID',
+      width: 260,
+      align: 'left',
+      headerAlign: 'center',
+      renderCell: (params) => (        
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'businessPartnerName',
+      headerName: 'Business Partner',
+      width: 180,
+      renderCell: (params) => (        
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'businessPartnerBpnl',
+      headerName: 'Business Partner BPNL',
+      width: 200,
+      renderCell: (params) => (        
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'manufacturerId',
+      headerName: 'Manufacturer ID',
+      width: 170,
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'manufacturerPartId',
+      headerName: 'Manufacturer Part ID',
+      width: 180,
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'partInstanceId',
+      headerName: 'Part Instance ID',
+      width: 270,
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value || '-'}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'name',
+      headerName: 'Name',
+      width: 240,
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value || '-'}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'category',
+      headerName: 'Category',
+      width: 200,
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value || '-'}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'bpns',
+      headerName: 'BPNS',
+      width: 180,
+      align: 'center',
+      headerAlign: 'center',
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value || '-'}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: 'van',
+      headerName: 'VAN',
+      width: 150,
+      align: 'center',
+      headerAlign: 'center',
+      renderCell: (params) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+          <Typography variant="body2" sx={{ fontSize: '0.875rem' }}>
+            {params.value || '-'}
+          </Typography>
+        </Box>
+      ),
+    },
+  ];
+
+  return (
+    <Box sx={{ height: '100%', width: '100%' }}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        initialState={{
+          pagination: {
+            paginationModel: { page: 0, pageSize: 25 },
+          },
+          sorting: {
+            sortModel: [{ field: 'id', sort: 'asc' }],
+          },
+        }}
+        pageSizeOptions={[10, 25, 50, 100]}
+        disableRowSelectionOnClick
+        disableColumnFilter={false}
+        disableColumnSelector={false}
+        disableDensitySelector={false}
+        rowHeight={50}
+        className='custom-data-grid'
+      />
+    </Box>
+  );
+};
+
+export default SerializedPartsTable;

--- a/ichub-frontend/src/features/serialized-parts/types.ts
+++ b/ichub-frontend/src/features/serialized-parts/types.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+export interface SerializedPart {
+    id: number, // not in API, just for table handling
+    customerPartId: string,
+    businessPartner: {name: string, bpnl: string},
+    manufacturerId: string,
+    manufacturerPartId: string,
+    partInstanceId: string,
+    name: string,
+    category: string,
+    bpns: string,
+    van: string
+}
+
+export interface AddSerializedPartRequest {
+  businessPartnerNumber: string;
+  manufacturerId: string;
+  manufacturerPartId: string;
+  partInstanceId: string;
+  van: string;
+  customerPartId: string;
+}

--- a/ichub-frontend/src/pages/PartsDiscovery.tsx
+++ b/ichub-frontend/src/pages/PartsDiscovery.tsx
@@ -178,7 +178,7 @@ const PartsDiscovery = () => {
         <Grid2 container spacing={2} margin={3} justifyContent="center">
         {partType === 'Serialized' ? (
           <Grid2 size={12} className='product-table-wrapper'>
-            <InstanceProductsTable />
+            <InstanceProductsTable part={null} />
           </Grid2>
         ) : (
           <ProductCard

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -194,7 +194,7 @@ const ProductsDetails = () => {
         </Grid2>
 
         <Grid2 size={12} className='product-table-wrapper'>
-          <InstanceProductsTable />
+          <InstanceProductsTable part={partType} />
         </Grid2>
         
         <JsonViewerDialog open={jsonDialogOpen} onClose={handleCloseJsonDialog} partData={partType} />

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -31,6 +31,7 @@ import ShareDropdown from "../features/catalog-management/components/product-det
 import ProductButton from "../features/catalog-management/components/product-detail/ProductButton";
 import ProductData from "../features/catalog-management/components/product-detail/ProductData";
 import JsonViewerDialog from "../features/catalog-management/components/product-detail/JsonViewerDialog";
+import AddSerializedPartDialog from "../features/catalog-management/components/product-detail/AddSerializedPartDialog";
 
 import ShareDialog from "../components/general/ShareDialog";
 import {ErrorNotFound} from "../components/general/ErrorNotFound";
@@ -55,6 +56,7 @@ const ProductsDetails = () => {
   const [partType, setPartType] = useState<PartType>();
   const [jsonDialogOpen, setJsonDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [addSerializedPartDialogOpen, setAddSerializedPartDialogOpen] = useState(false);
   const [notification, setNotification] = useState<{ open: boolean; severity: "success" | "error"; title: string } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [sharedPartners, setSharedPartners] = useState<SharedPartner[]>([]);
@@ -110,6 +112,14 @@ const ProductsDetails = () => {
 
   const handleCloseShareDialog = () => {
     setShareDialogOpen(false);
+  };
+
+  const handleOpenAddSerializedPartDialog = () => {
+    setAddSerializedPartDialogOpen(true);
+  };
+
+  const handleCloseAddSerializedPartDialog = () => {
+    setAddSerializedPartDialogOpen(false);
   };
 
   const handleCopy = () => {
@@ -187,7 +197,7 @@ const ProductsDetails = () => {
           <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DIGITAL PRODUCT PASSPORT v6.0.0" onClick={() => console.log("TRANSMISSION PASS v2.0.0")} />
           <ProductButton gridSize={{ lg: 4, md: 12, sm: 12 }} disabled={true} buttonText="DCM v2.0.0" onClick={() => console.log("DPP v2.0 button")} />
           <Grid2 size={{ sm: 12 }}>
-            <Button className="submodel-button" color="success" size="small" onClick={() => console.log("Add button")} fullWidth={true} style={{ padding: "5px" }}>
+            <Button className="submodel-button" color="success" size="small" onClick={handleOpenAddSerializedPartDialog} fullWidth={true} style={{ padding: "5px" }}>
               <Icon fontSize="18" iconName="Add" />
             </Button>
           </Grid2>
@@ -199,6 +209,7 @@ const ProductsDetails = () => {
         
         <JsonViewerDialog open={jsonDialogOpen} onClose={handleCloseJsonDialog} partData={partType} />
         <ShareDialog open={shareDialogOpen} onClose={handleCloseShareDialog} partData={partType} />
+        <AddSerializedPartDialog open={addSerializedPartDialogOpen} onClose={handleCloseAddSerializedPartDialog} partData={partType} />
       </Grid2>
     </>
   );

--- a/ichub-frontend/src/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/pages/ProductsDetails.tsx
@@ -61,35 +61,31 @@ const ProductsDetails = () => {
 
   useEffect(() => {
     if (!manufacturerId || !manufacturerPartId) return;
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        const apiData = await fetchCatalogPart(manufacturerId, manufacturerPartId);
+        const mappedPart: PartType = mapApiPartDataToPartType(apiData)
+        setPartType(mappedPart);
+        // Just if the customer part ids are available we can see if they are shared
+        if(mappedPart.customerPartIds){
+            const mappedResult:SharedPartner[] = mapSharePartCustomerPartIds(mappedPart.customerPartIds)
+            setSharedPartners(mappedResult)
+        }
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-      fetchData();
-    }, [manufacturerId, manufacturerPartId]);
+    fetchData();
+  }, [manufacturerId, manufacturerPartId]);
 
-    if(!manufacturerId || !manufacturerPartId){
+  if(!manufacturerId || !manufacturerPartId){
     return <div>Product not found</div>; 
   }
   const productId = manufacturerId + "/" + manufacturerPartId
-
-  const fetchData = async () => {
-    setIsLoading(true);
-    try {
-      const apiData = await fetchCatalogPart(manufacturerId, manufacturerPartId);
-      console.log(apiData)
-      // Map API data to PartInstance[]
-      const mappedPart: PartType = mapApiPartDataToPartType(apiData)
-      setPartType(mappedPart);
-      // Just if the customer part ids are available we can see if they are shared
-      if(mappedPart.customerPartIds){
-          const mappedResult:SharedPartner[] = mapSharePartCustomerPartIds(mappedPart.customerPartIds)
-          setSharedPartners(mappedResult)
-      }
-
-    } catch (error) {
-      console.error("Error fetching data:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   if (isLoading) {
     return <LoadingSpinner />;

--- a/ichub-frontend/src/pages/SerializedParts.tsx
+++ b/ichub-frontend/src/pages/SerializedParts.tsx
@@ -20,12 +20,14 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-import { Box, Grid2 } from '@mui/material';
+import { Box, Grid2, Typography } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { fetchAllSerializedParts } from '../features/serialized-parts/api';
+import SerializedPartsTable from '../features/serialized-parts/components/SerializedPartsTable';
+import { SerializedPart } from '../features/serialized-parts/types';
 
 const SerializedParts = () => {
-  const [serializedParts, setSerializedParts] = useState<SerializedParts[]>([]);
+  const [serializedParts, setSerializedParts] = useState<SerializedPart[]>([]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -42,8 +44,13 @@ const SerializedParts = () => {
 
   return (
     <Grid2 container direction="row">
+      <Box sx={{ p: 3, mx: 'auto',  color: 'white'}} className="product-catalog title">
+        <Typography className="text">Serialized Parts</Typography>
+      </Box>
       <Box sx={{ p: 3, width: '100%', color: 'white'}}>
-        {serializedParts.length}
+        <SerializedPartsTable parts={serializedParts} onView={(part) => {
+          console.log("View part:", part);
+        }} />
       </Box>
     </Grid2>
   );

--- a/ichub-frontend/src/pages/SerializedParts.tsx
+++ b/ichub-frontend/src/pages/SerializedParts.tsx
@@ -20,24 +20,33 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-export interface SerializedParts {
-    id: number, // not in API, just for table handling
-    customerPartId: string,
-    businessPartner: {name: string, bpnl: string},
-    manufacturerId: string,
-    manufacturerPartId: string,
-    partInstanceId: string,
-    name: string,
-    category: string,
-    bpns: string,
-    van: string
-}
+import { Box, Grid2 } from '@mui/material';
+import { useState, useEffect } from 'react';
+import { fetchAllSerializedParts } from '../features/serialized-parts/api';
 
-export interface AddSerializedPartRequest {
-  businessPartnerNumber: string;
-  manufacturerId: string;
-  manufacturerPartId: string;
-  partInstanceId: string;
-  van: string;
-  customerPartId: string;
-}
+const SerializedParts = () => {
+  const [serializedParts, setSerializedParts] = useState<SerializedParts[]>([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchAllSerializedParts();
+        setSerializedParts(data);
+      } catch (error) {
+        console.error("Error fetching instance products:", error);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <Grid2 container direction="row">
+      <Box sx={{ p: 3, width: '100%', color: 'white'}}>
+        {serializedParts.length}
+      </Box>
+    </Grid2>
+  );
+};
+
+export default SerializedParts;

--- a/ichub-frontend/src/routes.tsx
+++ b/ichub-frontend/src/routes.tsx
@@ -27,6 +27,7 @@ import ProductsList from './pages/ProductsList';
 import PartnersList from './pages/PartnersList';
 import ProductsDetails from './pages/ProductsDetails';
 import PartsDiscovery from "./pages/PartsDiscovery";
+import SerializedParts from "./pages/SerializedParts"
 
 export default function AppRoutes() {
   return (
@@ -41,6 +42,7 @@ export default function AppRoutes() {
           <Route path="/discover-parts" element={<PartsDiscovery />} />
           <Route path="/shared" element={<PartnersList />} />
           <Route path="/status" element={<ProductsList />} />
+          <Route path="/serialized-parts" element={<SerializedParts />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/ichub-frontend/src/types/axiosError.tsx
+++ b/ichub-frontend/src/types/axiosError.tsx
@@ -1,0 +1,8 @@
+export interface AxiosError {
+  response?: {
+    data?: {
+      message?: string;
+    };
+  };
+  message?: string;
+}

--- a/ichub-frontend/src/types/serializedParts.ts
+++ b/ichub-frontend/src/types/serializedParts.ts
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-export interface InstanceProduct {
+export interface SerializedParts {
     id: number,
     uuid: string,
     partInstanceId: string,

--- a/ichub-frontend/src/types/serializedParts.ts
+++ b/ichub-frontend/src/types/serializedParts.ts
@@ -21,13 +21,14 @@
 ********************************************************************************/
 
 export interface SerializedParts {
-    id: number,
-    uuid: string,
+    id: number, // not in API, just for table handling
+    customerPartId: string,
+    businessPartner: {name: string, bpnl: string},
+    manufacturerId: string,
+    manufacturerPartId: string,
     partInstanceId: string,
-    submodels: number,
-    status: string,
-    type: string,
-    created: string,
-    updated: string,
-    manufacturer: string
+    name: string,
+    category: string,
+    bpns: string,
+    van: string
 }

--- a/ichub-frontend/src/types/serializedParts.ts
+++ b/ichub-frontend/src/types/serializedParts.ts
@@ -32,3 +32,12 @@ export interface SerializedParts {
     bpns: string,
     van: string
 }
+
+export interface AddSerializedPartRequest {
+  businessPartnerNumber: string;
+  manufacturerId: string;
+  manufacturerPartId: string;
+  partInstanceId: string;
+  van: string;
+  customerPartId: string;
+}


### PR DESCRIPTION
## WHAT

- Serialized parts of catalog parts are shown in a table with the data obtained from the `/v1/part-management/serialized-part` endpoint.

<img width="1904" height="907" alt="serialized-parts-0" src="https://github.com/user-attachments/assets/6b4df225-eee3-4db5-ad43-1479ffb64fe0" />

- Same URL but with a POST method is used to create a new serialized part for a catalog part. This is done from the detail view pressing the green button and completing the data in a form.

<img width="1904" height="910" alt="serialized-parts-1" src="https://github.com/user-attachments/assets/ebb16c0d-82c9-40e3-a1bb-6b58546f75a2" />

- A new view is included to show all the serialized parts. The data is shown with a data grid table, so you can sort, filter, and customize the view, etc.

<img width="1917" height="719" alt="serialized-parts-2" src="https://github.com/user-attachments/assets/c2879898-36c1-4559-9b36-fff707c4e8ad" />

## WHY

To display and manage serialized parts data.
