### PR TITLE
fix: correct appVersion casing in Chart.yaml and chart template errors

### DIFF
--- a/DEPENDENCIES_ICHUB-BACKEND
+++ b/DEPENDENCIES_ICHUB-BACKEND
@@ -21,7 +21,7 @@ pypi/pypi/-/email_validator/2.2.0, Unlicense, approved, #19387
 pypi/pypi/-/exceptiongroup/1.2.2, MIT AND PSF-2.0, approved, #12076
 pypi/pypi/-/fastapi-cli/0.0.7, MIT, approved, clearlydefined
 pypi/pypi/-/fastapi-keycloak-middleware/1.2.0, MIT, approved, clearlydefined
-pypi/pypi/-/fastapi/0.116.1, MIT AND Apache-2.0, approved, #22844
+pypi/pypi/-/fastapi/0.120.3, MIT AND Apache-2.0, approved, #24551
 pypi/pypi/-/filelock/3.19.1, Unlicense, approved, clearlydefined
 pypi/pypi/-/greenlet/3.1.1, MIT AND PSF-2.0, approved, #19389
 pypi/pypi/-/h11/0.16.0, MIT AND BSD-3-Clause, approved, #20895
@@ -63,9 +63,9 @@ pypi/pypi/-/shellingham/1.5.4, ISC AND BSD-3-Clause, approved, #19381
 pypi/pypi/-/six/1.17.0, MIT, approved, #19893
 pypi/pypi/-/sniffio/1.3.1, Apache-2.0 OR (Apache-2.0 AND MIT), approved, clearlydefined
 pypi/pypi/-/sqlmodel/0.0.22, MIT, approved, clearlydefined
-pypi/pypi/-/starlette/0.47.2, BSD-3-Clause, approved, #22614
+pypi/pypi/-/starlette/0.49.1, BSD-3-Clause, approved, #24550
 pypi/pypi/-/tomli/2.0.1, MIT, approved, #7824
-pypi/pypi/-/tractusx_sdk/0.5.0, Apache-2.0 AND CC-BY-4.0, approved, #23712
+pypi/pypi/-/tractusx_sdk/0.6.0rc1, Apache-2.0 AND CC-BY-4.0, approved, #25112
 pypi/pypi/-/typer/0.15.2, MIT, approved, #21293
 pypi/pypi/-/typing-inspection/0.4.1, MIT, approved, clearlydefined
 pypi/pypi/-/typing_extensions/4.13.1, PSF-2.0 AND (PSF-2.0 OR 0BSD), approved, #20549

--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -23,7 +23,7 @@ apiVersion: v2
 name: industry-core-hub
 type: application
 appVersion: "0.3.0-rc2"
-version: 0.3.7
+version: 0.3.8
 description: A Helm chart for Eclipse Tractus-X - Industry Core Hub
 home: https://github.com/eclipse-tractusx/industry-core-hub
 sources:

--- a/charts/industry-core-hub/Chart.yaml
+++ b/charts/industry-core-hub/Chart.yaml
@@ -22,7 +22,7 @@
 apiVersion: v2
 name: industry-core-hub
 type: application
-appVersion: "0.3.0-RC2"
+appVersion: "0.3.0-rc2"
 version: 0.3.7
 description: A Helm chart for Eclipse Tractus-X - Industry Core Hub
 home: https://github.com/eclipse-tractusx/industry-core-hub

--- a/charts/industry-core-hub/README.md
+++ b/charts/industry-core-hub/README.md
@@ -221,6 +221,7 @@ helm install industry-core-hub tractusx/industry-core-hub
 | keycloak.postgresql.enabled | bool | `false` | PostgreSQL chart configuration (recommended for demonstration purposes only); default configurations: host: "centralidp-postgresql", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
 | keycloak.postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-11"}` | Setting to Postgres version 15 as that is the aligned version, https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/#aligning-dependency-versions). Keycloak helm-chart from Bitnami has moved on to version 16. |
 | keycloak.production | bool | `false` | Run Keycloak in production mode. TLS configuration is required except when using proxy=edge. |
+| keycloak.proxy | string | `"edge"` | Proxy mode for Keycloak when running behind a reverse proxy (edge, reencrypt, passthrough, or none). Use 'edge' when running behind a reverse proxy that terminates SSL/TLS |
 | keycloak.rbac.create | bool | `true` |  |
 | keycloak.rbac.rules[0].apiGroups[0] | string | `""` |  |
 | keycloak.rbac.rules[0].resources[0] | string | `"pods"` |  |

