### PR TITLE
fix: back to the original function

### DIFF
--- a/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionList.tsx
+++ b/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionList.tsx
@@ -110,7 +110,7 @@ const getVersionDisplay = (version: string | undefined): string => {
 const getStatusLabel = (status: string): string => {
   const statusMap: Record<string, string> = {
     'draft': 'Draft',
-    'active': 'Shared',
+    'active': 'Registered',
     'shared': 'Shared',
     'pending': 'Pending'
   };

--- a/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionWizard.tsx
+++ b/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionWizard.tsx
@@ -56,7 +56,6 @@ import {
   Link as LinkIcon,
   Add,
   CloudUpload,
-  IosShare,
   Edit,
   Close,
   Visibility,
@@ -66,7 +65,7 @@ import { createTwinAspect } from '@/features/industry-core-kit/catalog-managemen
 import SubmodelCreator from '@/components/submodel-creation/SubmodelCreator';
 import { darkCardStyles } from '../styles/cardStyles';
 import { GenericPassportVisualization } from '../../passport-consumption/passport-types/generic/GenericPassportVisualization';
-import { fetchAllSerializedPartTwins, fetchAllSerializedParts, createSerializedPartTwin, shareSerializedPartTwin } from '@/features/industry-core-kit/serialized-parts/api';
+import { fetchAllSerializedPartTwins, fetchAllSerializedParts, createSerializedPartTwin } from '@/features/industry-core-kit/serialized-parts/api';
 import { SerializedPart } from '@/features/industry-core-kit/serialized-parts/types';
 import { SerializedPartTwinRead } from '@/features/industry-core-kit/serialized-parts/types/twin-types';
 import { StatusVariants } from '@/features/industry-core-kit/catalog-management/types/types';
@@ -129,9 +128,9 @@ const PassportProvisionWizard: React.FC = () => {
         setError(t('wizard.errors.selectPart'));
         return;
       }
-      // Check if part is registered/shared — for SerializedParts, registration already shares
+      // Check if part is registered
       if (partRegistrationStatus !== StatusVariants.registered && partRegistrationStatus !== StatusVariants.shared) {
-        setError(t('wizard.errors.partMustBeShared'));
+        setError(t('wizard.errors.partMustBeRegistered'));
         return;
       }
       setActiveStep(2);
@@ -185,8 +184,7 @@ const PassportProvisionWizard: React.FC = () => {
           return {
             ...part,
             ...twin, // This adds globalId, dtrAasId, etc. if they exist
-            // For SerializedParts, registration already shares (partner BPN is in DTR shell descriptor)
-            _registrationStatus: 'shared'
+            _registrationStatus: twin.dtrAasId && twin.globalId ? 'shared' : 'registered'
           };
         }
         return {
@@ -224,12 +222,14 @@ const PassportProvisionWizard: React.FC = () => {
       // Check if the part already has the registration status from loadSerializedParts
       if ((part as any)._registrationStatus) {
         const status = (part as any)._registrationStatus;
-        // For SerializedParts, both 'registered' and 'shared' map to Shared
-        // because registration already makes the twin visible to the partner
-        setPartRegistrationStatus(
-          (status === 'shared' || status === 'registered') ? StatusVariants.shared : 
-          StatusVariants.draft
-        );
+        // Map status string to StatusVariants enum
+        if (status === 'shared') {
+          setPartRegistrationStatus(StatusVariants.shared);
+        } else if (status === 'registered') {
+          setPartRegistrationStatus(StatusVariants.registered);
+        } else {
+          setPartRegistrationStatus(StatusVariants.draft);
+        }
       } else {
         // Fallback to checking twins if status not available
         const twins = await fetchAllSerializedPartTwins();
@@ -241,9 +241,10 @@ const PassportProvisionWizard: React.FC = () => {
 
         if (!twin) {
           setPartRegistrationStatus(StatusVariants.draft);
-        } else {
-          // For SerializedParts, any registered twin is effectively shared
+        } else if (twin.dtrAasId && twin.globalId) {
           setPartRegistrationStatus(StatusVariants.shared);
+        } else {
+          setPartRegistrationStatus(StatusVariants.registered);
         }
       }
     } catch (err) {
@@ -261,27 +262,15 @@ const PassportProvisionWizard: React.FC = () => {
     setError(null);
 
     try {
-      // Step 1: Register the twin (this already makes it visible in DTR to the partner)
+      // Register the twin in the DTR
       await createSerializedPartTwin({
         manufacturerId: selectedPart.manufacturerId,
         manufacturerPartId: selectedPart.manufacturerPartId,
         partInstanceId: selectedPart.partInstanceId,
       });
 
-      // Step 2: Automatically create TwinExchange record so the DB state reflects the shared reality
-      try {
-        await shareSerializedPartTwin({
-          manufacturerId: selectedPart.manufacturerId,
-          manufacturerPartId: selectedPart.manufacturerPartId,
-          partInstanceId: selectedPart.partInstanceId,
-        });
-      } catch (shareErr) {
-        // Share may fail if TwinExchange already exists — not critical since DTR visibility is already set
-        console.warn('Auto-share after registration warning:', shareErr);
-      }
-
-      // Show success message immediately after sharing
-      setSuccessMessage(t('wizard.step2.twinSharedSuccess'));
+      // Show success message immediately after registration
+      setSuccessMessage(t('wizard.step2.twinRegisteredSuccess'));
       setTimeout(() => setSuccessMessage(null), 4000);
 
       // Reload the serialized parts list to get the updated twin data with globalId and dtrAasId
@@ -304,12 +293,12 @@ const PassportProvisionWizard: React.FC = () => {
         await checkPartRegistrationStatus(partWithTwinData || selectedPart);
       } catch (statusErr) {
         console.warn('Failed to check registration status after registration:', statusErr);
-        // Set status to shared manually since registration already shares for SerializedParts
-        setPartRegistrationStatus(StatusVariants.shared);
+        // Set status to registered manually since we know the registration succeeded
+        setPartRegistrationStatus(StatusVariants.registered);
       }
     } catch (err: any) {
-      console.error('Failed to share serialized part:', err);
-      const errorMessage = err?.response?.data?.message || err?.response?.data?.error || err?.message || 'Failed to share serialized part. Please try again.';
+      console.error('Failed to register serialized part:', err);
+      const errorMessage = err?.response?.data?.message || err?.response?.data?.error || err?.message || 'Failed to register serialized part. Please try again.';
       setError(errorMessage);
     } finally {
       setRegistering(false);
@@ -788,7 +777,7 @@ const PassportProvisionWizard: React.FC = () => {
                         <Box>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                             <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.8)' }}>
-                              {t('wizard.step2.sharingStatus')}:
+                              {t('wizard.step2.registrationStatus')}:
                             </Typography>
                             <Chip
                               label={partRegistrationStatus}
@@ -814,14 +803,14 @@ const PassportProvisionWizard: React.FC = () => {
                                 mb: 2
                               }}
                             >
-                              {t('wizard.step2.mustBeSharedWarning')}
+                              {t('wizard.step2.mustBeRegisteredWarning')}
                             </Alert>
                           )}
                           {(partRegistrationStatus === StatusVariants.draft || partRegistrationStatus === StatusVariants.pending) && (
                             <Button
                               fullWidth
                               variant="contained"
-                              startIcon={registering ? <CircularProgress size={20} color="inherit" /> : <IosShare />}
+                              startIcon={registering ? <CircularProgress size={20} color="inherit" /> : <CloudUpload />}
                               onClick={handleRegisterPart}
                               disabled={registering}
                               sx={{
@@ -832,7 +821,7 @@ const PassportProvisionWizard: React.FC = () => {
                                 }
                               }}
                             >
-                              {registering ? t('wizard.step2.sharing') : t('wizard.step2.shareSerializedPart')}
+                              {registering ? t('wizard.step2.registering') : t('wizard.step2.registerSerializedPart')}
                             </Button>
                           )}
                         </Box>
@@ -1577,7 +1566,7 @@ const PassportProvisionWizard: React.FC = () => {
                     {t('wizard.publishing.currentStatus')}:
                   </Typography>
                   <Chip
-                    label={t('common:status.shared')}
+                    label={t('common:status.registered')}
                     size="small"
                     sx={{
                       bgcolor: 'rgba(16, 185, 129, 0.1)',
@@ -1588,20 +1577,27 @@ const PassportProvisionWizard: React.FC = () => {
                   />
                 </Box>
                 <Divider sx={{ my: 2, borderColor: 'rgba(255, 255, 255, 0.1)' }} />
-                <Box sx={{ 
-                  display: 'flex', 
-                  alignItems: 'center', 
-                  gap: 1, 
-                  p: 1.5,
-                  bgcolor: 'rgba(16, 185, 129, 0.1)',
-                  border: '1px solid rgba(16, 185, 129, 0.3)',
-                  borderRadius: 1,
-                }}>
-                  <CheckCircle sx={{ color: '#10b981', fontSize: '1.2rem' }} />
-                  <Typography sx={{ color: '#10b981', fontSize: '0.9rem' }}>
-                    {t('wizard.publishing.alreadyShared')}
-                  </Typography>
-                </Box>
+                <Typography sx={{ color: 'rgba(255,255,255,0.7)', mb: 2, fontSize: '0.9rem' }}>
+                  {t('wizard.publishing.sharePrompt')}
+                </Typography>
+                <Button
+                  fullWidth
+                  variant="outlined"
+                  startIcon={<LinkIcon />}
+                  sx={{
+                    borderColor: 'rgba(139, 92, 246, 0.5)',
+                    color: '#a78bfa',
+                    textTransform: 'none',
+                    py: 1.2,
+                    '&:hover': {
+                      borderColor: '#8b5cf6',
+                      bgcolor: 'rgba(139, 92, 246, 0.1)',
+                      color: '#a78bfa',
+                    }
+                  }}
+                >
+                  {t('common:actions.share')} DPP
+                </Button>
               </Box>
             </Box>
           ) : (

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/InstanceProductsTable.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/InstanceProductsTable.tsx
@@ -38,6 +38,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import AddIcon from '@mui/icons-material/Add';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import IosShare from '@mui/icons-material/IosShare';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -136,9 +137,13 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
       return { status: StatusVariants.draft };
     }
 
-    // For SerializedParts, registration already makes the twin visible to the partner
-    // (partner BPN is added to DTR shell descriptor), so both 'registered' and 'shared' are treated as 'shared'
-    return { status: StatusVariants.shared, globalId: twin.globalId?.toString(), dtrAasId: twin.dtrAasId?.toString() };
+    // If twin has shares, it's shared; otherwise it's only registered
+    const hasShares = twin.shares && twin.shares.length > 0;
+    return {
+      status: hasShares ? StatusVariants.shared : StatusVariants.registered,
+      globalId: twin.globalId?.toString(),
+      dtrAasId: twin.dtrAasId?.toString(),
+    };
   };
 
   useEffect(() => {
@@ -199,26 +204,14 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
     
     setTwinCreatingId(row.id);
     try {
-      // Step 1: Register the twin (this already makes it visible in DTR to the partner)
+      // Register the twin in the DTR
       await createSerializedPartTwin({
         manufacturerId: row.manufacturerId,
         manufacturerPartId: row.manufacturerPartId,
         partInstanceId: row.partInstanceId,
       });
-
-      // Step 2: Automatically create TwinExchange record so the DB state reflects the shared reality
-      try {
-        await shareSerializedPartTwin({
-          manufacturerId: row.manufacturerId,
-          manufacturerPartId: row.manufacturerPartId,
-          partInstanceId: row.partInstanceId,
-        });
-      } catch (shareErr) {
-        // Share may fail if TwinExchange already exists — not critical since DTR visibility is already set
-        console.warn('Auto-share after registration warning:', shareErr);
-      }
       
-      // Refresh data after successful creation
+      // Refresh data after successful registration
       const [serializedParts, twins] = await Promise.all([
         fetchSerializedParts(part.manufacturerId, part.manufacturerPartId),
         fetchSerializedPartTwinsForCatalogPart(part.manufacturerId, part.manufacturerPartId)
@@ -267,7 +260,7 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
         );
 
         if (updatedRow && (updatedRow.twinStatus === StatusVariants.shared || updatedRow.twinStatus === StatusVariants.registered)) {
-          showSuccess('Twin shared successfully!');
+          showSuccess('Twin registered successfully!');
           return; // suppress original error
         }
       } catch (recheckError) {
@@ -276,16 +269,16 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
       }
 
       // Extract meaningful error message if status remains draft
-      let errorMessage = 'Failed to share twin. Please try again.';
+      let errorMessage = 'Failed to register twin. Please try again.';
       
       if (error instanceof Error) {
-        errorMessage = `Sharing failed: ${error.message}`;
+        errorMessage = `Registration failed: ${error.message}`;
       } else if (typeof error === 'object' && error !== null && 'response' in error) {
         const axiosError = error as { response?: { data?: { message?: string; error?: string } } };
         if (axiosError.response?.data?.message) {
-          errorMessage = `Sharing failed: ${axiosError.response.data.message}`;
+          errorMessage = `Registration failed: ${axiosError.response.data.message}`;
         } else if (axiosError.response?.data?.error) {
-          errorMessage = `Sharing failed: ${axiosError.response.data.error}`;
+          errorMessage = `Registration failed: ${axiosError.response.data.error}`;
         }
       }
       
@@ -503,11 +496,48 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
 
         if (row.twinStatus === StatusVariants.draft) {
           actions.push(
-            <Tooltip title={t('common:tooltips.shareTwin')} key="share" arrow>
+            <Tooltip title={tCommon('tooltips.registerTwin')} key="register" arrow>
               <IconButton
                 size="small"
                 onClick={() => handleCreateTwin(row)}
                 disabled={twinCreatingId === row.id}
+                sx={{
+                  backgroundColor: 'rgba(25, 118, 210, 0.1)',
+                  color: '#1976d2',
+                  borderRadius: '8px',
+                  width: 36,
+                  height: 36,
+                  border: '1px solid rgba(25, 118, 210, 0.3)',
+                  '&:hover': {
+                    backgroundColor: 'rgba(25, 118, 210, 0.2)',
+                    transform: 'translateY(-1px)',
+                    boxShadow: '0 4px 12px rgba(25, 118, 210, 0.3)',
+                  },
+                  '&:disabled': {
+                    backgroundColor: 'rgba(248, 249, 250, 0.1)',
+                    color: 'rgba(248, 249, 250, 0.3)',
+                    border: '1px solid rgba(248, 249, 250, 0.1)',
+                  },
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                {twinCreatingId === row.id ? (
+                  <CircularProgress size={16} sx={{ color: '#1976d2' }} />
+                ) : (
+                  <CloudUploadIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          );
+        }
+
+        if (row.twinStatus === StatusVariants.registered) {
+          actions.push(
+            <Tooltip title={tCommon('tooltips.shareTwin')} key="share" arrow>
+              <IconButton
+                size="small"
+                onClick={() => handleShareTwin(row)}
+                disabled={twinSharingId === row.id}
                 sx={{
                   backgroundColor: 'rgba(156, 39, 176, 0.1)',
                   color: '#9c27b0',
@@ -528,11 +558,42 @@ export default function InstanceProductsTable({ part, onAddClick }: Readonly<Ins
                   transition: 'all 0.2s ease-in-out',
                 }}
               >
-                {twinCreatingId === row.id ? (
-                  <CircularProgress size={16} sx={{ color: '#9c27b0' }} />
-                ) : (
-                  <IosShare fontSize="small" />
-                )}
+                <IosShare fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          );
+          
+          // Add delete button for registered twins
+          actions.push(
+            <Tooltip title={t('productDetail.instanceProductsTable.tooltips.deleteSerializedPart')} key="delete" arrow>
+              <IconButton
+                size="small"
+                onClick={() => {
+                  
+                  showDeleteConfirmation(row);
+                }}
+                disabled={partDeletingId === row.id}
+                sx={{
+                  backgroundColor: 'rgba(244, 67, 54, 0.1)',
+                  color: '#f44336',
+                  borderRadius: '8px',
+                  width: 36,
+                  height: 36,
+                  border: '1px solid rgba(244, 67, 54, 0.3)',
+                  '&:hover': {
+                    backgroundColor: 'rgba(244, 67, 54, 0.2)',
+                    transform: 'translateY(-1px)',
+                    boxShadow: '0 4px 12px rgba(244, 67, 54, 0.3)',
+                  },
+                  '&:disabled': {
+                    backgroundColor: 'rgba(248, 249, 250, 0.1)',
+                    color: 'rgba(248, 249, 250, 0.3)',
+                    border: '1px solid rgba(248, 249, 250, 0.1)',
+                  },
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                <DeleteIcon fontSize="small" />
               </IconButton>
             </Tooltip>
           );

--- a/ichub-frontend/src/features/industry-core-kit/serialized-parts/components/SerializedPartsTable.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/serialized-parts/components/SerializedPartsTable.tsx
@@ -40,6 +40,7 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import IosShare from '@mui/icons-material/IosShare';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
@@ -170,9 +171,13 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
       return { status: StatusVariants.draft };
     }
 
-    // For SerializedParts, registration already makes the twin visible to the partner
-    // (partner BPN is added to DTR shell descriptor), so both 'registered' and 'shared' are treated as 'shared'
-    return { status: StatusVariants.shared, globalId: twin.globalId?.toString(), dtrAasId: twin.dtrAasId?.toString() };
+    // If twin has shares, it's shared; otherwise it's only registered
+    const hasShares = twin.shares && twin.shares.length > 0;
+    return {
+      status: hasShares ? StatusVariants.shared : StatusVariants.registered,
+      globalId: twin.globalId?.toString(),
+      dtrAasId: twin.dtrAasId?.toString(),
+    };
   };
 
   useEffect(() => {
@@ -262,26 +267,14 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
   const handleCreateTwin = async (row: SerializedPartWithStatus) => {
     setTwinCreatingId(row.id);
     try {
-      // Step 1: Register the twin (this already makes it visible in DTR to the partner)
+      // Register the twin in the DTR
       await createSerializedPartTwin({
         manufacturerId: row.manufacturerId,
         manufacturerPartId: row.manufacturerPartId,
         partInstanceId: row.partInstanceId,
       });
-
-      // Step 2: Automatically create TwinExchange record so the DB state reflects the shared reality
-      try {
-        await shareSerializedPartTwin({
-          manufacturerId: row.manufacturerId,
-          manufacturerPartId: row.manufacturerPartId,
-          partInstanceId: row.partInstanceId,
-        });
-      } catch (shareErr) {
-        // Share may fail if TwinExchange already exists — not critical since DTR visibility is already set
-        console.warn('Auto-share after registration warning:', shareErr);
-      }
       
-      // Refresh twin data after successful creation
+      // Refresh twin data after successful registration
       const updatedTwins = await fetchTwinsOnce();
       const relevantTwins = getRelevantTwins(updatedTwins);
       
@@ -300,7 +293,7 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
       setRows(rowsWithStatus);
       
       // Show success message
-      showSuccess(t('table.messages.twinShared'));
+      showSuccess(t('table.messages.twinRegistered'));
     } catch (error) {
       console.error("Error creating twin:", error);
       // After error (e.g., 404), refetch and decide success vs error based on updated status
@@ -330,7 +323,7 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
             r.partInstanceId === row.partInstanceId
         );
         if (updatedRow && (updatedRow.twinStatus === StatusVariants.shared || updatedRow.twinStatus === StatusVariants.registered)) {
-          showSuccess(t('table.messages.twinShared'));
+          showSuccess(t('table.messages.twinRegistered'));
           return; // suppress original error
         }
       } catch (recheckError) {
@@ -338,15 +331,15 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
       }
 
       // Extract meaningful error message if status remains draft
-      let errorMessage = t('table.messages.shareFailed');
+      let errorMessage = t('table.messages.registerFailed');
       if (error instanceof Error) {
-        errorMessage = `${t('table.messages.shareFailed')}: ${error.message}`;
+        errorMessage = `${t('table.messages.registerFailed')}: ${error.message}`;
       } else if (typeof error === 'object' && error !== null && 'response' in error) {
         const axiosError = error as { response?: { data?: { message?: string; error?: string } } };
         if (axiosError.response?.data?.message) {
-          errorMessage = `${t('table.messages.shareFailed')}: ${axiosError.response.data.message}`;
+          errorMessage = `${t('table.messages.registerFailed')}: ${axiosError.response.data.message}`;
         } else if (axiosError.response?.data?.error) {
-          errorMessage = `${t('table.messages.shareFailed')}: ${axiosError.response.data.error}`;
+          errorMessage = `${t('table.messages.registerFailed')}: ${axiosError.response.data.error}`;
         }
       }
       showError(errorMessage);
@@ -639,11 +632,48 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
 
         if (row.twinStatus === StatusVariants.draft) {
           actions.push(
-            <Tooltip title={t('common:tooltips.shareTwin')} key="share" arrow>
+            <Tooltip title={t('common:tooltips.registerTwin')} key="register" arrow>
               <IconButton
                 size="small"
                 onClick={() => handleCreateTwin(row)}
                 disabled={twinCreatingId === row.id}
+                sx={{
+                  backgroundColor: 'rgba(25, 118, 210, 0.1)',
+                  color: '#1976d2',
+                  borderRadius: '8px',
+                  width: 36,
+                  height: 36,
+                  border: '1px solid rgba(25, 118, 210, 0.3)',
+                  '&:hover': {
+                    backgroundColor: 'rgba(25, 118, 210, 0.2)',
+                    transform: 'translateY(-1px)',
+                    boxShadow: '0 4px 12px rgba(25, 118, 210, 0.3)',
+                  },
+                  '&:disabled': {
+                    backgroundColor: 'rgba(248, 249, 250, 0.1)',
+                    color: 'rgba(248, 249, 250, 0.3)',
+                    border: '1px solid rgba(248, 249, 250, 0.1)',
+                  },
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                {twinCreatingId === row.id ? (
+                  <CircularProgress size={16} sx={{ color: '#1976d2' }} />
+                ) : (
+                  <CloudUploadIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          );
+        }
+
+        if (row.twinStatus === StatusVariants.registered) {
+          actions.push(
+            <Tooltip title={t('common:tooltips.shareTwin')} key="share" arrow>
+              <IconButton
+                size="small"
+                onClick={() => handleShareTwin(row)}
+                disabled={twinSharingId === row.id}
                 sx={{
                   backgroundColor: 'rgba(156, 39, 176, 0.1)',
                   color: '#9c27b0',
@@ -664,11 +694,42 @@ const SerializedPartsTable = ({ parts, onRefresh }: SerializedPartsTableProps) =
                   transition: 'all 0.2s ease-in-out',
                 }}
               >
-                {twinCreatingId === row.id ? (
-                  <CircularProgress size={16} sx={{ color: '#9c27b0' }} />
-                ) : (
-                  <IosShare fontSize="small" />
-                )}
+                <IosShare fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          );
+          
+          // Add delete button for registered twins
+          actions.push(
+            <Tooltip title={t('table.tooltips.deleteSerializedPart')} key="delete" arrow>
+              <IconButton
+                size="small"
+                onClick={() => {
+                  
+                  showDeleteConfirmation(row);
+                }}
+                disabled={partDeletingId === row.id}
+                sx={{
+                  backgroundColor: 'rgba(244, 67, 54, 0.1)',
+                  color: '#f44336',
+                  borderRadius: '8px',
+                  width: 36,
+                  height: 36,
+                  border: '1px solid rgba(244, 67, 54, 0.3)',
+                  '&:hover': {
+                    backgroundColor: 'rgba(244, 67, 54, 0.2)',
+                    transform: 'translateY(-1px)',
+                    boxShadow: '0 4px 12px rgba(244, 67, 54, 0.3)',
+                  },
+                  '&:disabled': {
+                    backgroundColor: 'rgba(248, 249, 250, 0.1)',
+                    color: 'rgba(248, 249, 250, 0.3)',
+                    border: '1px solid rgba(248, 249, 250, 0.1)',
+                  },
+                  transition: 'all 0.2s ease-in-out',
+                }}
+              >
+                <DeleteIcon fontSize="small" />
               </IconButton>
             </Tooltip>
           );

--- a/ichub-frontend/src/i18n/locales/de/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/de/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "Serialisiertes Teil löschen"
       },
       "messages": {
-        "twinRegisteredSuccess": "Zwilling erfolgreich geteilt!",
-        "registrationFailed": "Teilen fehlgeschlagen: {{error}}",
+        "twinRegisteredSuccess": "Zwilling erfolgreich registriert!",
+        "registrationFailed": "Registrierung fehlgeschlagen: {{error}}",
         "sharingFailed": "Teilen fehlgeschlagen: {{error}}",
         "unsharingFailed": "Freigabe aufheben fehlgeschlagen: {{error}}",
         "deletionFailed": "Löschen fehlgeschlagen: {{error}}",

--- a/ichub-frontend/src/i18n/locales/de/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/de/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "Serialisiertes Teil auswählen",
       "chooseSerializedPart": "Wählen Sie ein serialisiertes Teil...",
       "selectedPart": "Ausgewähltes Teil",
-      "checkingRegistration": "Freigabestatus wird überprüft...",
+      "checkingRegistration": "Registrierungsstatus wird überprüft...",
       "registrationStatus": "Registrierungsstatus",
-      "sharingStatus": "Freigabestatus",
-      "notRegistered": "Nicht geteilt",
+      "notRegistered": "Nicht registriert",
       "alreadyHasDpp": "Hat bereits DPP",
       "noDppAssigned": "Kein DPP zugewiesen",
       "mustBeRegisteredWarning": "Dieses serialisierte Teil muss als digitaler Zwilling registriert werden, bevor Sie einen DPP bereitstellen können.",
-      "mustBeSharedWarning": "Dieses serialisierte Teil muss als digitaler Zwilling geteilt werden, bevor Sie einen DPP bereitstellen können.",
       "registerSerializedPart": "Serialisiertes Teil registrieren",
-      "shareSerializedPart": "Serialisiertes Teil teilen",
       "registerThisPart": "Dieses Teil registrieren",
       "registering": "Registrieren...",
-      "sharing": "Teilen...",
       "orCreateNewPart": "Oder neues Teil erstellen:",
       "createNewSerializedPart": "Neues serialisiertes Teil erstellen",
-      "twinRegisteredSuccess": "Zwilling erfolgreich geteilt!",
-      "twinSharedSuccess": "Zwilling erfolgreich geteilt!",
+      "twinRegisteredSuccess": "Zwilling erfolgreich registriert!",
       "partCreatedSuccess": "Serialisiertes Teil erfolgreich erstellt"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "Bitte wählen Sie ein serialisiertes Teil aus, um es mit diesem DPP zu verknüpfen",
       "partMustBeRegistered": "Das ausgewählte serialisierte Teil muss registriert sein, bevor ein DPP erstellt werden kann. Bitte registrieren Sie es zuerst.",
-      "partMustBeShared": "Das ausgewählte serialisierte Teil muss geteilt sein, bevor ein DPP erstellt werden kann. Bitte teilen Sie es zuerst.",
       "provideDppData": "Bitte geben Sie DPP-Daten an, bevor Sie fortfahren. Sie können diese über das Formular erstellen oder eine JSON-Datei hochladen.",
       "validateFirst": "Bitte validieren Sie die DPP-Daten, bevor Sie fortfahren."
     },
@@ -165,7 +159,6 @@
       "successMessage": "Ihr Digitaler Produktpass wurde erfolgreich veröffentlicht!",
       "currentStatus": "Aktueller Status",
       "sharePrompt": "Jetzt können Sie ihn mit Ihrem Partner teilen!",
-      "alreadyShared": "Dieser DPP wird bereits mit Ihrem Partner geteilt.",
       "errorOccurred": "Beim Veröffentlichen des DPP ist ein Fehler aufgetreten"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/de/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/de/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "Serialisiertes Teil löschen"
     },
     "messages": {
-      "twinRegistered": "Zwilling erfolgreich geteilt!",
+      "twinRegistered": "Zwilling erfolgreich registriert!",
       "twinShared": "Zwilling erfolgreich geteilt!",
       "twinUnshared": "Zwilling erfolgreich nicht mehr geteilt!",
       "partDeleted": "Serialisiertes Teil erfolgreich gelöscht!",
       "dataRefreshed": "Daten erfolgreich aktualisiert!",
-      "registerFailed": "Teilen fehlgeschlagen",
+      "registerFailed": "Registrierung fehlgeschlagen",
       "shareFailed": "Teilen fehlgeschlagen",
       "unshareFailed": "Aufheben der Freigabe fehlgeschlagen",
       "deleteFailed": "Löschen fehlgeschlagen",

--- a/ichub-frontend/src/i18n/locales/en/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/en/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "Delete Serialized Part"
       },
       "messages": {
-        "twinRegisteredSuccess": "Twin shared successfully!",
-        "registrationFailed": "Sharing failed: {{error}}",
+        "twinRegisteredSuccess": "Twin registered successfully!",
+        "registrationFailed": "Registration failed: {{error}}",
         "sharingFailed": "Sharing failed: {{error}}",
         "unsharingFailed": "Unsharing failed: {{error}}",
         "deletionFailed": "Deletion failed: {{error}}",

--- a/ichub-frontend/src/i18n/locales/en/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/en/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "Select Serialized Part",
       "chooseSerializedPart": "Choose a serialized part...",
       "selectedPart": "Selected Part",
-      "checkingRegistration": "Checking sharing status...",
+      "checkingRegistration": "Checking registration status...",
       "registrationStatus": "Registration Status",
-      "sharingStatus": "Sharing Status",
-      "notRegistered": "Not Shared",
+      "notRegistered": "Not Registered",
       "alreadyHasDpp": "Already has DPP",
       "noDppAssigned": "No DPP assigned",
       "mustBeRegisteredWarning": "This serialized part must be registered as a digital twin before you can provision a DPP.",
-      "mustBeSharedWarning": "This serialized part must be shared as a digital twin before you can provision a DPP.",
       "registerSerializedPart": "Register Serialized Part",
-      "shareSerializedPart": "Share Serialized Part",
       "registerThisPart": "Register This Part",
       "registering": "Registering...",
-      "sharing": "Sharing...",
       "orCreateNewPart": "Or create a new part:",
       "createNewSerializedPart": "Create New Serialized Part",
-      "twinRegisteredSuccess": "Twin shared successfully!",
-      "twinSharedSuccess": "Twin shared successfully!",
+      "twinRegisteredSuccess": "Twin registered successfully!",
       "partCreatedSuccess": "Serialized part created successfully"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "Please select a serialized part to associate with this DPP",
       "partMustBeRegistered": "The selected serialized part must be registered before creating a DPP. Please register it first.",
-      "partMustBeShared": "The selected serialized part must be shared before creating a DPP. Please share it first.",
       "provideDppData": "Please provide DPP data before proceeding. You can create it using the form or upload a JSON file.",
       "validateFirst": "Please validate the DPP data before proceeding."
     },
@@ -165,7 +159,6 @@
       "successMessage": "Your Digital Product Passport has been successfully published!",
       "currentStatus": "Current Status",
       "sharePrompt": "Now you can share it with your partner!",
-      "alreadyShared": "This DPP is already shared with your partner.",
       "errorOccurred": "An error occurred while publishing the DPP"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/en/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/en/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "Delete Serialized Part"
     },
     "messages": {
-      "twinRegistered": "Twin shared successfully!",
+      "twinRegistered": "Twin registered successfully!",
       "twinShared": "Twin shared successfully!",
       "twinUnshared": "Twin unshared successfully!",
       "partDeleted": "Serialized part deleted successfully!",
       "dataRefreshed": "Data refreshed successfully!",
-      "registerFailed": "Sharing failed",
+      "registerFailed": "Registration failed",
       "shareFailed": "Sharing failed",
       "unshareFailed": "Unsharing failed",
       "deleteFailed": "Deletion failed",

--- a/ichub-frontend/src/i18n/locales/es/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/es/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "Eliminar Pieza Serializada"
       },
       "messages": {
-        "twinRegisteredSuccess": "¡Gemelo compartido correctamente!",
-        "registrationFailed": "Error al compartir: {{error}}",
+        "twinRegisteredSuccess": "¡Gemelo registrado correctamente!",
+        "registrationFailed": "Error al registrar: {{error}}",
         "sharingFailed": "Error al compartir: {{error}}",
         "unsharingFailed": "Error al dejar de compartir: {{error}}",
         "deletionFailed": "Error al eliminar: {{error}}",

--- a/ichub-frontend/src/i18n/locales/es/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/es/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "Seleccionar Pieza Serializada",
       "chooseSerializedPart": "Elige una pieza serializada...",
       "selectedPart": "Pieza Seleccionada",
-      "checkingRegistration": "Verificando estado de compartición...",
+      "checkingRegistration": "Verificando estado de registro...",
       "registrationStatus": "Estado de Registro",
-      "sharingStatus": "Estado de Compartición",
-      "notRegistered": "No Compartido",
+      "notRegistered": "No Registrado",
       "alreadyHasDpp": "Ya tiene DPP",
       "noDppAssigned": "Sin DPP asignado",
       "mustBeRegisteredWarning": "Esta pieza serializada debe registrarse como gemelo digital antes de poder aprovisionar un DPP.",
-      "mustBeSharedWarning": "Esta pieza serializada debe compartirse como gemelo digital antes de poder aprovisionar un DPP.",
       "registerSerializedPart": "Registrar Pieza Serializada",
-      "shareSerializedPart": "Compartir Pieza Serializada",
       "registerThisPart": "Registrar Esta Pieza",
       "registering": "Registrando...",
-      "sharing": "Compartiendo...",
       "orCreateNewPart": "O crea una nueva pieza:",
       "createNewSerializedPart": "Crear Nueva Pieza Serializada",
-      "twinRegisteredSuccess": "¡Gemelo compartido exitosamente!",
-      "twinSharedSuccess": "¡Gemelo compartido exitosamente!",
+      "twinRegisteredSuccess": "¡Gemelo registrado exitosamente!",
       "partCreatedSuccess": "Pieza serializada creada exitosamente"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "Por favor selecciona una pieza serializada para asociar con este DPP",
       "partMustBeRegistered": "La pieza serializada seleccionada debe estar registrada antes de crear un DPP. Por favor regístrala primero.",
-      "partMustBeShared": "La pieza serializada seleccionada debe estar compartida antes de crear un DPP. Por favor compártala primero.",
       "provideDppData": "Por favor proporciona datos del DPP antes de continuar. Puedes crearlos usando el formulario o subir un archivo JSON.",
       "validateFirst": "Por favor valida los datos del DPP antes de continuar."
     },
@@ -165,7 +159,6 @@
       "successMessage": "¡Tu Pasaporte Digital de Producto ha sido publicado exitosamente!",
       "currentStatus": "Estado Actual",
       "sharePrompt": "¡Ahora puedes compartirlo con tu socio!",
-      "alreadyShared": "Este DPP ya está compartido con tu socio.",
       "errorOccurred": "Ocurrió un error al publicar el DPP"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/es/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/es/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "Eliminar Pieza Serializada"
     },
     "messages": {
-      "twinRegistered": "¡Gemelo compartido correctamente!",
+      "twinRegistered": "¡Gemelo registrado correctamente!",
       "twinShared": "¡Gemelo compartido correctamente!",
       "twinUnshared": "¡Gemelo dejado de compartir correctamente!",
       "partDeleted": "¡Pieza serializada eliminada correctamente!",
       "dataRefreshed": "¡Datos actualizados correctamente!",
-      "registerFailed": "Error al compartir",
+      "registerFailed": "Error al registrar",
       "shareFailed": "Error al compartir",
       "unshareFailed": "Error al dejar de compartir",
       "deleteFailed": "Error al eliminar",

--- a/ichub-frontend/src/i18n/locales/fr/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/fr/catalogManagement.json
@@ -150,8 +150,8 @@
         "deleteSerializedPart": "Supprimer la Pièce Sérialisée"
       },
       "messages": {
-        "twinRegisteredSuccess": "Jumeau partagé avec succès !",
-        "registrationFailed": "Échec du partage : {{error}}",
+        "twinRegisteredSuccess": "Jumeau enregistré avec succès !",
+        "registrationFailed": "Échec de l'enregistrement : {{error}}",
         "sharingFailed": "Échec du partage : {{error}}",
         "unsharingFailed": "Échec de l'annulation du partage : {{error}}",
         "deletionFailed": "Échec de la suppression : {{error}}",

--- a/ichub-frontend/src/i18n/locales/fr/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/fr/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "Sélectionner une Pièce Sérialisée",
       "chooseSerializedPart": "Choisissez une pièce sérialisée...",
       "selectedPart": "Pièce Sélectionnée",
-      "checkingRegistration": "Vérification du statut de partage...",
+      "checkingRegistration": "Vérification du statut d'enregistrement...",
       "registrationStatus": "Statut d'Enregistrement",
-      "sharingStatus": "Statut de Partage",
-      "notRegistered": "Non partagé",
+      "notRegistered": "Non enregistré",
       "alreadyHasDpp": "A déjà un DPP",
       "noDppAssigned": "Pas de DPP assigné",
       "mustBeRegisteredWarning": "Cette pièce sérialisée doit être enregistrée comme jumeau numérique avant de pouvoir provisionner un DPP.",
-      "mustBeSharedWarning": "Cette pièce sérialisée doit être partagée comme jumeau numérique avant de pouvoir provisionner un DPP.",
       "registerSerializedPart": "Enregistrer la Pièce Sérialisée",
-      "shareSerializedPart": "Partager la Pièce Sérialisée",
       "registerThisPart": "Enregistrer Cette Pièce",
       "registering": "Enregistrement...",
-      "sharing": "Partage...",
       "orCreateNewPart": "Ou créer une nouvelle pièce :",
       "createNewSerializedPart": "Créer une Nouvelle Pièce Sérialisée",
-      "twinRegisteredSuccess": "Jumeau partagé avec succès !",
-      "twinSharedSuccess": "Jumeau partagé avec succès !",
+      "twinRegisteredSuccess": "Jumeau enregistré avec succès !",
       "partCreatedSuccess": "Pièce sérialisée créée avec succès"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "Veuillez sélectionner une pièce sérialisée à associer à ce DPP",
       "partMustBeRegistered": "La pièce sérialisée sélectionnée doit être enregistrée avant de créer un DPP. Veuillez l'enregistrer d'abord.",
-      "partMustBeShared": "La pièce sérialisée sélectionnée doit être partagée avant de créer un DPP. Veuillez la partager d'abord.",
       "provideDppData": "Veuillez fournir des données DPP avant de continuer. Vous pouvez les créer via le formulaire ou télécharger un fichier JSON.",
       "validateFirst": "Veuillez valider les données DPP avant de continuer."
     },
@@ -165,7 +159,6 @@
       "successMessage": "Votre Passeport Produit Numérique a été publié avec succès !",
       "currentStatus": "Statut Actuel",
       "sharePrompt": "Maintenant vous pouvez le partager avec votre partenaire !",
-      "alreadyShared": "Ce DPP est déjà partagé avec votre partenaire.",
       "errorOccurred": "Une erreur s'est produite lors de la publication du DPP"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/fr/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/fr/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "Supprimer la Pièce Sérialisée"
     },
     "messages": {
-      "twinRegistered": "Jumeau partagé avec succès !",
+      "twinRegistered": "Jumeau enregistré avec succès !",
       "twinShared": "Jumeau partagé avec succès !",
       "twinUnshared": "Partage du jumeau annulé avec succès !",
       "partDeleted": "Pièce sérialisée supprimée avec succès !",
       "dataRefreshed": "Données actualisées avec succès !",
-      "registerFailed": "Échec du partage",
+      "registerFailed": "Échec de l'enregistrement",
       "shareFailed": "Échec du partage",
       "unshareFailed": "Échec de l'annulation du partage",
       "deleteFailed": "Échec de la suppression",

--- a/ichub-frontend/src/i18n/locales/ja/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/ja/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "シリアライズ部品を削除"
       },
       "messages": {
-        "twinRegisteredSuccess": "ツインが正常に共有されました！",
-        "registrationFailed": "共有に失敗しました: {{error}}",
+        "twinRegisteredSuccess": "ツインが正常に登録されました！",
+        "registrationFailed": "登録に失敗しました: {{error}}",
         "sharingFailed": "共有に失敗しました: {{error}}",
         "unsharingFailed": "共有解除に失敗しました: {{error}}",
         "deletionFailed": "削除に失敗しました: {{error}}",

--- a/ichub-frontend/src/i18n/locales/ja/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/ja/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "シリアライズ部品を選択",
       "chooseSerializedPart": "シリアライズ部品を選択...",
       "selectedPart": "選択された部品",
-      "checkingRegistration": "共有ステータスを確認中...",
+      "checkingRegistration": "登録ステータスを確認中...",
       "registrationStatus": "登録ステータス",
-      "sharingStatus": "共有ステータス",
-      "notRegistered": "未共有",
+      "notRegistered": "未登録",
       "alreadyHasDpp": "既にDPPがあります",
       "noDppAssigned": "DPPが割り当てられていません",
       "mustBeRegisteredWarning": "このシリアライズ部品はDPPを設定する前にデジタルツインとして登録する必要があります。",
-      "mustBeSharedWarning": "このシリアライズ部品はDPPを設定する前にデジタルツインとして共有する必要があります。",
       "registerSerializedPart": "シリアライズ部品を登録",
-      "shareSerializedPart": "シリアライズ部品を共有",
       "registerThisPart": "この部品を登録",
       "registering": "登録中...",
-      "sharing": "共有中...",
       "orCreateNewPart": "または新しい部品を作成:",
       "createNewSerializedPart": "新しいシリアライズ部品を作成",
-      "twinRegisteredSuccess": "ツインが正常に共有されました！",
-      "twinSharedSuccess": "ツインが正常に共有されました！",
+      "twinRegisteredSuccess": "ツインが正常に登録されました！",
       "partCreatedSuccess": "シリアライズ部品が正常に作成されました"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "このDPPに関連付けるシリアライズ部品を選択してください",
       "partMustBeRegistered": "選択されたシリアライズ部品はDPPを作成する前に登録する必要があります。まず登録してください。",
-      "partMustBeShared": "選択されたシリアライズ部品はDPPを作成する前に共有する必要があります。まず共有してください。",
       "provideDppData": "続行する前にDPPデータを提供してください。フォームを使用して作成するか、JSONファイルをアップロードできます。",
       "validateFirst": "続行する前にDPPデータを検証してください。"
     },
@@ -165,7 +159,6 @@
       "successMessage": "デジタル製品パスポートが正常に公開されました！",
       "currentStatus": "現在のステータス",
       "sharePrompt": "パートナーと共有できます！",
-      "alreadyShared": "このDPPはすでにパートナーと共有されています。",
       "errorOccurred": "DPPの公開中にエラーが発生しました"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/ja/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/ja/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "シリアライズ部品を削除"
     },
     "messages": {
-      "twinRegistered": "ツインが正常に共有されました!",
+      "twinRegistered": "ツインが正常に登録されました!",
       "twinShared": "ツインが正常に共有されました!",
       "twinUnshared": "ツインの共有が正常に解除されました!",
       "partDeleted": "シリアライズ部品が正常に削除されました!",
       "dataRefreshed": "データが正常に更新されました!",
-      "registerFailed": "共有に失敗しました",
+      "registerFailed": "登録に失敗しました",
       "shareFailed": "共有に失敗しました",
       "unshareFailed": "共有解除に失敗しました",
       "deleteFailed": "削除に失敗しました",

--- a/ichub-frontend/src/i18n/locales/pt/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/pt/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "Eliminar Peça Serializada"
       },
       "messages": {
-        "twinRegisteredSuccess": "Gémeo partilhado com sucesso!",
-        "registrationFailed": "Partilha falhou: {{error}}",
+        "twinRegisteredSuccess": "Gémeo registado com sucesso!",
+        "registrationFailed": "Registo falhou: {{error}}",
         "sharingFailed": "Partilha falhou: {{error}}",
         "unsharingFailed": "Anulação de partilha falhou: {{error}}",
         "deletionFailed": "Eliminação falhou: {{error}}",

--- a/ichub-frontend/src/i18n/locales/pt/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/pt/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "Selecionar Peça Serializada",
       "chooseSerializedPart": "Escolha uma peça serializada...",
       "selectedPart": "Peça Selecionada",
-      "checkingRegistration": "A verificar estado de partilha...",
+      "checkingRegistration": "A verificar estado de registo...",
       "registrationStatus": "Estado de Registo",
-      "sharingStatus": "Estado de Partilha",
-      "notRegistered": "Não Partilhado",
+      "notRegistered": "Não Registado",
       "alreadyHasDpp": "Já tem DPP",
       "noDppAssigned": "Nenhum DPP atribuído",
       "mustBeRegisteredWarning": "Esta peça serializada deve ser registada como gémeo digital antes de poder configurar um DPP.",
-      "mustBeSharedWarning": "Esta peça serializada deve ser partilhada como gémeo digital antes de poder configurar um DPP.",
       "registerSerializedPart": "Registar Peça Serializada",
-      "shareSerializedPart": "Partilhar Peça Serializada",
       "registerThisPart": "Registar Esta Peça",
       "registering": "A registar...",
-      "sharing": "A partilhar...",
       "orCreateNewPart": "Ou criar uma nova peça:",
       "createNewSerializedPart": "Criar Nova Peça Serializada",
-      "twinRegisteredSuccess": "Gémeo partilhado com sucesso!",
-      "twinSharedSuccess": "Gémeo partilhado com sucesso!",
+      "twinRegisteredSuccess": "Gémeo registado com sucesso!",
       "partCreatedSuccess": "Peça serializada criada com sucesso"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "Por favor, selecione uma peça serializada para associar a este DPP",
       "partMustBeRegistered": "A peça serializada selecionada deve ser registada antes de criar um DPP. Por favor, registe-a primeiro.",
-      "partMustBeShared": "A peça serializada selecionada deve ser partilhada antes de criar um DPP. Por favor, partilhe-a primeiro.",
       "provideDppData": "Por favor, forneça dados do DPP antes de continuar. Pode criá-los usando o formulário ou carregar um ficheiro JSON.",
       "validateFirst": "Por favor, valide os dados do DPP antes de continuar."
     },
@@ -165,7 +159,6 @@
       "successMessage": "O seu Passaporte Digital de Produto foi publicado com sucesso!",
       "currentStatus": "Estado Atual",
       "sharePrompt": "Agora pode partilhá-lo com o seu parceiro!",
-      "alreadyShared": "Este DPP já está partilhado com o seu parceiro.",
       "errorOccurred": "Ocorreu um erro ao publicar o DPP"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/pt/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/pt/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "Eliminar Peça Serializada"
     },
     "messages": {
-      "twinRegistered": "Gémeo partilhado com sucesso!",
+      "twinRegistered": "Gémeo registado com sucesso!",
       "twinShared": "Gémeo partilhado com sucesso!",
       "twinUnshared": "Partilha do gémeo anulada com sucesso!",
       "partDeleted": "Peça serializada eliminada com sucesso!",
       "dataRefreshed": "Dados atualizados com sucesso!",
-      "registerFailed": "Partilha falhou",
+      "registerFailed": "Registo falhou",
       "shareFailed": "Partilha falhou",
       "unshareFailed": "Anulação de partilha falhou",
       "deleteFailed": "Eliminação falhou",

--- a/ichub-frontend/src/i18n/locales/zh/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/zh/catalogManagement.json
@@ -147,8 +147,8 @@
         "deleteSerializedPart": "删除序列化零件"
       },
       "messages": {
-        "twinRegisteredSuccess": "孪生共享成功！",
-        "registrationFailed": "共享失败：{{error}}",
+        "twinRegisteredSuccess": "孪生注册成功！",
+        "registrationFailed": "注册失败：{{error}}",
         "sharingFailed": "分享失败：{{error}}",
         "unsharingFailed": "取消分享失败：{{error}}",
         "deletionFailed": "删除失败：{{error}}",

--- a/ichub-frontend/src/i18n/locales/zh/passportProvision.json
+++ b/ichub-frontend/src/i18n/locales/zh/passportProvision.json
@@ -87,23 +87,18 @@
       "selectSerializedPart": "选择序列化零件",
       "chooseSerializedPart": "选择一个序列化零件...",
       "selectedPart": "已选零件",
-      "checkingRegistration": "正在检查共享状态...",
+      "checkingRegistration": "正在检查注册状态...",
       "registrationStatus": "注册状态",
-      "sharingStatus": "共享状态",
-      "notRegistered": "未共享",
+      "notRegistered": "未注册",
       "alreadyHasDpp": "已有DPP",
       "noDppAssigned": "未分配DPP",
       "mustBeRegisteredWarning": "此序列化零件必须先注册为数字孪生才能配置DPP。",
-      "mustBeSharedWarning": "此序列化零件必须先作为数字孪生共享才能配置DPP。",
       "registerSerializedPart": "注册序列化零件",
-      "shareSerializedPart": "共享序列化零件",
       "registerThisPart": "注册此零件",
       "registering": "注册中...",
-      "sharing": "共享中...",
       "orCreateNewPart": "或创建新零件：",
       "createNewSerializedPart": "创建新序列化零件",
-      "twinRegisteredSuccess": "孪生共享成功！",
-      "twinSharedSuccess": "孪生共享成功！",
+      "twinRegisteredSuccess": "孪生注册成功！",
       "partCreatedSuccess": "序列化零件创建成功"
     },
     "step3": {
@@ -152,7 +147,6 @@
     "errors": {
       "selectPart": "请选择要与此DPP关联的序列化零件",
       "partMustBeRegistered": "所选序列化零件必须先注册才能创建DPP。请先注册。",
-      "partMustBeShared": "所选序列化零件必须先共享才能创建DPP。请先共享。",
       "provideDppData": "请在继续之前提供DPP数据。您可以使用表单创建或上传JSON文件。",
       "validateFirst": "请在继续之前验证DPP数据。"
     },
@@ -165,7 +159,6 @@
       "successMessage": "您的数字产品护照已成功发布！",
       "currentStatus": "当前状态",
       "sharePrompt": "现在您可以与合作伙伴分享它！",
-      "alreadyShared": "此DPP已与您的合作伙伴共享。",
       "errorOccurred": "发布DPP时发生错误"
     },
     "preview": {

--- a/ichub-frontend/src/i18n/locales/zh/serializedParts.json
+++ b/ichub-frontend/src/i18n/locales/zh/serializedParts.json
@@ -13,12 +13,12 @@
       "deleteSerializedPart": "删除序列化零件"
     },
     "messages": {
-      "twinRegistered": "孪生共享成功！",
+      "twinRegistered": "孪生注册成功！",
       "twinShared": "孪生分享成功！",
       "twinUnshared": "孪生取消分享成功！",
       "partDeleted": "序列化零件删除成功！",
       "dataRefreshed": "数据刷新成功！",
-      "registerFailed": "共享失败",
+      "registerFailed": "注册失败",
       "shareFailed": "分享失败",
       "unshareFailed": "取消分享失败",
       "deleteFailed": "删除失败",


### PR DESCRIPTION
## WHAT

Restores the **Registered** intermediate status for Serialized Parts, reverting the changes introduced in [PR #521](https://github.com/eclipse-tractusx/industry-core-hub/pull/521) that merged Registration and Sharing into a single step. The status flow is now **Draft → Registered → Shared** again, with distinct actions and icons for each transition.

## WHY

[PR #521](https://github.com/eclipse-tractusx/industry-core-hub/pull/521) removed the Registered state assuming that registration already made twins visible to partners, collapsing the flow into Draft → Shared. This removed a useful intermediate state that allows users to register a twin in the DTR without immediately sharing it via TwinExchange, giving more control over the data sharing lifecycle.

Closes #525