### PR TITLE
fix: Pass bpnl to singletwinresult

### DIFF
--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/pages/PartsDiscovery.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/pages/PartsDiscovery.tsx
@@ -2035,7 +2035,7 @@ const PartsDiscovery = () => {
                 {/* Single Twin Mode Results - Outside Results Display to avoid padding inheritance */}
                 {singleTwinResult && searchMode === 'single' && (
                   <SingleTwinResult 
-                    counterPartyId={selectedPartner?.bpnl || ''} 
+                    counterPartyId={selectedPartner?.bpnl || bpnl}
                     singleTwinResult={singleTwinResult} 
                   />
                 )}
@@ -2044,7 +2044,7 @@ const PartsDiscovery = () => {
                 {viewingTwin && searchMode === 'view' && (
                   <Box sx={{ width: '100%', p: 2 }}>
                     <SingleTwinResult 
-                      counterPartyId={selectedPartner?.bpnl || ''} 
+                      counterPartyId={selectedPartner?.bpnl || bpnl}
                       singleTwinResult={viewingTwin} 
                     />
                   </Box>


### PR DESCRIPTION
## WHAT

The PR passes the manually inserted `bpnl` to the view that shows the discovered twin instead of an empty value. This is necessary when the user discovers a part not by selecting a known partner but by inserting the BPNL manually.

## WHY

See bug description: https://github.com/eclipse-tractusx/industry-core-hub/issues/567

## FURTHER NOTES
none

Closes #567
