### PR TITLE
fix: Add environment variables for OCI dependency handling

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -60,32 +60,69 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre-pull OCI dependencies
+        env:
+          REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
+          REGISTRY_PASS: ${{ secrets.DOCKER_HUB_TOKEN }}
         run: |
           export HELM_EXPERIMENTAL_OCI=1
 
           chart="charts/industry-core-hub/Chart.yaml"
+          found_oci=0
 
-          oci_block=$(awk '
-            /- name:/ {current=""}
-            /repository: oci:\/\// {current=1}
-            current {print}
-          ' "$chart")
-
-          repo=$(echo "$oci_block"   | grep "repository:" | awk '{print $2}')
-          alias=$(echo "$oci_block"  | grep "alias:"      | awk '{print $2}')
-          version=$(echo "$oci_block"| grep "version:"    | awk '{print $2}')
-
+          # Initialize variables
+          oci_repo=""
+          oci_version=""
+          oci_name=""
+          
+          # Temporary variables
+          temp_repo=""
+          temp_ver=""
+          temp_name=""
+          
+          # Read file line by line
+          while IFS= read -r line; do
+            # 1. Detect start of new dependency block
+            if [[ "$line" =~ ^[[:space:]]*-[[:space:]] ]]; then
+              if [[ "$found_oci" -eq 1 ]]; then break; fi
+              temp_repo=""
+              temp_ver=""
+              temp_name=""
+            fi
+          
+            # 2. Extract values
+            if [[ "$line" =~ repository:[[:space:]]*(.*) ]]; then temp_repo="${BASH_REMATCH[1]}"; fi
+            if [[ "$line" =~ version:[[:space:]]*(.*) ]]; then temp_ver="${BASH_REMATCH[1]}"; fi
+            if [[ "$line" =~ name:[[:space:]]*(.*) ]]; then temp_name="${BASH_REMATCH[1]}"; fi
+          
+            # 3. Check for OCI
+            if [[ "$temp_repo" == oci://* ]]; then
+              found_oci=1
+              oci_repo="$temp_repo"
+              oci_version="$temp_ver"
+              oci_name="$temp_name"
+            fi
+          done < "$chart"
+          
+          # Clean up variables
+          repo=$(echo "$oci_repo" | tr -d ' "')
+          version=$(echo "$oci_version" | tr -d ' "')
+          name=$(echo "$oci_name" | tr -d ' "')
+          
           if [[ -n "$repo" ]]; then
-            echo "Found OCI dependency: $alias $version from $repo"
-
+            echo "Found OCI dependency: $name $version from $repo"
             mkdir -p charts/industry-core-hub/charts
-
-            helm pull "$repo/postgres" \
+          
+            # Login using the environment variables defined above
+            registry_domain=$(echo "$repo" | sed -E 's|oci://([^/]+).*|\1|')
+            echo "Logging into $registry_domain..."
+            
+            echo "$REGISTRY_PASS" | helm registry login "$registry_domain" --username "$REGISTRY_USER" --password-stdin
+          
+            # Pull the chart
+            helm pull "${repo}/${name}" \
               --version "$version" \
               --untar \
-              --untardir charts/industry-core-hub/charts \
-              --username ${{ secrets.DOCKER_HUB_USER }} \
-              --password ${{ secrets.DOCKER_HUB_TOKEN }}
+              --untardir charts/industry-core-hub/charts
           else
             echo "No OCI dependencies found."
           fi


### PR DESCRIPTION
## WHAT

Updates the GitHub Actions workflow script to correctly parse and pull OCI-based Helm dependencies.

## WHY

The previous script was too "greedy" when parsing Chart.yaml. It aggregated the versions of all dependencies (Postgres, Keycloak, PgAdmin) into a single variable (e.g., 0.11.0 1.25.x 23.0.0), causing the helm pull command to fail with an "invalid URL" error.

This change ensures the script correctly identifies the single OCI dependency block, stops reading, and constructs the download URL correctly.


