### PR TITLE
[Frontend] feat: Add 'updated' PCF status and remove individual subpart download buttons

### DIFF
--- a/ichub-frontend/src/features/pcf-kit/pcf-request/api/pcfRequestApi.ts
+++ b/ichub-frontend/src/features/pcf-kit/pcf-request/api/pcfRequestApi.ts
@@ -39,13 +39,14 @@ export interface SubpartPcfResponse {
   supplierName: string;
   manufacturerPartId: string;
   partName: string;
-  pcfStatus: 'pending' | 'delivered' | 'received' | 'rejected' | 'error';
+  pcfStatus: 'pending' | 'delivered' | 'received' | 'rejected' | 'error' | 'updated';
   pcfValue?: number;
   pcfUnit?: string;
   requestedAt?: string;
   deliveredAt?: string;
   errorMessage?: string;
   rejectReason?: string;
+  pcfLocation?: string;
 }
 
 /**
@@ -242,12 +243,15 @@ export async function searchCatalogPartsByManufacturerPartId(
  */
 function convertToSubpartResponse(exchange: PcfExchangeModel): SubpartPcfResponse {
   // Derive UI status from both backend status and type:
+  // type:"response" + updated → 'updated' (certificate updated by supplier)
   // type:"response" + delivered/responded → 'received' (full cycle complete)
   // type:"request" + delivered/responded → 'delivered' (request delivered to supplier)
   const s = exchange.status.toLowerCase();
-  const isDelivered = s === 'delivered' || s === 'responded';
   const isResponse = exchange.type?.toLowerCase() === 'response';
-  const pcfStatus: SubpartPcfResponse['pcfStatus'] = isDelivered
+  const isDelivered = s === 'delivered' || s === 'responded';
+  const pcfStatus: SubpartPcfResponse['pcfStatus'] = s === 'updated' && isResponse
+    ? 'updated'
+    : isDelivered
     ? (isResponse ? 'received' : 'delivered')
     : s === 'rejected' ? 'rejected'
     : (s === 'failed' || s === 'error') ? 'error'
@@ -263,8 +267,10 @@ function convertToSubpartResponse(exchange: PcfExchangeModel): SubpartPcfRespons
     pcfValue: exchange.pcfData?.pcfValue as number | undefined,
     pcfUnit: (exchange.pcfData?.pcfUnit as string) || 'kg CO2e',
     requestedAt: new Date().toISOString(), // API should provide this
+    deliveredAt: exchange.pcfData?.deliveredAt as string | undefined,
     errorMessage: exchange.status.toLowerCase() === 'error' ? exchange.message : undefined,
-    rejectReason: exchange.status.toLowerCase() === 'rejected' ? exchange.message : undefined
+    rejectReason: exchange.status.toLowerCase() === 'rejected' ? exchange.message : undefined,
+    pcfLocation: exchange.pcfLocation
   };
 }
 