--- a/charts/industry-core-hub/files/realm-export.json
+++ b/charts/industry-core-hub/files/realm-export.json
@@ -210,38 +210,7 @@
     }
   ],
   "clientScopes": [],
-  "users": [
-    {
-      "username": "ichub-admin",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": true,
-      "firstName": "Industry",
-      "lastName": "Admin",
-      "email": "ichub-admin@example.com",
-      "attributes": {
-        "BPN": ["BPNL000000000000"]
-      },
-      "credentials": [
-        {
-          "type": "password",
-          "userLabel": "Initial password",
-          "secretData": "{{ADMIN_PASSWORD_HASH}}",
-          "credentialData": "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
-        }
-      ],
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "default-roles-ichub",
-        "offline_access",
-        "uma_authorization"
-      ],
-      "clientRoles": {},
-      "notBefore": 0,
-      "groups": []
-    }
-  ],
+  "users": [],
   "browserSecurityHeaders": {
     "contentSecurityPolicyReportOnly": "",
     "xContentTypeOptions": "nosniff",

--- a/charts/industry-core-hub/templates/configmap-realm-data.yaml
+++ b/charts/industry-core-hub/templates/configmap-realm-data.yaml
@@ -20,6 +20,28 @@
 * SPDX-License-Identifier: Apache-2.0
 */}}
 {{- if and .Values.keycloak.enabled .Values.keycloak.realmImport.enabled }}
+{{- $realmData := .Files.Get "files/realm-export.json" | fromJson }}
+{{- $_ := set $realmData "users" list }}
+{{- range $user := .Values.keycloak.realm.users }}
+{{- $newUser := dict 
+  "username" $user.username
+  "enabled" (default true $user.enabled)
+  "totp" false
+  "emailVerified" (default true $user.emailVerified)
+  "firstName" (default "" $user.firstName)
+  "lastName" (default "" $user.lastName)
+  "email" $user.email
+  "attributes" (default dict $user.attributes)
+  "credentials" list
+  "disableableCredentialTypes" list
+  "requiredActions" list
+  "realmRoles" (default (list "default-roles-ichub") $user.realmRoles)
+  "clientRoles" (default dict $user.clientRoles)
+  "notBefore" 0
+  "groups" (default list $user.groups)
+}}
+{{- $_ := set $realmData "users" (append $realmData.users $newUser) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,5 +52,5 @@ metadata:
     app.kubernetes.io/component: keycloak
 data:
   realm-export.json: |
-{{ (.Files.Get "files/realm-export.json") | indent 4 }}
+{{ $realmData | toPrettyJson | indent 4 }}
 {{- end }}

--- a/charts/industry-core-hub/templates/job-realm-import.yaml
+++ b/charts/industry-core-hub/templates/job-realm-import.yaml
@@ -78,8 +78,8 @@ spec:
               with open('/import/realm-export.json', 'r') as f:
                   realm_data = json.load(f)
               
-              # Get password from environment and decode from base64
-              password = base64.b64decode(os.environ['ICHUB_ADMIN_PASSWORD']).decode('utf-8')
+              # Get password from environment (already decoded by Kubernetes)
+              password = os.environ['ICHUB_ADMIN_PASSWORD']
               
               # Generate bcrypt hash (Keycloak uses bcrypt with 10 rounds by default)
               salt = bcrypt.gensalt(rounds=10)

--- a/charts/industry-core-hub/templates/job-realm-import.yaml
+++ b/charts/industry-core-hub/templates/job-realm-import.yaml
@@ -41,72 +41,6 @@ spec:
         app.kubernetes.io/component: keycloak-import
     spec:
       restartPolicy: OnFailure
-      initContainers:
-        - name: prepare-realm
-          image: python:3.11-alpine
-          imagePullPolicy: IfNotPresent
-          env:
-            {{- range $user := .Values.keycloak.realm.users }}
-            - name: {{ $user.username | upper | replace "-" "_" }}_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Release.Name }}-keycloak-realm-users
-                  key: {{ $user.username }}-password
-            {{- end }}
-          volumeMounts:
-            - name: realm-data
-              mountPath: /import
-            - name: processed-realm
-              mountPath: /output
-          command:
-            - /bin/sh
-            - -c
-          args:
-            - |
-              set -e
-              echo "Installing bcrypt library..."
-              pip install bcrypt --quiet
-              
-              echo "Generating password hash..."
-              python3 <<'PYTHON_SCRIPT'
-              import bcrypt
-              import json
-              import os
-              import base64
-              
-              # Read the realm template
-              with open('/import/realm-export.json', 'r') as f:
-                  realm_data = json.load(f)
-              
-              # Get password from environment (already decoded by Kubernetes)
-              password = os.environ['ICHUB_ADMIN_PASSWORD']
-              
-              # Generate bcrypt hash (Keycloak uses bcrypt with 10 rounds by default)
-              salt = bcrypt.gensalt(rounds=10)
-              password_hash = bcrypt.hashpw(password.encode('utf-8'), salt)
-              
-              # Prepare the secretData JSON structure
-              secret_data = {
-                  "value": password_hash.decode('utf-8'),
-                  "salt": base64.b64encode(salt).decode('utf-8'),
-                  "additionalParameters": {}
-              }
-              
-              # Update the user credentials
-              for user in realm_data.get('users', []):
-                  if user.get('username') == 'ichub-admin':
-                      for cred in user.get('credentials', []):
-                          if cred.get('type') == 'password':
-                              cred['secretData'] = json.dumps(secret_data)
-              
-              # Write the processed realm
-              with open('/output/realm-export.json', 'w') as f:
-                  json.dump(realm_data, f, indent=2)
-              
-              print("Password hash generated and realm template processed")
-              PYTHON_SCRIPT
-              
-              echo "Realm template ready for import"
       containers:
         - name: realm-import
           image: curlimages/curl:8.5.0
