### PR TITLE
fix: allows manufacturer part id with space

### DIFF
--- a/ichub-frontend/src/features/catalog-management/api.ts
+++ b/ichub-frontend/src/features/catalog-management/api.ts
@@ -43,7 +43,7 @@ export const fetchCatalogPart = async (
   manufacturerPartId: string
 ): Promise<ApiPartData> => {
   const response = await httpClient.get<ApiPartData>(
-    `${backendUrl}${catalogManagementConfig.api.endpoints.CATALOG_PARTS}/${manufacturerId}/${manufacturerPartId}`
+    `${backendUrl}${catalogManagementConfig.api.endpoints.CATALOG_PARTS}/${manufacturerId}/${encodeURIComponent(manufacturerPartId)}`
   );
   return response.data;
 };
@@ -95,7 +95,7 @@ export const fetchCatalogPartTwinDetails = async (
   try {
     
     const response = await httpClient.get<CatalogPartTwinDetailsRead>(
-      `${backendUrl}/twin-management/catalog-part-twin/${manufacturerId}/${manufacturerPartId}`
+      `${backendUrl}/twin-management/catalog-part-twin/${manufacturerId}/${encodeURIComponent(manufacturerPartId)}`
     );
     
     return response.data;

--- a/ichub-frontend/src/features/catalog-management/pages/ProductsList.tsx
+++ b/ichub-frontend/src/features/catalog-management/pages/ProductsList.tsx
@@ -82,7 +82,9 @@ const ProductsList = () => {
   }, []);
 
   const handleButtonClick = (partId: string) => {
-    navigate(`/product/${partId}`); // Navigate to the details page
+    // partId is typically manufacturerId/manufacturerPartId
+    const [manufacturerId, manufacturerPartId] = partId.split('/');
+    navigate(`/product/${manufacturerId}/${encodeURIComponent(manufacturerPartId)}`); // Navigate to the details page
   };
 
   const handleShareDialog = (


### PR DESCRIPTION
## WHAT

This PR updates the handling of ManufacturerPartID so that values containing trailing spaces are properly encoded. This ensures that parts created with a ManufacturerPartID ending in a space can be displayed correctly without breaking the URL.

## WHY

Previously, when creating a part with a ManufacturerPartID that included a trailing space, the application failed to display the part because the URL was not being encoded. This PR addresses that issue by ensuring the ManufacturerPartID is encoded or parsed correctly, preventing invalid URLs and enabling proper navigation.

## FURTHER NOTES

Previous behavior when attempting to access a Part with a trailing space:
<img width="1919" height="979" alt="image" src="https://github.com/user-attachments/assets/ec4cca54-8601-4908-81a0-d530218e6f19" />

Changes applied:Behavior after applying the changes:
<img width="1919" height="979" alt="image" src="https://github.com/user-attachments/assets/570450bf-01db-49b0-b4d7-9a145c5fbc11" />


Closes #343
