### PR TITLE
fix: correct API key assignment in provider connector headers

### DIFF
--- a/ichub-backend/connector.py
+++ b/ichub-backend/connector.py
@@ -85,7 +85,7 @@ try:
 
     # Create EDC headers
     provider_connector_headers = {
-        provider_api_key_header: provider_api_key_header,
+        provider_api_key_header: provider_api_key,
         "Content-Type": "application/json"
     }
 


### PR DESCRIPTION
Fix typo where provider_api_key_header was incorrectly assigned as both key and value in provider_connector_headers dictionary, causing 401 authentication failures in EDC asset creation.

Before: {'provider_connector_headers': 'provider_connector_headers'}
After:  {'provider_api_key_header': 'provider_api_key'}

## WHAT

Fixed API key assignment in provider connector headers where the header name was incorrectly used as both key and value, causing EDC authentication failures.

## WHY

The provider_connector_headers dictionary was malformed, resulting in 401 authentication errors when creating EDC assets. This prevented proper communication with the EDC.

## FURTHER NOTES

- No breaking changes to existing APIs
- Fix resolves authentication issues in asset creation operations
- Change maintains backward compatibility with existing configurations


Closes # <-- _insert Issue number if one exists_