@@ -118,8 +52,17 @@ spec:
               value: "{{ .Values.keycloak.auth.adminUser }}"
             - name: KEYCLOAK_ADMIN_PASSWORD
               value: "{{ .Values.keycloak.auth.adminPassword }}"
+            {{- range $user := .Values.keycloak.realm.users }}
+            - name: {{ $user.username | upper | replace "-" "_" }}_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-keycloak-realm-users
+                  key: {{ $user.username }}-password
+            - name: {{ $user.username | upper | replace "-" "_" }}_EMAIL
+              value: "{{ $user.email }}"
+            {{- end }}
           volumeMounts:
-            - name: processed-realm
+            - name: realm-data
               mountPath: /import
           command:
             - /bin/sh
@@ -167,7 +110,7 @@ spec:
                 "$KEYCLOAK_URL/auth/admin/realms/$REALM_NAME")
               
               if [ "$REALM_EXISTS" = "200" ]; then
-                echo "Realm '$REALM_NAME' already exists, skipping import"
+                echo "Realm '$REALM_NAME' already exists"
               else
                 echo "Importing realm '$REALM_NAME'..."
                 curl -s -X POST "$KEYCLOAK_URL/auth/admin/realms" \
@@ -183,13 +126,43 @@ spec:
                 fi
               fi
               
-              echo "Realm import process completed!"
+              # Set passwords for all users
+              {{- range $user := .Values.keycloak.realm.users }}
+              echo "Processing user '{{ $user.username }}'..."
+              
+              # Get user ID
+              USER_ID=$(curl -s -X GET "$KEYCLOAK_URL/auth/admin/realms/$REALM_NAME/users?username={{ $user.username }}" \
+                -H "Authorization: Bearer $TOKEN" | \
+                sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
+              
+              if [ -z "$USER_ID" ]; then
+                echo "WARNING: User '{{ $user.username }}' not found in realm, skipping password setup"
+              else
+                echo "Found user '{{ $user.username }}' with ID: $USER_ID"
+                
+                # Set password using Admin API
+                HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+                  "$KEYCLOAK_URL/auth/admin/realms/$REALM_NAME/users/$USER_ID/reset-password" \
+                  -H "Authorization: Bearer $TOKEN" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"type\":\"password\",\"value\":\"${{ $user.username | upper | replace "-" "_" }}_PASSWORD\",\"temporary\":false}")
+                
+                if [ "$HTTP_STATUS" = "204" ]; then
+                  echo "✓ Password set successfully for user '{{ $user.username }}'"
+                else
+                  echo "✗ Failed to set password for user '{{ $user.username }}' (HTTP $HTTP_STATUS)"
+                fi
+              fi
+              echo ""
+              {{- end }}
+              
+              echo "Realm import process completed successfully!"
+          resources:
+            {{- toYaml .Values.keycloak.realmImport.resources | nindent 12 }}
       volumes:
         - name: realm-data
           configMap:
             name: {{ .Release.Name }}-realm-data
