### PR TITLE
feat: CCM-04-FE Create share dialog mock

### DIFF
--- a/ichub-frontend/src/features/ccm-kit/certificate-management/components/dialogs/ShareCertificateDialog.tsx
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/components/dialogs/ShareCertificateDialog.tsx
@@ -28,16 +28,26 @@ import {
   DialogActions,
   Button,
   TextField,
-  FormControl,
-  FormLabel,
-  RadioGroup,
-  FormControlLabel,
-  Radio,
   Typography,
-  Box
+  Box,
+  Chip,
+  IconButton,
+  MenuItem
 } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import { ShareCertificateDialogProps } from '../../types/dialog-types';
 import { certificateManagementConfig } from '../../config';
+import { PartnerAutocomplete } from '@/features/business-partner-kit/partner-management/components';
+import { fetchPartners } from '@/features/business-partner-kit/partner-management/api';
+import { PartnerInstance } from '@/features/business-partner-kit/partner-management/types/types';
+
+// Mock access policies - in real implementation these would come from EDC
+const ACCESS_POLICIES = [
+  { value: 'default', label: 'Default Policy' },
+  { value: 'restricted', label: 'Restricted Access' },
+  { value: 'membership', label: 'Membership Verification' },
+  { value: 'framework', label: 'Framework Agreement' }
+];
 
 export const ShareCertificateDialog = ({
   open,
@@ -47,13 +57,48 @@ export const ShareCertificateDialog = ({
   defaultMethod = 'PULL'
 }: ShareCertificateDialogProps) => {
   const [partnerBpn, setPartnerBpn] = useState('');
-  const [method, setMethod] = useState<'PULL' | 'PUSH'>(defaultMethod);
+  const [companyName, setCompanyName] = useState('');
+  const [accessPolicy, setAccessPolicy] = useState('');
+  const [message, setMessage] = useState('');
+  const [method] = useState<'PULL' | 'PUSH'>(defaultMethod);
   const [error, setError] = useState('');
 
-  // Update method when defaultMethod changes
+  // Partner autocomplete state
+  const [partnersList, setPartnersList] = useState<PartnerInstance[]>([]);
+  const [selectedPartner, setSelectedPartner] = useState<PartnerInstance | null>(null);
+  const [isLoadingPartners, setIsLoadingPartners] = useState(false);
+  const [partnersError, setPartnersError] = useState(false);
+
+  /**
+   * Load available partners from the API
+   */
+  const loadPartners = async () => {
+    setIsLoadingPartners(true);
+    setPartnersError(false);
+    try {
+      const data = await fetchPartners();
+      setPartnersList(data);
+    } catch (err) {
+      console.error('Error fetching partners:', err);
+      setPartnersList([]);
+      setPartnersError(true);
+    } finally {
+      setIsLoadingPartners(false);
+    }
+  };
+
+  // Reset form and load partners when dialog opens
   useEffect(() => {
-    setMethod(defaultMethod);
-  }, [defaultMethod, open]);
+    if (open) {
+      setPartnerBpn('');
+      setCompanyName('');
+      setSelectedPartner(null);
+      setAccessPolicy('');
+      setMessage('');
+      setError('');
+      loadPartners();
+    }
+  }, [open, defaultMethod]);
 
   const handleShare = () => {
     if (!partnerBpn.trim()) {
@@ -72,76 +117,208 @@ export const ShareCertificateDialog = ({
 
   const handleClose = () => {
     setPartnerBpn('');
-    setMethod('PULL');
+    setCompanyName('');
+    setSelectedPartner(null);
+    setAccessPolicy('');
+    setMessage('');
     setError('');
     onClose();
   };
 
+  /**
+   * Get certificate type label
+   */
+  const getCertificateTypeLabel = (type: string) => {
+    const typeConfig = certificateManagementConfig.certificateTypes.find(t => t.value === type);
+    return typeConfig?.label || type;
+  };
+
+  // Get certificate type and status from extended certificate prop
+  const certificateType = (certificate as { type?: string })?.type || 'ISO9001';
+  const certificateStatus = (certificate as { status?: string })?.status || 'valid';
+
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Share Certificate</DialogTitle>
-      <DialogContent>
+    <Dialog 
+      open={open} 
+      onClose={handleClose} 
+      maxWidth="md" 
+      fullWidth
+      PaperProps={{
+        sx: { borderRadius: 2, maxWidth: 600 }
+      }}
+    >
+      <DialogTitle 
+        sx={{ 
+          backgroundColor: '#4caf50',
+          color: 'white',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          py: 2,
+          px: 3
+        }}
+      >
+        <Typography variant="h6" fontWeight={600} sx={{ color: 'white' }}>
+          Share Certificate
+        </Typography>
+        <IconButton 
+          onClick={handleClose} 
+          size="small"
+          sx={{ color: 'white' }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: '24px !important', px: 3 }}>
+        {/* Certificate Info Card */}
         {certificate && (
-          <Box sx={{ mb: 3 }}>
-            <Typography variant="body2" color="textSecondary">
-              Sharing certificate:
-            </Typography>
-            <Typography variant="subtitle1" fontWeight={600}>
-              {certificate.name}
-            </Typography>
+          <Box 
+            sx={{ 
+              backgroundColor: '#e8f5e9',
+              borderRadius: 2,
+              p: 2,
+              mb: 3,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2
+            }}
+          >
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="body1" fontWeight={500}>
+                {certificate.name}
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Chip 
+                  label={getCertificateTypeLabel(certificateType)}
+                  size="small"
+                  sx={{ 
+                    backgroundColor: '#bbdefb',
+                    color: '#1565c0',
+                    fontWeight: 500,
+                    fontSize: '0.75rem'
+                  }}
+                />
+                <Chip 
+                  label={certificateStatus.charAt(0).toUpperCase() + certificateStatus.slice(1)}
+                  size="small"
+                  sx={{ 
+                    backgroundColor: certificateStatus === 'valid' ? '#c8e6c9' : '#fff9c4',
+                    color: certificateStatus === 'valid' ? '#2e7d32' : '#f57f17',
+                    fontWeight: 500,
+                    fontSize: '0.75rem'
+                  }}
+                />
+              </Box>
+            </Box>
           </Box>
         )}
 
+        {/* Partner BPN Field */}
+        <Box sx={{ mb: 2.5 }}>
+          <PartnerAutocomplete
+            value={partnerBpn}
+            availablePartners={partnersList}
+            selectedPartner={selectedPartner}
+            isLoadingPartners={isLoadingPartners}
+            partnersError={partnersError}
+            hasError={!!error}
+            label="Partner BPN"
+            placeholder="Search partner by BPN..."
+            helperText="Select the partner to share the certificate with"
+            errorMessage={error || 'Partner BPN is required'}
+            onBpnlChange={(bpnl) => {
+              setPartnerBpn(bpnl);
+              if (error) {
+                setError('');
+              }
+            }}
+            onPartnerChange={(partner) => {
+              setSelectedPartner(partner);
+              if (partner) {
+                setPartnerBpn(partner.bpnl);
+                setCompanyName(partner.name);
+              } else {
+                setCompanyName('');
+              }
+            }}
+            onRetryLoadPartners={loadPartners}
+          />
+        </Box>
+
+        {/* Company Name (Auto-filled) */}
         <TextField
           fullWidth
-          label="Partner BPN"
-          value={partnerBpn}
-          onChange={(e) => {
-            setPartnerBpn(e.target.value);
-            setError('');
+          label="Company Name"
+          value={companyName}
+          placeholder="Auto-filled from selected partner"
+          disabled
+          sx={{ 
+            mb: 2.5,
+            '& .MuiInputBase-input.Mui-disabled': {
+              WebkitTextFillColor: companyName ? 'inherit' : 'rgba(0, 0, 0, 0.38)'
+            }
           }}
-          error={!!error}
-          helperText={error}
-          placeholder="BPNL..."
-          sx={{ mb: 3 }}
         />
 
-        <FormControl component="fieldset">
-          <FormLabel component="legend">Sharing Method</FormLabel>
-          <RadioGroup
-            value={method}
-            onChange={(e) => setMethod(e.target.value as 'PULL' | 'PUSH')}
-          >
-            <FormControlLabel
-              value="PULL"
-              control={<Radio />}
-              label={
-                <Box>
-                  <Typography variant="body1">EDC Pull</Typography>
-                  <Typography variant="caption" color="textSecondary">
-                    Partner will pull the certificate via EDC connector
-                  </Typography>
-                </Box>
-              }
-            />
-            <FormControlLabel
-              value="PUSH"
-              control={<Radio />}
-              label={
-                <Box>
-                  <Typography variant="body1">Notification Push</Typography>
-                  <Typography variant="caption" color="textSecondary">
-                    Certificate will be sent to partner via notification
-                  </Typography>
-                </Box>
-              }
-            />
-          </RadioGroup>
-        </FormControl>
+        {/* Access Policy */}
+        <TextField
+          fullWidth
+          select
+          label="Access Policy"
+          value={accessPolicy}
+          onChange={(e) => setAccessPolicy(e.target.value)}
+          placeholder="Select policy..."
+          helperText="EDC contract policy for data sharing"
+          sx={{ mb: 2.5 }}
+        >
+          <MenuItem value="">
+            <em>Select policy...</em>
+          </MenuItem>
+          {ACCESS_POLICIES.map((policy) => (
+            <MenuItem key={policy.value} value={policy.value}>
+              {policy.label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        {/* Message (Optional) */}
+        <TextField
+          fullWidth
+          label="Message (optional)"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          multiline
+          rows={3}
+          placeholder="Add a message for the partner..."
+        />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleShare} variant="contained" color="primary">
+
+      <DialogActions sx={{ px: 3, pb: 3, pt: 2, gap: 1 }}>
+        <Button 
+          onClick={handleClose}
+          variant="outlined"
+          sx={{ 
+            textTransform: 'none',
+            minWidth: 100,
+            borderRadius: 1
+          }}
+        >
+          Cancel
+        </Button>
+        <Button 
+          onClick={handleShare} 
+          variant="contained"
+          sx={{ 
+            textTransform: 'none',
+            minWidth: 100,
+            borderRadius: 1,
+            backgroundColor: '#4caf50',
+            '&:hover': {
+              backgroundColor: '#388e3c'
+            }
+          }}
+        >
           Share
         </Button>
       </DialogActions>

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/components/dialogs/ShareCertificateDialog.tsx
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/components/dialogs/ShareCertificateDialog.tsx
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -43,11 +43,17 @@ export const ShareCertificateDialog = ({
   open,
   onClose,
   certificate,
-  onShare
+  onShare,
+  defaultMethod = 'PULL'
 }: ShareCertificateDialogProps) => {
   const [partnerBpn, setPartnerBpn] = useState('');
-  const [method, setMethod] = useState<'PULL' | 'PUSH'>('PULL');
+  const [method, setMethod] = useState<'PULL' | 'PUSH'>(defaultMethod);
   const [error, setError] = useState('');
+
+  // Update method when defaultMethod changes
+  useEffect(() => {
+    setMethod(defaultMethod);
+  }, [defaultMethod, open]);
 
   const handleShare = () => {
     if (!partnerBpn.trim()) {

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/pages/CertificateDetail.tsx
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/pages/CertificateDetail.tsx
@@ -1,0 +1,526 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Paper,
+  Grid2,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Alert,
+  Snackbar
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import DownloadIcon from '@mui/icons-material/Download';
+import ShareIcon from '@mui/icons-material/Share';
+import SendIcon from '@mui/icons-material/Send';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import { Certificate, SharingRecord } from '../types/types';
+import { fetchCertificateById, revokeShare } from '../api';
+import { certificateManagementConfig } from '../config';
+import { ShareCertificateDialog } from '../components/dialogs/ShareCertificateDialog';
+import { DeleteCertificateDialog } from '../components/dialogs/DeleteCertificateDialog';
+import LoadingSpinner from '@/components/general/LoadingSpinner';
+
+/**
+ * Certificate Detail Page
+ * Displays full certificate information, attached file, and sharing history
+ */
+const CertificateDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  // State
+  const [certificate, setCertificate] = useState<Certificate | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Dialog states
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [shareMethod, setShareMethod] = useState<'PULL' | 'PUSH'>('PULL');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  // Snackbar state
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+
+  /**
+   * Load certificate data
+   */
+  const loadCertificate = useCallback(async () => {
+    if (!id) return;
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await fetchCertificateById(id);
+      if (data) {
+        setCertificate(data);
+      } else {
+        setError('Certificate not found');
+      }
+    } catch (err) {
+      console.error('Error loading certificate:', err);
+      setError('Failed to load certificate details');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadCertificate();
+  }, [loadCertificate]);
+
+  /**
+   * Get status chip color
+   */
+  const getStatusColor = (status: string) => {
+    const config = certificateManagementConfig.statusConfig[status as keyof typeof certificateManagementConfig.statusConfig];
+    return config?.color || '#666';
+  };
+
+  /**
+   * Get certificate type label
+   */
+  const getCertificateTypeLabel = (type: string) => {
+    const typeConfig = certificateManagementConfig.certificateTypes.find(t => t.value === type);
+    return typeConfig?.label || type;
+  };
+
+  /**
+   * Format date for display
+   */
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  };
+
+  /**
+   * Handle back navigation
+   */
+  const handleBack = () => {
+    navigate('/certificates');
+  };
+
+  /**
+   * Handle download document
+   */
+  const handleDownload = () => {
+    if (certificate?.documentUrl) {
+      window.open(certificate.documentUrl, '_blank');
+    } else if (certificate?.documentBase64) {
+      // Create download from base64
+      const link = document.createElement('a');
+      link.href = `data:application/pdf;base64,${certificate.documentBase64}`;
+      link.download = `${certificate.name}.pdf`;
+      link.click();
+    } else {
+      setSnackbar({ open: true, message: 'No document available for download', severity: 'error' });
+    }
+  };
+
+  /**
+   * Handle share certificate (Pull method)
+   */
+  const handleSharePull = () => {
+    setShareMethod('PULL');
+    setShareDialogOpen(true);
+  };
+
+  /**
+   * Handle send certificate (Push method)
+   */
+  const handleSendPush = () => {
+    setShareMethod('PUSH');
+    setShareDialogOpen(true);
+  };
+
+  /**
+   * Handle share submission
+   */
+  const handleShareSubmit = async (_certificateId: string, _partnerBpn: string, _method: 'PULL' | 'PUSH') => {
+    // TODO: Implement share logic
+    setSnackbar({ open: true, message: 'Certificate shared successfully!', severity: 'success' });
+    setShareDialogOpen(false);
+    loadCertificate();
+  };
+
+  /**
+   * Handle delete certificate
+   */
+  const handleDelete = () => {
+    setDeleteDialogOpen(true);
+  };
+
+  /**
+   * Handle delete confirmation
+   */
+  const handleDeleteConfirm = async (_certificateId: string) => {
+    // TODO: Implement delete logic
+    setSnackbar({ open: true, message: 'Delete functionality not yet available.', severity: 'error' });
+    setDeleteDialogOpen(false);
+  };
+
+  /**
+   * Handle revoke share
+   */
+  const handleRevokeShare = async (shareId: string) => {
+    if (!certificate) return;
+
+    try {
+      await revokeShare(certificate.id, shareId);
+      setSnackbar({ open: true, message: 'Share revoked successfully!', severity: 'success' });
+      loadCertificate();
+    } catch (err) {
+      console.error('Error revoking share:', err);
+      setSnackbar({ open: true, message: 'Failed to revoke share.', severity: 'error' });
+    }
+  };
+
+  /**
+   * Get method chip color
+   */
+  const getMethodColor = (method: 'PULL' | 'PUSH') => {
+    return method === 'PULL' ? '#2196f3' : '#ff9800';
+  };
+
+  /**
+   * Get share status chip color
+   */
+  const getShareStatusColor = (status: string) => {
+    switch (status) {
+      case 'Active': return '#4caf50';
+      case 'Pending': return '#ff9800';
+      case 'Revoked': return '#f44336';
+      default: return '#666';
+    }
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error || !certificate) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={handleBack}
+          sx={{ mb: 2, textTransform: 'none' }}
+        >
+          Back to list
+        </Button>
+        <Alert severity="error">{error || 'Certificate not found'}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="certificate-detail" sx={{ p: 3 }}>
+      {/* Back Link */}
+      <Button
+        variant="text"
+        startIcon={<ArrowBackIcon />}
+        onClick={handleBack}
+        sx={{ mb: 3, textTransform: 'none', color: 'info.main' }}
+      >
+        Back to list
+      </Button>
+
+      {/* Header: Certificate Name + Status */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+        <Typography variant="h5" fontWeight={500} sx={{ color: 'white' }}>
+          {certificate.name}
+        </Typography>
+        <Chip
+          label={certificate.status.charAt(0).toUpperCase() + certificate.status.slice(1)}
+          size="medium"
+          sx={{
+            backgroundColor: getStatusColor(certificate.status),
+            color: 'white',
+            fontWeight: 600,
+            borderRadius: 1,
+            px: 1
+          }}
+        />
+      </Box>
+
+      {/* Main Content: Two Columns */}
+      <Grid2 container spacing={3}>
+        {/* Left Column: Certificate Information */}
+        <Grid2 size={{ xs: 12, md: 7 }}>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+            <Typography variant="h6" fontWeight={600} sx={{ mb: 3 }}>
+              Certificate Information
+            </Typography>
+
+            <Grid2 container spacing={2.5}>
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">Type:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2">{getCertificateTypeLabel(certificate.type)}</Typography>
+              </Grid2>
+
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">Issuer:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2">{certificate.issuer}</Typography>
+              </Grid2>
+
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">BPN:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{certificate.bpn}</Typography>
+              </Grid2>
+
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">Valid From:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2">{formatDate(certificate.validFrom)}</Typography>
+              </Grid2>
+
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">Valid Until:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2">{formatDate(certificate.validUntil)}</Typography>
+              </Grid2>
+
+              <Grid2 size={3}>
+                <Typography variant="body2" color="text.secondary">Description:</Typography>
+              </Grid2>
+              <Grid2 size={9}>
+                <Typography variant="body2" sx={{ color: certificate.description ? 'text.primary' : 'text.disabled' }}>
+                  {certificate.description || 'No description provided'}
+                </Typography>
+              </Grid2>
+            </Grid2>
+          </Paper>
+        </Grid2>
+
+        {/* Right Column: Attached File + Actions */}
+        <Grid2 size={{ xs: 12, md: 5 }}>
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+            <Typography variant="h6" fontWeight={600} sx={{ mb: 3 }}>
+              Attached File
+            </Typography>
+
+            <Grid2 container spacing={2}>
+              {/* File Preview */}
+              <Grid2 size={7}>
+                <Box
+                  sx={{
+                    backgroundColor: '#f5f5f5',
+                    borderRadius: 2,
+                    p: 4,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: 180
+                  }}
+                >
+                  <DescriptionOutlinedIcon sx={{ fontSize: 48, color: '#90caf9', mb: 1 }} />
+                  <Typography variant="body2" color="text.secondary">
+                    certificate.pdf
+                  </Typography>
+                </Box>
+              </Grid2>
+
+              {/* Action Buttons */}
+              <Grid2 size={5}>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                  <Button
+                    variant="outlined"
+                    startIcon={<DownloadIcon />}
+                    onClick={handleDownload}
+                    fullWidth
+                    sx={{ textTransform: 'none', justifyContent: 'flex-start' }}
+                  >
+                    Download
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    startIcon={<ShareIcon />}
+                    onClick={handleSharePull}
+                    fullWidth
+                    sx={{ textTransform: 'none', justifyContent: 'flex-start' }}
+                  >
+                    Share (Pull)
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="warning"
+                    startIcon={<SendIcon />}
+                    onClick={handleSendPush}
+                    fullWidth
+                    sx={{ textTransform: 'none', justifyContent: 'flex-start' }}
+                  >
+                    Send (Push)
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    startIcon={<DeleteOutlineIcon />}
+                    onClick={handleDelete}
+                    fullWidth
+                    sx={{ textTransform: 'none', justifyContent: 'flex-start' }}
+                  >
+                    Delete
+                  </Button>
+                </Box>
+              </Grid2>
+            </Grid2>
+          </Paper>
+        </Grid2>
+      </Grid2>
+
+      {/* Sharing History Table */}
+      <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, mt: 3 }}>
+        <Typography variant="h6" fontWeight={600} sx={{ mb: 3 }}>
+          Sharing History
+        </Typography>
+
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: '#f5f9ff' }}>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Shared With (BPN)</TableCell>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Company Name</TableCell>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Shared Date</TableCell>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Method</TableCell>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Status</TableCell>
+                <TableCell sx={{ fontWeight: 600, color: 'primary.main' }}>Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {certificate.sharingRecords && certificate.sharingRecords.length > 0 ? (
+                certificate.sharingRecords.map((record: SharingRecord) => (
+                  <TableRow key={record.id} hover>
+                    <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
+                      {record.partnerBpn}
+                    </TableCell>
+                    <TableCell>{record.partnerName || '-'}</TableCell>
+                    <TableCell>{formatDate(record.sharedDate)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        label={record.method}
+                        size="small"
+                        sx={{
+                          backgroundColor: `${getMethodColor(record.method)}20`,
+                          color: getMethodColor(record.method),
+                          fontWeight: 500,
+                          fontSize: '0.75rem'
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={record.status}
+                        size="small"
+                        sx={{
+                          backgroundColor: `${getShareStatusColor(record.status)}20`,
+                          color: getShareStatusColor(record.status),
+                          fontWeight: 500,
+                          fontSize: '0.75rem'
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {record.status === 'Active' && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          color="error"
+                          onClick={() => handleRevokeShare(record.id)}
+                          sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                    This certificate has not been shared yet
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      {/* Dialogs */}
+      <ShareCertificateDialog
+        open={shareDialogOpen}
+        onClose={() => setShareDialogOpen(false)}
+        certificate={certificate}
+        onShare={handleShareSubmit}
+        defaultMethod={shareMethod}
+      />
+
+      <DeleteCertificateDialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        certificate={certificate}
+        onConfirm={handleDeleteConfirm}
+      />
+
+      {/* Snackbar */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default CertificateDetail;

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/pages/CertificateManagement.tsx
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/pages/CertificateManagement.tsx
@@ -21,6 +21,7 @@
  ********************************************************************************/
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Box,
   Typography,
@@ -47,7 +48,6 @@ import { StatsCard } from '../components/certificate-list/StatsCard';
 import { CertificateTable } from '../components/certificate-list/CertificateTable';
 import { UploadCertificateDialog } from '../components/dialogs/UploadCertificateDialog';
 import { ShareCertificateDialog } from '../components/dialogs/ShareCertificateDialog';
-import { ViewCertificateDialog } from '../components/dialogs/ViewCertificateDialog';
 import { DeleteCertificateDialog } from '../components/dialogs/DeleteCertificateDialog';
 import LoadingSpinner from '@/components/general/LoadingSpinner';
 
@@ -73,6 +73,8 @@ function TabPanel(props: TabPanelProps) {
 }
 
 const CertificateManagement = () => {
+  const navigate = useNavigate();
+  
   // State
   const [activeTab, setActiveTab] = useState(0);
   const [certificates, setCertificates] = useState<Certificate[]>([]);
@@ -91,7 +93,6 @@ const CertificateManagement = () => {
   // Dialog states
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
-  const [viewDialogOpen, setViewDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedCertificate, setSelectedCertificate] = useState<Certificate | null>(null);
 
@@ -212,8 +213,7 @@ const CertificateManagement = () => {
   };
 
   const handleView = (certificate: Certificate) => {
-    setSelectedCertificate(certificate);
-    setViewDialogOpen(true);
+    navigate(`/certificates/${certificate.id}`);
   };
 
   const handleShare = (certificate: Certificate) => {
@@ -378,12 +378,6 @@ const CertificateManagement = () => {
         onClose={() => setShareDialogOpen(false)}
         certificate={selectedCertificate}
         onShare={handleShareCertificate}
-      />
-
-      <ViewCertificateDialog
-        open={viewDialogOpen}
-        onClose={() => setViewDialogOpen(false)}
-        certificate={selectedCertificate}
       />
 
       <DeleteCertificateDialog

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/pages/index.ts
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/pages/index.ts
@@ -21,3 +21,4 @@
  ********************************************************************************/
 
 export { default as CertificateManagement } from './CertificateManagement';
+export { default as CertificateDetail } from './CertificateDetail';

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/routes.tsx
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/routes.tsx
@@ -21,6 +21,7 @@
  ********************************************************************************/
 
 import CertificateManagement from './pages/CertificateManagement';
+import CertificateDetail from './pages/CertificateDetail';
 import { FeatureConfig } from '@/types/routing';
 
 export const certificateManagementFeature: FeatureConfig = {
@@ -34,6 +35,14 @@ export const certificateManagementFeature: FeatureConfig = {
       meta: {
         title: 'Certificate Management',
         description: 'Manage, share and consume compliance certificates'
+      }
+    },
+    {
+      path: '/certificates/:id',
+      element: <CertificateDetail />,
+      meta: {
+        title: 'Certificate Detail',
+        description: 'View certificate details and sharing history'
       }
     }
   ]

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/types/dialog-types.ts
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/types/dialog-types.ts
@@ -48,6 +48,8 @@ export interface ShareCertificateDialogProps {
   certificate: {
     id: string;
     name: string;
+    type?: string;
+    status?: string;
   } | null;
   onShare: (certificateId: string, partnerBpn: string, method: 'PULL' | 'PUSH') => void;
   defaultMethod?: 'PULL' | 'PUSH';

--- a/ichub-frontend/src/features/ccm-kit/certificate-management/types/dialog-types.ts
+++ b/ichub-frontend/src/features/ccm-kit/certificate-management/types/dialog-types.ts
@@ -50,6 +50,7 @@ export interface ShareCertificateDialogProps {
     name: string;
   } | null;
   onShare: (certificateId: string, partnerBpn: string, method: 'PULL' | 'PUSH') => void;
+  defaultMethod?: 'PULL' | 'PUSH';
 }
 
 export interface ViewCertificateDialogProps {


### PR DESCRIPTION
## WHAT

Redesigned the Share Certificate dialog to match the mockup design with a green header, close button, and a certificate info card displaying the certificate name with type and status chips.

Integrated the `PartnerAutocomplete` component for partner BPN selection with search functionality. Added an auto-filled Company Name field that populates when a partner is selected.

### Screenshots

<img width="1918" height="909" alt="image" src="https://github.com/user-attachments/assets/e3ab231f-9547-48c0-af6c-cb424cadf638" />


## FURTHER NOTES

Not integrated with the backend yet

Closes #449 