--- a/ichub-frontend/src/features/pcf-kit/pcf-request/pages/PcfRequestPage.tsx
+++ b/ichub-frontend/src/features/pcf-kit/pcf-request/pages/PcfRequestPage.tsx
@@ -58,7 +58,8 @@ import {
   AccountTree,
   Send,
   Block,
-  Search
+  Search,
+  SystemUpdateAlt
 } from '@mui/icons-material';
 import { CatalogPartSearch, CatalogPartSearchResult as SharedCatalogPartSearchResult, PartInfoHeader } from '../../shared/components';
 import {
@@ -303,6 +304,8 @@ const PcfRequestPage: React.FC = () => {
         return { color: PCF_PRIMARY, icon: CheckCircle, label: 'Delivered', lineColor: PCF_PRIMARY };
       case 'received':
         return { color: PCF_PRIMARY, icon: MoveToInbox, label: 'Received', lineColor: PCF_PRIMARY };
+      case 'updated':
+        return { color: '#0ea5e9', icon: SystemUpdateAlt, label: 'Updated', lineColor: '#0ea5e9' };
       case 'rejected':
         return { color: '#ef4444', icon: Block, label: 'Rejected', lineColor: '#ef4444' };
       case 'error':
@@ -334,6 +337,8 @@ const PcfRequestPage: React.FC = () => {
               unit: subpart.pcfUnit || 'kg CO₂e'
             })
           : t('precalculation.subpartTooltip.receivedNoValue');
+      case 'updated':
+        return t('precalculation.subpartTooltip.updated');
       case 'rejected':
         return subpart.rejectReason
           ? t('precalculation.subpartTooltip.rejectedWithReason', {
@@ -411,7 +416,7 @@ const PcfRequestPage: React.FC = () => {
   // Calculate progress stats for the main part
   const stats = useMemo(() => {
     if (!partData) return { total: 0, delivered: 0, pending: 0, rejected: 0, error: 0, progress: 0 };
-    const delivered = partData.subparts.filter(s => s.pcfStatus === 'delivered' || s.pcfStatus === 'received').length;
+    const delivered = partData.subparts.filter(s => s.pcfStatus === 'delivered' || s.pcfStatus === 'received' || s.pcfStatus === 'updated').length;
     const total = partData.subparts.length;
     return {
       total,
@@ -1093,9 +1098,9 @@ const PcfRequestPage: React.FC = () => {
                             display: 'flex',
                             alignItems: 'center',
                             gap: 2,
-                            cursor: (subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received') ? 'pointer' : 'default'
+                            cursor: (subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received' || subpart.pcfStatus === 'updated') ? 'pointer' : 'default'
                           }}
-                          onClick={() => (subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received') && toggleSubpartExpansion(subpart.id)}
+                          onClick={() => (subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received' || subpart.pcfStatus === 'updated') && toggleSubpartExpansion(subpart.id)}
                         >
                           {/* Supplier Info */}
                           <Box sx={{ flex: '0 0 200px' }}>
@@ -1136,7 +1141,7 @@ const PcfRequestPage: React.FC = () => {
 
                           {/* PCF Value */}
                           <Box sx={{ flex: '0 0 120px', textAlign: 'right' }}>
-                            {(subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received') && subpart.pcfValue ? (
+                            {(subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received' || subpart.pcfStatus === 'updated') && subpart.pcfValue ? (
                               <Typography variant="body2" sx={{ color: PCF_PRIMARY, fontWeight: 600 }}>
                                 {subpart.pcfValue} {subpart.pcfUnit}
                               </Typography>
@@ -1185,17 +1190,10 @@ const PcfRequestPage: React.FC = () => {
                                     </IconButton>
                                   </Tooltip>
                                 )}
-                                {(subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received') && (
-                                  <>
-                                    <Tooltip title={t('precalculation.downloadPcf')}>
-                                      <IconButton size="small" sx={{ color: 'rgba(255,255,255,0.5)', '&:hover': { color: PCF_PRIMARY } }}>
-                                        <Download sx={{ fontSize: 18 }} />
-                                      </IconButton>
-                                    </Tooltip>
-                                    <IconButton size="small" sx={{ color: 'rgba(255,255,255,0.5)' }}>
-                                      {isExpanded ? <ExpandLess /> : <ExpandMore />}
-                                    </IconButton>
-                                  </>
+                                {(subpart.pcfStatus === 'delivered' || subpart.pcfStatus === 'received' || subpart.pcfStatus === 'updated') && (
+                                  <IconButton size="small" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                                    {isExpanded ? <ExpandLess /> : <ExpandMore />}
+                                  </IconButton>
                                 )}
                               </>
                             )}
@@ -1209,7 +1207,7 @@ const PcfRequestPage: React.FC = () => {
                             <Typography variant="subtitle2" sx={{ color: PCF_PRIMARY, mb: 1.5, fontWeight: 600 }}>
                               {t('precalculation.pcfDetails')}
                             </Typography>
-                            <Box sx={{ display: 'flex', gap: 4 }}>
+                            <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                               <Box>
                                 <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.5)' }}>
                                   {t('precalculation.requestedAt')}
@@ -1231,9 +1229,19 @@ const PcfRequestPage: React.FC = () => {
                                   {t('precalculation.carbonFootprint')}
                                 </Typography>
                                 <Typography variant="body2" sx={{ color: PCF_PRIMARY, fontWeight: 600 }}>
-                                  {subpart.pcfValue} {subpart.pcfUnit}
+                                  {subpart.pcfValue ? `${subpart.pcfValue} ${subpart.pcfUnit}` : '—'}
                                 </Typography>
                               </Box>
+                              {subpart.pcfLocation && (
+                                <Box>
+                                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                                    {t('precalculation.certificateLocation')}
+                                  </Typography>
+                                  <Typography variant="body2" sx={{ color: '#fff', fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-all' }}>
+                                    {subpart.pcfLocation}
+                                  </Typography>
+                                </Box>
+                              )}
                             </Box>
                           </Box>
                         </Collapse>

--- a/ichub-frontend/src/i18n/locales/de/pcf.json
+++ b/ichub-frontend/src/i18n/locales/de/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "Angefordert am",
     "deliveredAt": "Geliefert am",
     "carbonFootprint": "CO2-Fußabdruck",
+    "certificateLocation": "Zertifikatstandort",
     "creatingSubpart": "Unterteil-Beziehung wird erstellt...",
     "addSubpartGhost": "Unterteil-Beziehung hinzufügen",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "PCF-Daten an den Lieferanten geliefert — klicke zum Erweitern der Details.",
       "receivedWithValue": "PCF-Antwort erhalten: {{value}} {{unit}} — klicke zum Erweitern der Details.",
       "receivedNoValue": "PCF-Antwort vom Lieferanten erhalten — klicke zum Erweitern der Details.",
+      "updated": "Zertifikat vom Lieferanten aktualisiert — klicke zum Erweitern der Details.",
       "rejectedWithReason": "Anfrage von Lieferant abgelehnt: {{reason}}",
       "rejectedNoReason": "Die Anfrage wurde vom Lieferanten abgelehnt.",
       "errorWithMessage": "Anfrage fehlgeschlagen: {{error}}",

--- a/ichub-frontend/src/i18n/locales/en/pcf.json
+++ b/ichub-frontend/src/i18n/locales/en/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "Requested At",
     "deliveredAt": "Delivered At",
     "carbonFootprint": "Carbon Footprint",
+    "certificateLocation": "Certificate Location",
     "creatingSubpart": "Creating subpart relation...",
     "addSubpartGhost": "Add Subpart Relation",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "PCF data delivered to supplier — click to expand details.",
       "receivedWithValue": "PCF response received: {{value}} {{unit}} — click to expand details.",
       "receivedNoValue": "PCF response received from supplier — click to expand details.",
+      "updated": "Certificate updated by supplier — click to expand details.",
       "rejectedWithReason": "Request rejected by supplier: {{reason}}",
       "rejectedNoReason": "Request was rejected by the supplier.",
       "errorWithMessage": "Request failed: {{error}}",

--- a/ichub-frontend/src/i18n/locales/es/pcf.json
+++ b/ichub-frontend/src/i18n/locales/es/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "Solicitado el",
     "deliveredAt": "Entregado el",
     "carbonFootprint": "Huella de Carbono",
+    "certificateLocation": "Ubicación del Certificado",
     "creatingSubpart": "Creando relación de subcomponente...",
     "addSubpartGhost": "Añadir Relación de Subcomponente",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "Datos PCF entregados al proveedor — haz clic para expandir detalles.",
       "receivedWithValue": "Respuesta PCF recibida: {{value}} {{unit}} — haz clic para expandir detalles.",
       "receivedNoValue": "Respuesta PCF recibida del proveedor — haz clic para expandir detalles.",
+      "updated": "Certificado actualizado por el proveedor — haz clic para expandir detalles.",
       "rejectedWithReason": "Solicitud rechazada por el proveedor: {{reason}}",
       "rejectedNoReason": "La solicitud fue rechazada por el proveedor.",
       "errorWithMessage": "Error en la solicitud: {{error}}",

--- a/ichub-frontend/src/i18n/locales/fr/pcf.json
+++ b/ichub-frontend/src/i18n/locales/fr/pcf.json
@@ -65,7 +65,9 @@
     "pcfDetails": "Détails du PCF",
     "requestedAt": "Demandé le",
     "deliveredAt": "Livré le",
-    "carbonFootprint": "Empreinte carbone",    "certificateLocation": "Emplacement du certificat",    "creatingSubpart": "Création de la relation de sous-composant...",
+    "carbonFootprint": "Empreinte carbone", 
+    "certificateLocation": "Emplacement du certificat", 
+    "creatingSubpart": "Création de la relation de sous-composant...",
     "addSubpartGhost": "Ajouter une relation de sous-composant",
     "subpartTooltip": {
       "sending": "Envoi de la demande PCF au fournisseur...",

--- a/ichub-frontend/src/i18n/locales/fr/pcf.json
+++ b/ichub-frontend/src/i18n/locales/fr/pcf.json
@@ -65,8 +65,7 @@
     "pcfDetails": "Détails du PCF",
     "requestedAt": "Demandé le",
     "deliveredAt": "Livré le",
-    "carbonFootprint": "Empreinte carbone",
-    "creatingSubpart": "Création de la relation de sous-composant...",
+    "carbonFootprint": "Empreinte carbone",    "certificateLocation": "Emplacement du certificat",    "creatingSubpart": "Création de la relation de sous-composant...",
     "addSubpartGhost": "Ajouter une relation de sous-composant",
     "subpartTooltip": {
       "sending": "Envoi de la demande PCF au fournisseur...",
@@ -76,6 +75,7 @@
       "deliveredNoValue": "Données PCF livrées au fournisseur — cliquez pour développer les détails.",
       "receivedWithValue": "Réponse PCF reçue : {{value}} {{unit}} — cliquez pour développer les détails.",
       "receivedNoValue": "Réponse PCF reçue du fournisseur — cliquez pour développer les détails.",
+      "updated": "Certificat mis à jour par le fournisseur — cliquez pour développer les détails.",
       "rejectedWithReason": "Demande rejetée par le fournisseur : {{reason}}",
       "rejectedNoReason": "La demande a été rejetée par le fournisseur.",
       "errorWithMessage": "Erreur lors de la demande : {{error}}",

--- a/ichub-frontend/src/i18n/locales/ja/pcf.json
+++ b/ichub-frontend/src/i18n/locales/ja/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "リクエスト日時",
     "deliveredAt": "配信日時",
     "carbonFootprint": "カーボンフットプリント",
+    "certificateLocation": "証明書の場所",
     "creatingSubpart": "サブパーツ関係を作成中...",
     "addSubpartGhost": "サブパーツ関係を追加",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "PCFデータをサプライヤーに配信しました — クリックして詳細を展開します。",
       "receivedWithValue": "PCF応答を受信しました：{{value}} {{unit}} — クリックして詳細を展開します。",
       "receivedNoValue": "サプライヤーからPCF応答を受信しました — クリックして詳細を展開します。",
+      "updated": "サプライヤーが証明書を更新しました — クリックして詳細を展開します。",
       "rejectedWithReason": "サプライヤーがリクエストを拒否しました：{{reason}}",
       "rejectedNoReason": "リクエストはサプライヤーによって拒否されました。",
       "errorWithMessage": "リクエスト失敗: {{error}}",

--- a/ichub-frontend/src/i18n/locales/pt/pcf.json
+++ b/ichub-frontend/src/i18n/locales/pt/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "Solicitado em",
     "deliveredAt": "Entregue em",
     "carbonFootprint": "Pegada de Carbono",
+    "certificateLocation": "Local do Certificado",
     "creatingSubpart": "Criando relação de subcomponente...",
     "addSubpartGhost": "Adicionar Relação de Subcomponente",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "Dados PCF entregues ao fornecedor — clique para expandir detalhes.",
       "receivedWithValue": "Resposta PCF recebida: {{value}} {{unit}} — clique para expandir detalhes.",
       "receivedNoValue": "Resposta PCF recebida do fornecedor — clique para expandir detalhes.",
+      "updated": "Certificado atualizado pelo fornecedor — clique para expandir detalhes.",
       "rejectedWithReason": "Solicitação rejeitada pelo fornecedor: {{reason}}",
       "rejectedNoReason": "A solicitação foi rejeitada pelo fornecedor.",
       "errorWithMessage": "Erro na solicitação: {{error}}",

--- a/ichub-frontend/src/i18n/locales/zh/pcf.json
+++ b/ichub-frontend/src/i18n/locales/zh/pcf.json
@@ -66,6 +66,7 @@
     "requestedAt": "请求时间",
     "deliveredAt": "交付时间",
     "carbonFootprint": "碳足迹",
+    "certificateLocation": "证书位置",
     "creatingSubpart": "正在创建子零件关系...",
     "addSubpartGhost": "添加子零件关系",
     "subpartTooltip": {
@@ -76,6 +77,7 @@
       "deliveredNoValue": "PCF数据已交付给供应商 — 单击展开详情。",
       "receivedWithValue": "已收到PCF响应：{{value}} {{unit}} — 单击展开详情。",
       "receivedNoValue": "已从供应商收到PCF响应 — 单击展开详情。",
+      "updated": "供应商已更新证书 — 单击展开详情。",
       "rejectedWithReason": "供应商拒绝了请求：{{reason}}",
       "rejectedNoReason": "该请求已被供应商拒绝。",
       "errorWithMessage": "请求失败：{{error}}",


### PR DESCRIPTION
## WHAT

Implement new `'updated'` PCF subpart status and remove individual download buttons from subpart rows.

**Changes:**
- Added `'updated'` status to `pcfStatus` union type in `SubpartPcfResponse` interface
- Updated data transformation logic to map backend `status: "updated"` + `type: "response"` to UI status `'updated'`
- Added `pcfLocation?: string` field to capture certificate location reference from backend
- Implemented new status display with sky-blue color (`#0ea5e9`) and `SystemUpdateAlt` icon
- Updated progress calculation to count `'updated'` as completed alongside `'delivered'` and `'received'`
- Made `'updated'` status expandible to show details (requestedAt, deliveredAt, certificateLocation)
- Removed individual Download PCF button from each subpart row (kept expand/collapse button only)
- Added translations for new status and certificateLocation field across 7 languages (EN, DE, FR, JA, ZH, PT, ES)

## WHY

The backend now sends notifications when suppliers update their PCF certificates with `status: "updated"` + `type: "response"`. This feature provides visual feedback to users that a certificate has been updated, distinguishing it from initial delivery. Users can click to expand and see the certificate location reference. Individual download buttons were removed to simplify the UI, with aggregated download still available at the top of the page.

## FURTHER NOTES

- **UI Color Scheme:** Sky-blue (`#0ea5e9`) chosen to indicate successful update without repeating the green used for other completed states
- **Icon Selection:** `SystemUpdateAlt` (cloud with arrow) from Material-UI Icons to visually represent certificate update
- **Stats Integration:** `'updated'` status counts toward collection progress percentage
- **Expandable Details:** New conditional rendering for `pcfLocation` in the details section (monospace font for URN format)
- **TypeScript Validation:** No errors; all type definitions properly updated

Closes #