### PR TITLE
fix: remove unused registries configuration from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,6 @@
 ###############################################################
 
 version: 2
-registries:
-  github-central-pipelines:
-    type: git
-    url: https://github.com
-    username: x-access-token
-    password: ${{ secrets.CENTRAL_PIPELINES_READ_ONLY_GH_TOKEN }}
-
 updates:
   # Github Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## WHAT

This pull request makes a small update to the `.github/dependabot.yml` configuration file by removing the custom `github-central-pipelines` registry. This simplifies the Dependabot setup and relies on the default configuration.

## WHY

Currently, Dependabot is not working.