### PR TITLE
fix: Remove duplicated submodel config

### DIFF
--- a/charts/industry-core-hub/templates/configmap-backend.yaml
+++ b/charts/industry-core-hub/templates/configmap-backend.yaml
@@ -66,29 +66,6 @@ data:
             operandRight: {{ .Values.backend.configuration.consumer.discovery.digitalTwinRegistry.dct_type_filter.operandRight | quote }}
       connector: {{ .Values.backend.configuration.consumer.connector | toYaml | nindent 8 }}
     provider: {{ .Values.backend.configuration.provider | toYaml | nindent 6 }}
-      submodel_dispatcher:
-      {{- if eq .Values.backend.configuration.provider.submodel_dispatcher.mode "http" }}
-        mode: {{ .Values.backend.configuration.provider.submodel_dispatcher.mode | quote }}
-        path: {{ .Values.backend.configuration.provider.submodel_dispatcher.path | quote }}
-        apiPath: {{ .Values.backend.configuration.provider.submodel_dispatcher.apiPath | quote }}
-        http:
-          base_url: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.base_url | quote }}
-          api_path: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.api_path | quote }}
-          auth:
-            enabled: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.auth.enabled }}
-            type: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.auth.type | quote }}
-            {{- if and .Values.backend.configuration.provider.submodel_dispatcher.http.auth.enabled .Values.backend.configuration.provider.submodel_dispatcher.http.auth.token }}
-            token: "${SUBMODEL_SERVICE_TOKEN}"
-            {{- else }}
-            token: ""
-            {{- end }}
-            key_name: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.auth.key_name | quote }}
-          timeout: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.timeout }}
-          verify_ssl: {{ .Values.backend.configuration.provider.submodel_dispatcher.http.verify_ssl }}
-      {{- else }}
-      {{- /* Filesystem mode - use standard toYaml */}}
-      {{ .Values.backend.configuration.provider.submodel_dispatcher | toYaml | nindent 6 }}
-      {{- end }}
   logging.yml: |-
     version: 1
     disable_existing_loggers: False


### PR DESCRIPTION
## WHAT
This PR removes the specific `submodel_dispatcher` section from the helm chart's backend configuration template.

## WHY
The `submodel_dispatcher` section is a sub-section of `provider` and therefore automatically included with the line `provider: {{ .Values.backend.configuration.provider | toYaml | nindent 6 }}`. The additional declaration of this section leads to a duplicate which additionally is not in a valid yaml format.

## FURTHER NOTES
Rendered ConfigMap after the fix:
```yaml
# Source: industry-core-hub/templates/configmap-backend.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: ic-hub-config
  labels:
    app.kubernetes.io/name: industry-core-hub-backend
    helm.sh/chart: industry-core-hub-v0.5.0
data:
  configuration.yml: |-
    provider: 
      submodel_dispatcher:
        apiPath: /submodel-dispatcher
        http:
          api_path: ""
          auth:
            enabled: false
            key_name: X-Api-Key
            token: ""
            type: apikey
          base_url: https://external-ichub.example.com
          timeout: 30
          verify_ssl: true
        mode: filesystem
        path: /industry-core-hub/data/submodels
```

before the fix:
```yaml
# Source: industry-core-hub/templates/configmap-backend.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: ic-hub-config
  labels:
    app.kubernetes.io/name: industry-core-hub-backend
    helm.sh/chart: industry-core-hub-v0.5.0
data:
  configuration.yml: |-
    provider: 
      submodel_dispatcher:
        apiPath: /submodel-dispatcher
        http:
          api_path: ""
          auth:
            enabled: false
            key_name: X-Api-Key
            token: ""
            type: apikey
          base_url: https://external-ichub.example.com
          timeout: 30
          verify_ssl: true
        mode: filesystem
        path: /industry-core-hub/data/submodels
      submodel_dispatcher:
      
      apiPath: /submodel-dispatcher
      http:
        api_path: ""
        auth:
          enabled: false
          key_name: X-Api-Key
          token: ""
          type: apikey
        base_url: https://external-ichub.example.com
        timeout: 30
        verify_ssl: true
      mode: filesystem
      path: /industry-core-hub/data/submodels

```


Closes  - no issue was created of this PR.
