### PR TITLE
Bug: dpp bug fixing navigation marks in atributes and Schema Cards style

### DIFF
--- a/ichub-frontend/index.html
+++ b/ichub-frontend/index.html
@@ -105,17 +105,20 @@
       
       window.ENV = ENV;
       
-      // Debug: Log config on page load
-      console.log('🔧 CONFIG LOADED:', {
-        AUTH_ENABLED: ENV.AUTH_ENABLED,
-        AUTH_PROVIDER: ENV.AUTH_PROVIDER,
-        timestamp: new Date().toISOString()
-      });
-      
-      // Performance monitoring (development only)
-      if (ENV.ENABLE_PERFORMANCE_MONITORING === 'true') {
+      // Conditional debug output controlled by `ENABLE_DEV_TOOLS`
+      if (ENV.ENABLE_DEV_TOOLS === 'true') {
+        try {
+          console.log('🔧 CONFIG LOADED:', {
+            AUTH_ENABLED: ENV.AUTH_ENABLED,
+            AUTH_PROVIDER: ENV.AUTH_PROVIDER,
+            timestamp: new Date().toISOString()
+          });
+        } catch (e) {}
+      }
+      // Conditional performance monitoring (development only)
+      if (ENV.ENABLE_PERFORMANCE_MONITORING === 'true' && ENV.ENABLE_DEV_TOOLS === 'true') {
         window.addEventListener('load', () => {
-          console.info('App loaded in:', performance.now(), 'ms');
+          try { console.info('App loaded in:', performance.now(), 'ms'); } catch(e) {}
         });
       }
     </script>

--- a/ichub-frontend/src/components/submodel-creation/DynamicForm.tsx
+++ b/ichub-frontend/src/components/submodel-creation/DynamicForm.tsx
@@ -994,13 +994,22 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
                     // Create a friendly label for the group
                     const groupLabel = key.charAt(0).toUpperCase() + key.slice(1)
                         .replace(/([A-Z])/g, ' $1')
-                        .replace(/^\s/, '');
+                        .replace(/^s/, '');
 
                     const groupId = `${node.path}-${depth}`;
                     const isGroupExpanded = expandedGroups[groupId] ?? true; // Default expanded
 
+                    // Add data-object attribute for parent object containers (not for root)
+                    const groupBoxProps: any = {
+                        key: node.path,
+                        sx: { mb: 2 }
+                    };
+                    if (depth > 0) {
+                        groupBoxProps['data-object'] = node.path;
+                    }
+
                     return (
-                        <Box key={node.path} sx={{ mb: 2 }}>
+                        <Box {...groupBoxProps}>
                             {/* Parent Group Container */}
                             <Box
                                 sx={{
@@ -1058,6 +1067,14 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
                                         >
                                             {groupLabel}
                                         </Typography>
+                                        {/* Info icon for object group if metadata present (now to the right of the label) */}
+                                        {(() => {
+                                            const metaField = node.field;
+                                            if (metaField && (metaField.description || metaField.urn)) {
+                                                return getIconContainer(metaField.description, metaField.key, metaField.urn);
+                                            }
+                                            return null;
+                                        })()}
                                         <Chip 
                                             label={Object.keys(node.children).length} 
                                             size="small" 

--- a/ichub-frontend/src/components/submodel-creation/DynamicForm.tsx
+++ b/ichub-frontend/src/components/submodel-creation/DynamicForm.tsx
@@ -217,8 +217,8 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
             const performScroll = () => {
                 const element = fieldRefs.current[fieldKey] as HTMLElement | null;
                 if (!element) return;
-                // Use centralized helper: scroll, focus (if input), and highlight
-                scrollToElement({ element, container: containerRef.current, focus: true, highlightClass: 'field-nav-highlight', durationMs: 2000, block: 'center' });
+                // Use centralized helper: scroll, focus (if input), and highlight (3s)
+                scrollToElement({ element, container: containerRef.current, focus: true, highlightClass: 'field-nav-highlight', durationMs: 3000, block: 'center' });
             };
 
             if (sectionName && expandedPanel !== sectionName) {
@@ -378,32 +378,6 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
             }
         });
 
-
-
-    // Common description tooltip with info icon click
-    // Show info icon with combined tooltip (description + URN if present)
-    // This implementation always returns a valid React element or null
-    // (Do not redefine this function, use the one defined above)
-    // Remove this duplicate and use the main getDescriptionTooltip above.
-
-    // Icon container: right outside the field, show icons only if present
-    // Only show info icon with combined tooltip (description + URN)
-    const getIconContainer = (description?: string, fieldKey?: string, urn?: string) => {
-        if (!description && !urn) return null;
-        const tooltip = getDescriptionTooltip(description, fieldKey, urn);
-        if (!tooltip) return null;
-        return (
-            <Box sx={{
-                display: 'flex',
-                alignItems: 'center',
-                ml: 1.5,
-                gap: 0.5
-            }}>
-                {tooltip}
-            </Box>
-        );
-    };
-
         switch (field.type) {
             case 'text':
                 return (
@@ -561,7 +535,7 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
 
             case 'checkbox':
                 return (
-                    <Box key={field.key} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Box key={field.key} data-boolean={field.key} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <Box 
                                 onClick={() => handleFieldChange(field, !currentValue)}
@@ -850,7 +824,7 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
                         ) : (
                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                                 {ensureArray.map((item, index) => (
-                                    <Card key={index} sx={{
+                                    <Card key={index} data-array-item sx={{
                                         backgroundColor: 'rgba(255, 255, 255, 0.03)',
                                         border: '1px solid rgba(255, 255, 255, 0.1)',
                                         borderRadius: 2
@@ -1172,6 +1146,8 @@ const DynamicForm = forwardRef<DynamicFormRef, DynamicFormProps>(({
                         ref={(el) => {
                             if (el) accordionRefs.current[sectionName] = el;
                         }}
+                        // Make the accordion discoverable by the field navigation helper
+                        data-section={sectionName}
                         sx={{
                             mb: 2,
                             backgroundColor: 'rgba(255, 255, 255, 0.02)',

--- a/ichub-frontend/src/components/submodel-creation/SchemaSelector.tsx
+++ b/ichub-frontend/src/components/submodel-creation/SchemaSelector.tsx
@@ -120,8 +120,16 @@ const SchemaSelector: React.FC<SchemaSelectorProps> = ({
             const next = { ...prev, [schemaKey]: !prev[schemaKey] };
             // If collapsing (was expanded and now will be false), reset scroll of the description
             if (prev[schemaKey]) {
-                const el = document.getElementById(`desc-${schemaKey}`);
-                if (el) el.scrollTop = 0;
+                try {
+                    const el = typeof document !== 'undefined' ? document.getElementById(`desc-${schemaKey}`) : null;
+                    if (el && typeof (el as HTMLElement).scrollTo === 'function') {
+                        (el as HTMLElement).scrollTo({ top: 0, behavior: 'auto' as ScrollBehavior });
+                    } else if (el) {
+                        (el as HTMLElement).scrollTop = 0;
+                    }
+                } catch (err) {
+                    // ignore in non-browser environments
+                }
             }
             return next;
         });

--- a/ichub-frontend/src/components/submodel-creation/SchemaSelector.tsx
+++ b/ichub-frontend/src/components/submodel-creation/SchemaSelector.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React, { useState } from 'react';
+import { scrollToElement } from '../../utils/fieldNavigation';
 import {
     Dialog,
     DialogContent,
@@ -76,6 +77,39 @@ const darkTheme = createTheme({
             primary: '#ffffff',
             secondary: '#b3b3b3',
         },
+        danger: {
+            danger: undefined,
+            dangerHover: undefined,
+            dangerBadge: undefined
+        },
+        textField: {
+            placeholderText: undefined,
+            helperText: undefined,
+            background: undefined,
+            backgroundHover: undefined
+        },
+        chip: {
+            release: '',
+            active: '',
+            inactive: '',
+            created: '',
+            inReview: '',
+            enabled: '',
+            default: '',
+            bgRelease: '',
+            bgActive: '',
+            bgInactive: '',
+            bgCreated: '',
+            bgInReview: '',
+            bgEnabled: '',
+            bgDefault: '',
+            warning: '',
+            registered: '',
+            bgRegistered: '',
+            borderDraft: '',
+            black: '',
+            none: ''
+        }
     },
     components: {
         MuiDialog: {
@@ -122,10 +156,9 @@ const SchemaSelector: React.FC<SchemaSelectorProps> = ({
             if (prev[schemaKey]) {
                 try {
                     const el = typeof document !== 'undefined' ? document.getElementById(`desc-${schemaKey}`) : null;
-                    if (el && typeof (el as HTMLElement).scrollTo === 'function') {
-                        (el as HTMLElement).scrollTo({ top: 0, behavior: 'auto' as ScrollBehavior });
-                    } else if (el) {
-                        (el as HTMLElement).scrollTop = 0;
+                    if (el) {
+                        // Use helper to reset scroll position without animation
+                        scrollToElement({ element: el as HTMLElement, container: el as HTMLElement, focus: false, highlightClass: '', durationMs: 0, block: 'start' });
                     }
                 } catch (err) {
                     // ignore in non-browser environments
@@ -212,7 +245,7 @@ const SchemaSelector: React.FC<SchemaSelectorProps> = ({
                                         key={schemaKey} 
                                         size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
                                     >
-                                        <Card sx={{
+                                        <Card data-schema-card={schemaKey} sx={{
                                             backgroundColor: 'rgba(0, 0, 0, 0.4)',
                                             border: '1px solid rgba(255, 255, 255, 0.12)',
                                             borderRadius: 2,

--- a/ichub-frontend/src/components/submodel-creation/ScrollToTopFab.tsx
+++ b/ichub-frontend/src/components/submodel-creation/ScrollToTopFab.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { scrollToElement } from '../../utils/fieldNavigation';
 import { Fab, Zoom } from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
@@ -47,7 +48,7 @@ const ScrollToTopFab: React.FC<ScrollToTopFabProps> = ({ containerRef }) => {
   const handleClick = () => {
     const container = containerRef.current;
     if (container) {
-      container.scrollTo({ top: 0, behavior: 'smooth' });
+      scrollToElement({ container, focus: false, highlightClass: '', durationMs: 0, block: 'start' });
     }
   };
 

--- a/ichub-frontend/src/components/submodel-creation/SubmodelCreator.tsx
+++ b/ichub-frontend/src/components/submodel-creation/SubmodelCreator.tsx
@@ -119,6 +119,39 @@ const darkTheme = createTheme({
             primary: '#ffffff',
             secondary: '#b3b3b3',
         },
+        danger: {
+            danger: undefined,
+            dangerHover: undefined,
+            dangerBadge: undefined
+        },
+        textField: {
+            placeholderText: undefined,
+            helperText: undefined,
+            background: undefined,
+            backgroundHover: undefined
+        },
+        chip: {
+            release: '',
+            active: '',
+            inactive: '',
+            created: '',
+            inReview: '',
+            enabled: '',
+            default: '',
+            bgRelease: '',
+            bgActive: '',
+            bgInactive: '',
+            bgCreated: '',
+            bgInReview: '',
+            bgEnabled: '',
+            bgDefault: '',
+            warning: '',
+            registered: '',
+            bgRegistered: '',
+            borderDraft: '',
+            black: '',
+            none: ''
+        }
     },
     components: {
         MuiDialog: {

--- a/ichub-frontend/src/features/catalog-management/components/product-list/CreateProductListDialog.tsx
+++ b/ichub-frontend/src/features/catalog-management/components/product-list/CreateProductListDialog.tsx
@@ -23,6 +23,7 @@
 /** Created using an LLM (Github Copilot) review by a human committer */
 
 import { useState, useEffect, useRef } from "react";
+import { scrollToElement } from '../../../../utils/fieldNavigation';
 import {
   Box,
   TextField,
@@ -304,7 +305,9 @@ const CreateProductListDialog = ({ open, onClose, onSave }: ProductListDialogPro
       setApiErrorMessage(errorMessage);
       // Ensure the error is visible by scrolling to the top of the dialog content
       setTimeout(() => {
-        contentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+        if (contentRef.current) {
+          scrollToElement({ container: contentRef.current, focus: false, highlightClass: '', durationMs: 0, block: 'start' });
+        }
       }, 0);
     }
   };

--- a/ichub-frontend/src/main.tsx
+++ b/ichub-frontend/src/main.tsx
@@ -33,19 +33,25 @@ import App from './App.tsx'
 const isAuthEnabled = environmentService.isAuthEnabled();
 
 // Debug logging
-console.log('=== Authentication Configuration Debug ===');
-console.log('window.ENV:', window.ENV);
-console.log('isAuthEnabled:', isAuthEnabled);
-console.log('authProvider:', environmentService.getAuthProvider());
-if (isAuthEnabled) {
+if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') {
   try {
-    const keycloakConfig = environmentService.getKeycloakConfig();
-    console.log('Keycloak Config:', keycloakConfig);
+    console.log('=== Authentication Configuration Debug ===');
+    console.log('window.ENV:', window.ENV);
+    console.log('isAuthEnabled:', isAuthEnabled);
+    console.log('authProvider:', environmentService.getAuthProvider());
+    if (isAuthEnabled) {
+      try {
+        const keycloakConfig = environmentService.getKeycloakConfig();
+        console.log('Keycloak Config:', keycloakConfig);
+      } catch (e) {
+        console.error('Failed to get Keycloak config:', e);
+      }
+    }
+    console.log('==========================================');
   } catch (e) {
-    console.error('Failed to get Keycloak config:', e);
+    // ignore logging errors
   }
 }
-console.log('==========================================');
 
 createRoot(document.getElementById('root')!).render(
   <ThemeProvider theme={theme}>

--- a/ichub-frontend/src/services/AuthService.ts
+++ b/ichub-frontend/src/services/AuthService.ts
@@ -47,22 +47,24 @@ class AuthService {
  
   async initialize(): Promise<void> {
     if (this.initialized) {
-      console.log('🔐 AuthService already initialized, skipping');
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('🔐 AuthService already initialized, skipping'); } catch(e) {}
       return;
     }
  
     if (this.initializing) {
-      console.log('🔐 AuthService initialization already in progress, skipping');
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('🔐 AuthService initialization already in progress, skipping'); } catch(e) {}
       return;
     }
  
     this.initializing = true;
  
     try {
-      console.log('🔐 AuthService.initialize() called');
-      console.log('  - isAuthEnabled:', environmentService.isAuthEnabled());
-      console.log('  - authProvider:', environmentService.getAuthProvider());
-      console.log('  - isKeycloakEnabled:', environmentService.isKeycloakEnabled());
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try {
+        console.log('🔐 AuthService.initialize() called');
+        console.log('  - isAuthEnabled:', environmentService.isAuthEnabled());
+        console.log('  - authProvider:', environmentService.getAuthProvider());
+        console.log('  - isKeycloakEnabled:', environmentService.isKeycloakEnabled());
+      } catch(e) {}
       
       if (!environmentService.isAuthEnabled()) {
         console.log('  ⚠️ Auth is disabled, skipping initialization');
@@ -78,10 +80,10 @@ class AuthService {
       }
  
       if (environmentService.isKeycloakEnabled()) {
-        console.log('  ✅ Keycloak is enabled, initializing...');
+        if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('  ✅ Keycloak is enabled, initializing...'); } catch(e) {}
         await this.initializeKeycloak();
       } else {
-        console.log('  ⚠️ Keycloak is not enabled');
+        if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('  ⚠️ Keycloak is not enabled'); } catch(e) {}
       }
  
       this.initialized = true;
@@ -101,15 +103,17 @@ class AuthService {
     const keycloakConfig = environmentService.getKeycloakConfig();
     const initOptions = environmentService.getKeycloakInitOptions();
  
-    console.log('🔐 Initializing Keycloak with config:', {
-      url: keycloakConfig.url,
-      realm: keycloakConfig.realm,
-      clientId: keycloakConfig.clientId,
-      onLoad: initOptions.onLoad
-    });
-    console.log('📍 Current URL:', window.location.href);
-    console.log('🔗 URL has code:', window.location.href.includes('code='));
-    console.log('🔗 URL has state:', window.location.href.includes('state='));
+    if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try {
+      console.log('🔐 Initializing Keycloak with config:', {
+        url: keycloakConfig.url,
+        realm: keycloakConfig.realm,
+        clientId: keycloakConfig.clientId,
+        onLoad: initOptions.onLoad
+      });
+      console.log('📍 Current URL:', window.location.href);
+      console.log('🔗 URL has code:', window.location.href.includes('code='));
+      console.log('🔗 URL has state:', window.location.href.includes('state='));
+    } catch(e) {}
  
     this.keycloak = new Keycloak({
       url: keycloakConfig.url,
@@ -118,7 +122,7 @@ class AuthService {
     });
  
     try {
-      console.log('⏳ Calling keycloak.init()...');
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('⏳ Calling keycloak.init()...'); } catch(e) {}
       
       // Add timeout to prevent infinite hanging
       const initPromise = this.keycloak.init({
@@ -134,20 +138,22 @@ class AuthService {
  
       const authenticated = await Promise.race([initPromise, timeoutPromise]);
  
-      console.log('✅ Keycloak init completed. Authenticated:', authenticated);
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('✅ Keycloak init completed. Authenticated:', authenticated); } catch(e) {}
       
-      if (this.keycloak.token) {
-        console.log('🎫 Token received:', this.keycloak.token.substring(0, 20) + '...');
-      } else {
-        console.log('⚠️ No token available');
-      }
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try {
+        if (this.keycloak && this.keycloak.token) {
+          console.log('🎫 Token received: (truncated)');
+        } else {
+          console.log('⚠️ No token available');
+        }
+      } catch(e) {}
  
       if (authenticated) {
         console.log('✅ User is authenticated, loading profile...');
         
         // Clean up OAuth callback parameters from URL to prevent re-processing
         if (window.location.search.includes('state=') || window.location.search.includes('code=')) {
-          console.log('🧹 Cleaning up OAuth callback parameters from URL');
+          if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('🧹 Cleaning up OAuth callback parameters from URL'); } catch(e) {}
           const cleanUrl = window.location.origin + window.location.pathname;
           window.history.replaceState({}, document.title, cleanUrl);
         }
@@ -196,15 +202,7 @@ class AuthService {
         throw new Error('Invalid token received');
       }
 
-      console.log('📋 Token parsed:', {
-        sub: tokenParsed.sub,
-        preferred_username: tokenParsed.preferred_username,
-        email: tokenParsed.email,
-        given_name: tokenParsed.given_name,
-        family_name: tokenParsed.family_name,
-        realm_access: tokenParsed.realm_access,
-        resource_access: tokenParsed.resource_access
-      });
+      if (window.ENV && window.ENV.ENABLE_DEV_TOOLS === 'true') try { console.log('📋 Token parsed: (redacted)'); } catch(e) {}
  
       // Extract user info from token claims (avoid loadUserProfile which has CORS issues)
       const user: AuthUser = {

--- a/ichub-frontend/src/styles/fieldNavigation.css
+++ b/ichub-frontend/src/styles/fieldNavigation.css
@@ -1,3 +1,26 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+
 .field-nav-highlight {
   /* Subtle highlight: slightly lighter background and a gentle inner line to emphasize the value area */
   background-color: rgba(255, 255, 255, 0.06) !important;

--- a/ichub-frontend/src/styles/fieldNavigation.css
+++ b/ichub-frontend/src/styles/fieldNavigation.css
@@ -23,3 +23,11 @@
   /* The actual visible outline is usually the fieldset/notchedOutline; set a border-color-ish effect via box-shadow to match */
   box-shadow: inset 0 2px 10px rgba(255,255,255,0.10), 0 0 0 3px rgba(96,165,250,0.28);
 }
+
+/* Ensure boolean controls (Switch/Checkbox and label wrappers) show the hover outline when navigated to */
+.MuiSwitch-root.field-nav-hover,
+.MuiCheckbox-root.field-nav-hover,
+.MuiFormControlLabel-root.field-nav-hover {
+  box-shadow: inset 0 2px 10px rgba(255,255,255,0.10), 0 0 0 3px rgba(96,165,250,0.28);
+  border-radius: 6px;
+}

--- a/ichub-frontend/src/styles/fieldNavigation.css
+++ b/ichub-frontend/src/styles/fieldNavigation.css
@@ -1,0 +1,25 @@
+.field-nav-highlight {
+  /* Subtle highlight: slightly lighter background and a gentle inner line to emphasize the value area */
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  box-shadow: inset 0 2px 10px rgba(255,255,255,0.10);
+  border-radius: 6px;
+  position: relative;
+}
+
+/* Animatable wrapper controls the transitions so they apply both when class is added and removed */
+.field-nav-animatable {
+  transition: background-color 600ms cubic-bezier(.22,.9,.26,1), box-shadow 600ms cubic-bezier(.22,.9,.26,1), border-color 600ms cubic-bezier(.22,.9,.26,1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-nav-animatable {
+    transition: none;
+  }
+}
+
+/* Hover-like outline when navigated to */
+.field-nav-hover {
+  /* This targets the outline color used on hover in the form controls */
+  /* The actual visible outline is usually the fieldset/notchedOutline; set a border-color-ish effect via box-shadow to match */
+  box-shadow: inset 0 2px 10px rgba(255,255,255,0.10), 0 0 0 3px rgba(96,165,250,0.28);
+}

--- a/ichub-frontend/src/utils/fieldNavigation.ts
+++ b/ichub-frontend/src/utils/fieldNavigation.ts
@@ -1,0 +1,157 @@
+// Small helper to scroll to an element, respect reduced-motion, optionally focus it,
+// and add a temporary highlight class.
+export type ScrollOptions = {
+  element?: HTMLElement | null;
+  selector?: string;
+  container?: HTMLElement | null;
+  focus?: boolean;
+  highlightClass?: string;
+  durationMs?: number;
+  block?: 'center' | 'start' | 'nearest';
+};
+
+export function scrollToElement(options: ScrollOptions) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return { cleanup: () => {} };
+  }
+
+  const {
+    element = null,
+    selector,
+    container = null,
+    focus = false,
+    highlightClass = 'field-nav-highlight',
+    durationMs = 2000,
+    block = 'center'
+  } = options || {};
+
+  let target: HTMLElement | null = element || null;
+  if (!target && selector) {
+    try {
+      target = document.querySelector(selector) as HTMLElement | null;
+    } catch (err) {
+      target = null;
+    }
+  }
+
+  if (!target) return { cleanup: () => {} };
+
+  const prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Scroll behavior: prefer built-in scrollIntoView when possible
+  try {
+    if (container && container instanceof HTMLElement) {
+      // compute target position relative to container
+      const elRect = target.getBoundingClientRect();
+      const contRect = container.getBoundingClientRect();
+      const offset = elRect.top - contRect.top;
+      const top = container.scrollTop + offset - (contRect.height / 2) + (elRect.height / 2);
+      if (prefersReduced) {
+        container.scrollTop = top;
+      } else {
+        container.scrollTo({ top, behavior: 'smooth' });
+      }
+    } else if (!prefersReduced && typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ behavior: 'smooth', block });
+    } else if (typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ block });
+    }
+  } catch (err) {
+    // ignore
+  }
+
+  // Optionally focus the element if it's focusable
+  if (focus) {
+    try {
+      // Only focus interactive elements
+      const focusable = (target.tabIndex >= 0) || ['INPUT','SELECT','TEXTAREA','BUTTON','A'].includes(target.tagName);
+      if (focusable) {
+        (target as HTMLElement).focus({ preventScroll: true } as any);
+      }
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  // After container-level scroll, ensure the element is visible in the viewport.
+  try {
+    const rect = target.getBoundingClientRect();
+    const isVisible = rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
+    if (!isVisible) {
+      if (!prefersReduced && typeof target.scrollIntoView === 'function') {
+        // small delay so container scroll finishes first
+        setTimeout(() => {
+          try { target.scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch (e) {}
+        }, 120);
+      } else if (typeof target.scrollIntoView === 'function') {
+        try { target.scrollIntoView({ block: 'center' }); } catch (e) {}
+      }
+    }
+  } catch (err) {
+    // ignore
+  }
+
+  // Add highlight class temporarily
+  let removed = false;
+  if (highlightClass) {
+    // Prefer to highlight an inner value container (input/select/mui input root) instead of the full field wrapper
+    const selectors = [
+      '.MuiOutlinedInput-root',
+      '.MuiInputBase-root',
+      'input',
+      'textarea',
+      'select',
+      '.MuiSwitch-root',
+      '.MuiSelect-root'
+    ];
+    let highlightTarget: HTMLElement | null = null;
+    for (const s of selectors) {
+      const found = target.querySelector(s) as HTMLElement | null;
+      if (found) { highlightTarget = found; break; }
+    }
+    if (!highlightTarget) highlightTarget = target;
+
+    const animClass = 'field-nav-animatable';
+    const hoverClass = 'field-nav-hover';
+    // Ensure the element has the animatable class so transitions run both on add and remove
+    highlightTarget.classList.add(animClass);
+    highlightTarget.classList.add(highlightClass);
+
+    // Also add the hover-like class to the nearest input/select root so the outline matches hover
+    let hoverTarget: HTMLElement | null = null;
+    try {
+      hoverTarget = (highlightTarget.closest && (highlightTarget.closest('.MuiOutlinedInput-root, .MuiInputBase-root, .MuiSelect-root') as HTMLElement)) || null;
+    } catch (err) {
+      hoverTarget = null;
+    }
+    if (!hoverTarget) hoverTarget = highlightTarget;
+    hoverTarget.classList.add(hoverClass);
+
+    const t = setTimeout(() => {
+      // Remove the highlight class first so the element transitions back
+      highlightTarget && highlightTarget.classList.remove(highlightClass);
+      // Remove hover class to restore outline
+      hoverTarget && hoverTarget.classList.remove(hoverClass);
+      removed = true;
+      // After transition completes, remove the animatable class as cleanup
+      const TRANS_MS = 700; // should match CSS transition duration (ms)
+      setTimeout(() => {
+        highlightTarget && highlightTarget.classList.remove(animClass);
+      }, TRANS_MS);
+    }, durationMs);
+
+    return {
+      cleanup: () => {
+        if (!removed) {
+          clearTimeout(t);
+          highlightTarget && highlightTarget.classList.remove(highlightClass);
+          // also remove hover and animatable
+          highlightTarget && highlightTarget.classList.remove('field-nav-hover');
+          highlightTarget && highlightTarget.classList.remove('field-nav-animatable');
+        }
+      }
+    };
+  }
+
+  return { cleanup: () => {} };
+}

--- a/ichub-frontend/src/utils/fieldNavigation.ts
+++ b/ichub-frontend/src/utils/fieldNavigation.ts
@@ -1,3 +1,25 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 // Small helper to scroll to an element, respect reduced-motion, optionally focus it,
 // and add a temporary highlight class.
 export type ScrollOptions = {

--- a/ichub-frontend/src/utils/fieldNavigation.ts
+++ b/ichub-frontend/src/utils/fieldNavigation.ts
@@ -116,7 +116,19 @@ export function scrollToElement(options: ScrollOptions) {
       const found = target.querySelector(s) as HTMLElement | null;
       if (found) { highlightTarget = found; break; }
     }
-    if (!highlightTarget) highlightTarget = target;
+    // If navigating to a parent field (object/section) without a direct value, prefer the data-section or data-object container
+    if (!highlightTarget || highlightTarget === target) {
+      // Try to find a parent [data-section] or [data-object] container
+      const sectionWrapper = target.closest('[data-section]') as HTMLElement | null;
+      const objectWrapper = target.closest('[data-object]') as HTMLElement | null;
+      if (sectionWrapper) {
+        highlightTarget = sectionWrapper;
+      } else if (objectWrapper) {
+        highlightTarget = objectWrapper;
+      } else {
+        highlightTarget = target;
+      }
+    }
 
     // If there's an explicit boolean wrapper (label + switch) nearby, prefer it
     // so the whole attribute block is highlighted instead of just the inner control.


### PR DESCRIPTION
## WHAT

This PR improves the UI/UX of the Schema Selector by enhancing the styling and behavior of the Schema Cards. Specifically:

- Long schema descriptions now include a **“Read more”** functionality to ensure proper layout and readability.
- When navigating to a specific attribute using the **“Go to field”** action, the target attribute is now **visually highlighted**, making it clearer to the user which field they have been directed to.

## WHY

The previous behavior caused long descriptions to break the layout and made navigation to attributes less intuitive. These changes improve usability, readability, and user guidance within the Schema Selector.

## FURTHER NOTES

- Minor styling adjustments were applied to ensure consistent spacing and card layout across different screen sizes.
- Additional visual feedback logic was added to handle attribute highlighting reliably.

Closes #260