-        - name: processed-realm
-          emptyDir: {}
       securityContext:
         runAsNonRoot: false
         runAsUser: 0

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -659,8 +659,9 @@ postgresql:
     port: 5432
     # -- Secret containing the passwords for root usernames postgres and non-root usernames repl_user and ichub.
     existingSecret: "ichub-postgres-secret"
-    # -- Password for the root username 'postgres' (will be stored in a secret if existingSecret is not provided)
-    password: ""
+    # -- Key in the existing secret that contains database password for postgres user
+    secretKeys:
+      adminPasswordKey: "postgres-password"
     # -- Non-root username for ichub.
     ichubUser: "ichub"
     # -- Password for the non-root username 'ichub'. Secret-key 'ichub-password'.
@@ -681,11 +682,6 @@ postgresql:
           secretKeyRef:
             name: "{{ .Values.auth.existingSecret }}"
             key: "ichub-password"
-      - name: "POSTGRES_PASSWORD"
-        valueFrom:
-          secretKeyRef:
-            name: "ichub-postgres-secret"
-            key: "postgres-password"
     persistence:
       # -- Enable persistent storage
       enabled: true

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -776,6 +776,9 @@ keycloak:
     existingSecret: ""
   # -- Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.
   production: false
+  # -- Proxy mode for Keycloak when running behind a reverse proxy (edge, reencrypt, passthrough, or none)
+  # Use 'edge' when running behind a reverse proxy that terminates SSL/TLS
+  proxy: edge
   # -- Setting the path relative to '/' for serving resources:
   # as we're migrating from 16.1.1 version which was using the trailing 'auth', we're setting it to '/auth/'.
   # ref: https://www.keycloak.org/migration/migrating-to-quarkus#_default_context_path_changed
@@ -802,6 +805,16 @@ keycloak:
     enabled: true
     # -- Method: "startup" for --import-realm flag or "job" for post-install job
     method: "job"
+    # -- Resource limits for the realm import job
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: "64Mi"
+      limits:
+        cpu: 500m
+        memory: 256Mi
+        ephemeral-storage: "128Mi"
   # -- Realm user configuration (passwords will be hashed at deployment time)
   realm:
     name: "ICHub"

--- a/ichub-backend/requirements.txt
+++ b/ichub-backend/requirements.txt
@@ -10,7 +10,7 @@ deprecation==2.1.0
 dnspython==2.7.0
 email_validator==2.2.0
 exceptiongroup==1.2.2
-fastapi==0.116.1
+fastapi==0.120.3
 fastapi-cli==0.0.7
 fastapi-keycloak-middleware==1.2.0
 greenlet==3.1.1
@@ -46,9 +46,9 @@ shellingham==1.5.4
 sniffio==1.3.1
 SQLAlchemy==2.0.40
 sqlmodel==0.0.22
-starlette==0.47.2
+starlette==0.49.1
 tomli==2.0.1
-tractusx_sdk==0.5.0
+tractusx_sdk==0.6.0-rc1
 typer==0.15.2
 typing_extensions==4.13.1
 urllib3==2.5.0


### PR DESCRIPTION
## WHAT

This PR updates the `appVersion` value in `Chart.yaml` from `0.3.0-RC2` to `0.3.0-rc2` to match the actual image tags used by the Industry Core Hub frontend and backend.  
This ensures that Helm pulls the correct container images during deployment.

It also fixes several chart template errors.

## WHY

The previous `appVersion` used an uppercase `RC2`, but the real image tags in the registry use a lowercase `rc2`.  
This mismatch caused Helm to attempt pulling non-existent images, resulting in failed deployments.  
Updating the version fixes the issue and aligns the chart with the published images.

Additionally, this PR corrects the chart template errors introduced in PR https://github.com/eclipse-tractusx/industry-core-hub/pull/388

## FURTHER NOTES

No additional changes were made.  
This PR strictly updates the incorrect casing of the `appVersion` field.

Closes #389