### PR TITLE
feat: Add IDTA batterypass submodels

### DIFF
--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -2,7 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub
 #
 # Copyright (c) 2025 LKS Next
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Capgemini Deutschland GmbH
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -247,6 +248,245 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryNameplate
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.carbon_footprint:1.0.0#CarbonFootprintBattery
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.circularity:1.0.0#Circularity
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.material_composition:1.0.0#MaterialComposition
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.product_condition:1.0.0#ProductCondition
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#TechnicalData
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+
     authorization:
       enabled: true
       apiKey:
@@ -833,6 +1073,153 @@ frontend:
             prohibition: []
             obligation: []
       - semanticid: "urn:samm:io.catenax.us_tariff_information:1.0.0#UsTariffInformation"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryNameplate"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.carbon_footprint:1.0.0#CarbonFootprintBattery"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.circularity:1.0.0#Circularity"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.material_composition:1.0.0#MaterialComposition"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.product_condition:1.0.0#ProductCondition"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#TechnicalData"
         policies:
           - context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -2,7 +2,8 @@
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
 # Copyright (c) 2026 LKS Next
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Capgemini Deutschland GmbH
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -211,7 +212,244 @@ agreements:
             rightOperand: "active"
       prohibitions: []
       obligations: []
-
+  - semanticid: urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryNameplate
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.carbon_footprint:1.0.0#CarbonFootprintBattery"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.circularity:1.0.0#Circularity"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.material_composition:1.0.0#MaterialComposition"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.product_condition:1.0.0#ProductCondition"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
+  - semanticid: "urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#TechnicalData"
+    usage:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "use"
+          constraint:
+            and:
+              - leftOperand: "FrameworkAgreement"
+                operator: "eq"
+                rightOperand: "DataExchangeGovernance:1.0"
+              - leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+              - leftOperand: "UsagePurpose"
+                operator: "isAnyOf"
+                rightOperand: "cx.core.industrycore:1"
+      prohibitions: []
+      obligations: []
+    access:
+      context:
+        - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+        - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+        - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      permissions:
+        - action: "access"
+          constraint:
+            leftOperand: "Membership"
+            operator: "eq"
+            rightOperand: "active"
+      prohibitions: []
+      obligations: []
 database:
   connection_string: "postgresql://user:password@localhost:5432/ichub"
   echo: false

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/CarbonFootprintBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/CarbonFootprintBatteryViewer.tsx
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Link,
+  Divider,
+} from '@mui/material';
+import Co2Icon from '@mui/icons-material/Co2';
+import ScienceIcon from '@mui/icons-material/Science';
+import PublicIcon from '@mui/icons-material/Public';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { InfoRow } from '../battery-pass-shared/InfoRow';
+import { CarbonFootprintBattery } from './types';
+
+const isHttpUrl = (s: string) => /^https?:\/\//i.test(s);
+
+export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFootprintBattery>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<CarbonFootprintBattery>(rawData);
+  if (!data) return null;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Carbon Footprint"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {data.ProductCarbonFootprints.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No carbon footprint data available.
+          </Typography>
+        )}
+        {data.ProductCarbonFootprints.map((pcf, i) => (
+          <Card key={`pcf-${i}`}>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <Co2Icon color="primary" />
+                {data.ProductCarbonFootprints.length > 1
+                  ? `Carbon Footprint Entry ${i + 1}`
+                  : 'Product Carbon Footprint'}
+              </Typography>
+
+              <Grid2 container spacing={2}>
+                <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
+                  <Typography variant="subtitle2" color="text.secondary">CO₂ Equivalent</Typography>
+                  <Typography variant="body1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
+                    {pcf.PcfCo2eq} kg CO₂-eq / {pcf.QuantityOfMeasureForCalculation} {pcf.ReferenceImpactUnitForCalculation}
+                  </Typography>
+                </Grid2>
+                <InfoRow label="Performance Class" value={pcf.PerformanceClass} />
+              </Grid2>
+
+              {pcf.PcfCalculationMethods && pcf.PcfCalculationMethods.length > 0 && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <ScienceIcon fontSize="small" color="action" />
+                    Calculation Methods
+                  </Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {pcf.PcfCalculationMethods.map((method) => (
+                      <Chip key={method} label={method} size="small" variant="outlined" />
+                    ))}
+                  </Box>
+                </>
+              )}
+
+              {pcf.LifeCyclePhases && pcf.LifeCyclePhases.length > 0 && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Life Cycle Phases</Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {pcf.LifeCyclePhases.map((phase) => (
+                      <Chip key={phase} label={phase} size="small" color="info" variant="outlined" />
+                    ))}
+                  </Box>
+                </>
+              )}
+
+              {pcf.WebLinkToPublicCarbonFootprintStudy && pcf.WebLinkToPublicCarbonFootprintStudy.length > 0 && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <PublicIcon fontSize="small" color="action" />
+                    Public Carbon Footprint Studies
+                  </Typography>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    {pcf.WebLinkToPublicCarbonFootprintStudy.map((link) =>
+                      isHttpUrl(link) ? (
+                        <Link
+                          key={link}
+                          href={link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          sx={{ fontSize: '0.85rem', fontFamily: 'monospace', wordBreak: 'break-all' }}
+                        >
+                          {link}
+                        </Link>
+                      ) : (
+                        <Chip
+                          key={link}
+                          label={link}
+                          size="small"
+                          variant="outlined"
+                          sx={{ fontFamily: 'monospace', fontSize: '0.75rem', maxWidth: '100%' }}
+                        />
+                      )
+                    )}
+                  </Box>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/CarbonFootprintBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/CarbonFootprintBatteryViewer.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -48,17 +49,18 @@ export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFoo
   semanticId,
 }) => {
   const data = unwrapSubmodelData<CarbonFootprintBattery>(rawData);
+  const { t } = useTranslation('batteryPass');
   if (!data) return null;
 
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Carbon Footprint"
+      title={t('carbonFootprint.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {data.ProductCarbonFootprints.length === 0 && (
           <Typography variant="body2" color="text.secondary">
-            No carbon footprint data available.
+            {t('carbonFootprint.empty')}
           </Typography>
         )}
         {data.ProductCarbonFootprints.map((pcf, i) => (
@@ -67,18 +69,18 @@ export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFoo
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <Co2Icon color="primary" />
                 {data.ProductCarbonFootprints.length > 1
-                  ? `Carbon Footprint Entry ${i + 1}`
-                  : 'Product Carbon Footprint'}
+                  ? t('carbonFootprint.entry', { index: i + 1 })
+                  : t('carbonFootprint.single')}
               </Typography>
 
               <Grid2 container spacing={2}>
                 <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
-                  <Typography variant="subtitle2" color="text.secondary">CO₂ Equivalent</Typography>
+                  <Typography variant="subtitle2" color="text.secondary">{t('carbonFootprint.fields.co2Equivalent')}</Typography>
                   <Typography variant="body1" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
                     {pcf.PcfCo2eq} kg CO₂-eq / {pcf.QuantityOfMeasureForCalculation} {pcf.ReferenceImpactUnitForCalculation}
                   </Typography>
                 </Grid2>
-                <InfoRow label="Performance Class" value={pcf.PerformanceClass} />
+                <InfoRow label={t('carbonFootprint.fields.performanceClass')} value={pcf.PerformanceClass} />
               </Grid2>
 
               {pcf.PcfCalculationMethods && pcf.PcfCalculationMethods.length > 0 && (
@@ -86,7 +88,7 @@ export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFoo
                   <Divider sx={{ my: 2 }} />
                   <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                     <ScienceIcon fontSize="small" color="action" />
-                    Calculation Methods
+                    {t('carbonFootprint.sections.calculationMethods')}
                   </Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     {pcf.PcfCalculationMethods.map((method) => (
@@ -99,7 +101,7 @@ export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFoo
               {pcf.LifeCyclePhases && pcf.LifeCyclePhases.length > 0 && (
                 <>
                   <Divider sx={{ my: 2 }} />
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Life Cycle Phases</Typography>
+                  <Typography variant="subtitle1" sx={{ mb: 1 }}>{t('carbonFootprint.sections.lifeCyclePhases')}</Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     {pcf.LifeCyclePhases.map((phase) => (
                       <Chip key={phase} label={phase} size="small" color="info" variant="outlined" />
@@ -113,7 +115,7 @@ export const CarbonFootprintBatteryViewer: React.FC<SubmodelAddonProps<CarbonFoo
                   <Divider sx={{ my: 2 }} />
                   <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                     <PublicIcon fontSize="small" color="action" />
-                    Public Carbon Footprint Studies
+                    {t('carbonFootprint.sections.publicStudies')}
                   </Typography>
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                     {pcf.WebLinkToPublicCarbonFootprintStudy.map((link) =>

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  CarbonFootprintBattery,
+  BATTERY_PASS_CARBON_FOOTPRINT_NAMESPACE,
+  BATTERY_PASS_CARBON_FOOTPRINT_MODEL_NAME,
+  BATTERY_PASS_CARBON_FOOTPRINT_SEMANTIC_ID,
+  isCarbonFootprintBattery,
+} from './types';
+import { CarbonFootprintBatteryViewer } from '.';
+
+export const batteryPassCarbonFootprintAddon: VersionedSubmodelAddon<CarbonFootprintBattery> = {
+  id: 'battery-pass-carbon-footprint',
+  name: 'Battery Pass Carbon Footprint',
+  description: 'Specialized visualization for IDTA BatteryPass Carbon Footprint submodels including CO₂ equivalent values, life cycle phases, and calculation methods.',
+  namespace: BATTERY_PASS_CARBON_FOOTPRINT_NAMESPACE,
+  modelName: BATTERY_PASS_CARBON_FOOTPRINT_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_CARBON_FOOTPRINT_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isCarbonFootprintBattery,
+  component: CarbonFootprintBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { CarbonFootprintBatteryViewer } from './CarbonFootprintBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-carbon-footprint/types.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Carbon Footprint submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.carbon_footprint:1.0.0#CarbonFootprintBattery
+ */
+
+export const BATTERY_PASS_CARBON_FOOTPRINT_NAMESPACE =
+  'io.admin-shell.idta.batterypass.carbon_footprint';
+export const BATTERY_PASS_CARBON_FOOTPRINT_MODEL_NAME = 'CarbonFootprintBattery';
+
+export const BATTERY_PASS_CARBON_FOOTPRINT_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_CARBON_FOOTPRINT_NAMESPACE}:1.0.0#${BATTERY_PASS_CARBON_FOOTPRINT_MODEL_NAME}`;
+
+export type ReferenceImpactUnit = 'g' | 'kg' | 't' | 'ml' | 'l' | 'cbm' | 'qm' | 'piece' | 'kwH';
+
+export interface ProductCarbonFootprint {
+  PcfCalculationMethods: string[];
+  PcfCo2eq: number;
+  ReferenceImpactUnitForCalculation: ReferenceImpactUnit;
+  QuantityOfMeasureForCalculation: number;
+  LifeCyclePhases: string[];
+  PerformanceClass: string;
+  WebLinkToPublicCarbonFootprintStudy: string[];
+}
+
+export interface CarbonFootprintBattery {
+  ProductCarbonFootprints: ProductCarbonFootprint[];
+}
+
+export function isCarbonFootprintBattery(
+  _semanticId: string,
+  data: unknown
+): data is CarbonFootprintBattery {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'ProductCarbonFootprints' in obj &&
+    Array.isArray((obj as CarbonFootprintBattery).ProductCarbonFootprints)
+  );
+}

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/CircularityBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/CircularityBatteryViewer.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -54,21 +55,23 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
   semanticId,
 }) => {
   const data = unwrapSubmodelData<Circularity>(rawData);
+  const { t } = useTranslation('batteryPass');
   if (!data) return null;
 
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Circularity"
+      title={t('circularity.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
 
         {/* Renewable Content */}
         <Card>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <RecyclingIcon color="primary" />
-              Renewable Content
+              {t('circularity.sections.renewableContent')}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
               <Box sx={{ flex: 1 }}>
@@ -92,7 +95,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <RecyclingIcon color="primary" />
-                Recycled Content
+                {t('circularity.sections.recycledContent')}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 {data.RecycledContentInformation.map((rc) => (
@@ -103,7 +106,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
                       </Typography>
                       <Grid2 container spacing={2}>
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Pre-consumer Share</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('circularity.fields.preConsumerShare')}</Typography>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <LinearProgress
                               variant="determinate"
@@ -115,7 +118,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
                           </Box>
                         </Grid2>
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Post-consumer Share</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('circularity.fields.postConsumerShare')}</Typography>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <LinearProgress
                               variant="determinate"
@@ -141,7 +144,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <BuildIcon color="primary" />
-                Dismantling &amp; Removal Information
+                {t('circularity.sections.dismantling')}
               </Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                 {data.DismantlingAndRemovalInformation.map((doc) => (
@@ -158,7 +161,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <StorefrontIcon color="primary" />
-                Spare Part Sources
+                {t('circularity.sections.sparePartSources')}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 {data.SparePartSources.map((supplier) => (
@@ -169,16 +172,16 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
                       </Typography>
                       <Grid2 container spacing={2}>
                         <InfoRow
-                          label="Address"
+                          label={t('circularity.fields.address')}
                           value={[
                             getMultiLangValue(supplier.AddressOfSupplier.Street),
                             getMultiLangValue(supplier.AddressOfSupplier.PostalCode),
                             getMultiLangValue(supplier.AddressOfSupplier.NationalCode),
                           ].filter(Boolean).join(', ')}
                         />
-                        <InfoRow label="Email" value={supplier.EmailAddressOfSupplier.EmailAddress} />
+                        <InfoRow label={t('circularity.fields.email')} value={supplier.EmailAddressOfSupplier.EmailAddress} />
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Website</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('circularity.fields.website')}</Typography>
                           <Link href={supplier.SupplierWebAddress} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.875rem' }}>
                             {supplier.SupplierWebAddress}
                           </Link>
@@ -187,7 +190,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
                       {supplier.Components && supplier.Components.length > 0 && (
                         <>
                           <Divider sx={{ my: 1.5 }} />
-                          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Components</Typography>
+                          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.components')}</Typography>
                           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                             {supplier.Components.map((comp) => (
                               <Chip key={comp.PartNumber} label={`${comp.PartName} (${comp.PartNumber})`} size="small" variant="outlined" />
@@ -208,11 +211,11 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <SecurityIcon color="primary" />
-              Safety Measures
+              {t('circularity.sections.safetyMeasures')}
             </Typography>
             {data.SafetyMeasures.SafetyInstructions && data.SafetyMeasures.SafetyInstructions.length > 0 && (
               <>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Safety Instructions</Typography>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.safetyInstructions')}</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
                   {data.SafetyMeasures.SafetyInstructions.map((doc) => (
                     <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
@@ -222,7 +225,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
             )}
             {data.SafetyMeasures.ExtinguishingAgents && data.SafetyMeasures.ExtinguishingAgents.length > 0 && (
               <>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Extinguishing Agents</Typography>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.extinguishingAgents')}</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {data.SafetyMeasures.ExtinguishingAgents.map((agent) => (
                     <Chip key={agent} label={agent} size="small" color="warning" variant="outlined" />
@@ -238,12 +241,12 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <DeleteIcon color="primary" />
-              End of Life Information
+              {t('circularity.sections.endOfLife')}
             </Typography>
             <Grid2 container spacing={2}>
               {data.EndOfLifeInformation.WastePrevention && data.EndOfLifeInformation.WastePrevention.length > 0 && (
                 <Grid2 size={12}>
-                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Waste Prevention</Typography>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.wastePrevention')}</Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     {data.EndOfLifeInformation.WastePrevention.map((doc) => (
                       <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
@@ -253,7 +256,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
               )}
               {data.EndOfLifeInformation.SeparateCollection && data.EndOfLifeInformation.SeparateCollection.length > 0 && (
                 <Grid2 size={12}>
-                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Separate Collection</Typography>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.separateCollection')}</Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     {data.EndOfLifeInformation.SeparateCollection.map((doc) => (
                       <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
@@ -263,7 +266,7 @@ export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>>
               )}
               {data.EndOfLifeInformation.InformationOnCollection && data.EndOfLifeInformation.InformationOnCollection.length > 0 && (
                 <Grid2 size={12}>
-                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Information on Collection</Typography>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('circularity.fields.informationOnCollection')}</Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                     {data.EndOfLifeInformation.InformationOnCollection.map((doc) => (
                       <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/CircularityBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/CircularityBatteryViewer.tsx
@@ -1,0 +1,281 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Link,
+  Divider,
+  LinearProgress,
+} from '@mui/material';
+import RecyclingIcon from '@mui/icons-material/Recycling';
+import BuildIcon from '@mui/icons-material/Build';
+import SecurityIcon from '@mui/icons-material/Security';
+import DeleteIcon from '@mui/icons-material/Delete';
+import StorefrontIcon from '@mui/icons-material/Storefront';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { InfoRow } from '../battery-pass-shared/InfoRow';
+import { Circularity, getMultiLangValue } from './types';
+
+function toPercent(v: number): number {
+  const pct = v > 1 ? v : v * 100;
+  return Math.max(0, Math.min(pct, 100));
+}
+
+export const CircularityBatteryViewer: React.FC<SubmodelAddonProps<Circularity>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<Circularity>(rawData);
+  if (!data) return null;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Circularity"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        {/* Renewable Content */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <RecyclingIcon color="primary" />
+              Renewable Content
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Box sx={{ flex: 1 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={toPercent(data.RenewableContent)}
+                  color="success"
+                  sx={{ height: 10, borderRadius: 5 }}
+                />
+              </Box>
+              <Typography variant="body1" sx={{ fontWeight: 600, minWidth: 60 }}>
+                {toPercent(data.RenewableContent).toFixed(1)}%
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Recycled Content */}
+        {data.RecycledContentInformation && data.RecycledContentInformation.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <RecyclingIcon color="primary" />
+                Recycled Content
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {data.RecycledContentInformation.map((rc) => (
+                  <Card key={rc.RecycledMaterial} variant="outlined">
+                    <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+                        {rc.RecycledMaterial}
+                      </Typography>
+                      <Grid2 container spacing={2}>
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Pre-consumer Share</Typography>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <LinearProgress
+                              variant="determinate"
+                              value={toPercent(rc.PreConsumerShare)}
+                              color="info"
+                              sx={{ flex: 1, height: 8, borderRadius: 4 }}
+                            />
+                            <Typography variant="body2">{toPercent(rc.PreConsumerShare).toFixed(1)}%</Typography>
+                          </Box>
+                        </Grid2>
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Post-consumer Share</Typography>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <LinearProgress
+                              variant="determinate"
+                              value={toPercent(rc.PostConsumerShare)}
+                              color="success"
+                              sx={{ flex: 1, height: 8, borderRadius: 4 }}
+                            />
+                            <Typography variant="body2">{toPercent(rc.PostConsumerShare).toFixed(1)}%</Typography>
+                          </Box>
+                        </Grid2>
+                      </Grid2>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Dismantling */}
+        {data.DismantlingAndRemovalInformation && data.DismantlingAndRemovalInformation.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <BuildIcon color="primary" />
+                Dismantling &amp; Removal Information
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {data.DismantlingAndRemovalInformation.map((doc) => (
+                  <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Spare Part Sources */}
+        {data.SparePartSources && data.SparePartSources.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <StorefrontIcon color="primary" />
+                Spare Part Sources
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {data.SparePartSources.map((supplier) => (
+                  <Card key={supplier.SupplierWebAddress} variant="outlined">
+                    <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+                        {getMultiLangValue(supplier.NameOfSupplier)}
+                      </Typography>
+                      <Grid2 container spacing={2}>
+                        <InfoRow
+                          label="Address"
+                          value={[
+                            getMultiLangValue(supplier.AddressOfSupplier.Street),
+                            getMultiLangValue(supplier.AddressOfSupplier.PostalCode),
+                            getMultiLangValue(supplier.AddressOfSupplier.NationalCode),
+                          ].filter(Boolean).join(', ')}
+                        />
+                        <InfoRow label="Email" value={supplier.EmailAddressOfSupplier.EmailAddress} />
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Website</Typography>
+                          <Link href={supplier.SupplierWebAddress} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.875rem' }}>
+                            {supplier.SupplierWebAddress}
+                          </Link>
+                        </Grid2>
+                      </Grid2>
+                      {supplier.Components && supplier.Components.length > 0 && (
+                        <>
+                          <Divider sx={{ my: 1.5 }} />
+                          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Components</Typography>
+                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                            {supplier.Components.map((comp) => (
+                              <Chip key={comp.PartNumber} label={`${comp.PartName} (${comp.PartNumber})`} size="small" variant="outlined" />
+                            ))}
+                          </Box>
+                        </>
+                      )}
+                    </CardContent>
+                  </Card>
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Safety Measures */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <SecurityIcon color="primary" />
+              Safety Measures
+            </Typography>
+            {data.SafetyMeasures.SafetyInstructions && data.SafetyMeasures.SafetyInstructions.length > 0 && (
+              <>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Safety Instructions</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                  {data.SafetyMeasures.SafetyInstructions.map((doc) => (
+                    <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                  ))}
+                </Box>
+              </>
+            )}
+            {data.SafetyMeasures.ExtinguishingAgents && data.SafetyMeasures.ExtinguishingAgents.length > 0 && (
+              <>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Extinguishing Agents</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {data.SafetyMeasures.ExtinguishingAgents.map((agent) => (
+                    <Chip key={agent} label={agent} size="small" color="warning" variant="outlined" />
+                  ))}
+                </Box>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* End of Life */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <DeleteIcon color="primary" />
+              End of Life Information
+            </Typography>
+            <Grid2 container spacing={2}>
+              {data.EndOfLifeInformation.WastePrevention && data.EndOfLifeInformation.WastePrevention.length > 0 && (
+                <Grid2 size={12}>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Waste Prevention</Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {data.EndOfLifeInformation.WastePrevention.map((doc) => (
+                      <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                    ))}
+                  </Box>
+                </Grid2>
+              )}
+              {data.EndOfLifeInformation.SeparateCollection && data.EndOfLifeInformation.SeparateCollection.length > 0 && (
+                <Grid2 size={12}>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Separate Collection</Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {data.EndOfLifeInformation.SeparateCollection.map((doc) => (
+                      <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                    ))}
+                  </Box>
+                </Grid2>
+              )}
+              {data.EndOfLifeInformation.InformationOnCollection && data.EndOfLifeInformation.InformationOnCollection.length > 0 && (
+                <Grid2 size={12}>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Information on Collection</Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {data.EndOfLifeInformation.InformationOnCollection.map((doc) => (
+                      <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                    ))}
+                  </Box>
+                </Grid2>
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  Circularity,
+  BATTERY_PASS_CIRCULARITY_NAMESPACE,
+  BATTERY_PASS_CIRCULARITY_MODEL_NAME,
+  BATTERY_PASS_CIRCULARITY_SEMANTIC_ID,
+  isCircularity,
+} from './types';
+import { CircularityBatteryViewer } from '.';
+
+export const batteryPassCircularityAddon: VersionedSubmodelAddon<Circularity> = {
+  id: 'battery-pass-circularity',
+  name: 'Battery Pass Circularity',
+  description: 'Specialized visualization for IDTA BatteryPass Circularity submodels including recycled content, spare parts, safety measures, and end-of-life information.',
+  namespace: BATTERY_PASS_CIRCULARITY_NAMESPACE,
+  modelName: BATTERY_PASS_CIRCULARITY_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_CIRCULARITY_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isCircularity,
+  component: CircularityBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { CircularityBatteryViewer } from './CircularityBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-circularity/types.ts
@@ -1,0 +1,103 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Circularity submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.circularity:1.0.0#Circularity
+ */
+
+export const BATTERY_PASS_CIRCULARITY_NAMESPACE =
+  'io.admin-shell.idta.batterypass.circularity';
+export const BATTERY_PASS_CIRCULARITY_MODEL_NAME = 'Circularity';
+
+export const BATTERY_PASS_CIRCULARITY_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_CIRCULARITY_NAMESPACE}:1.0.0#${BATTERY_PASS_CIRCULARITY_MODEL_NAME}`;
+
+import type { MultiLangEntry } from '../battery-pass-shared/types';
+export type { MultiLangEntry };
+export { getMultiLangValue } from '../battery-pass-shared/types';
+
+export interface PostalAddress {
+  NationalCode: MultiLangEntry[];
+  PostalCode: MultiLangEntry[];
+  Street: MultiLangEntry[];
+}
+
+export interface EmailEntity {
+  EmailAddress: string;
+  TypeOfEmailAddress?: string;
+}
+
+export interface SparePartComponent {
+  PartName: string;
+  PartNumber: string;
+}
+
+export interface SparePartSupplier {
+  NameOfSupplier: MultiLangEntry[];
+  AddressOfSupplier: PostalAddress;
+  EmailAddressOfSupplier: EmailEntity;
+  SupplierWebAddress: string;
+  Components: SparePartComponent[];
+}
+
+export interface RecycledContent {
+  PreConsumerShare: number;
+  RecycledMaterial: string;
+  PostConsumerShare: number;
+}
+
+export interface SafetyMeasures {
+  SafetyInstructions: string[];
+  ExtinguishingAgents: string[];
+}
+
+export interface EndOfLifeInformation {
+  WastePrevention: string[];
+  SeparateCollection: string[];
+  InformationOnCollection: string[];
+}
+
+export interface Circularity {
+  DismantlingAndRemovalInformation: string[];
+  SparePartSources: SparePartSupplier[];
+  RecycledContentInformation: RecycledContent[];
+  SafetyMeasures: SafetyMeasures;
+  EndOfLifeInformation: EndOfLifeInformation;
+  RenewableContent: number;
+}
+
+export function isCircularity(
+  _semanticId: string,
+  data: unknown
+): data is Circularity {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'DismantlingAndRemovalInformation' in obj &&
+    'SafetyMeasures' in obj &&
+    'EndOfLifeInformation' in obj
+  );
+}
+

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/BatteryPassDigitalNameplateViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/BatteryPassDigitalNameplateViewer.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -60,17 +61,18 @@ const LIFECYCLE_COLORS: Record<BatteryLifeCycleStage, 'success' | 'info' | 'warn
 };
 
 const LIFECYCLE_DESCRIPTIONS: Record<BatteryLifeCycleStage, string> = {
-  original: 'Battery is new and has never been repurposed or remanufactured.',
-  repurposed: 'Battery has been repurposed for a different application.',
-  're-used': 'Battery has been reused in the same or similar application.',
-  remanufactured: 'Battery has been remanufactured to restore its performance.',
-  waste: 'Battery has reached end-of-life and is classified as waste.',
+  original: 'digitalNameplate.lifecycle.original',
+  repurposed: 'digitalNameplate.lifecycle.repurposed',
+  're-used': 'digitalNameplate.lifecycle.re-used',
+  remanufactured: 'digitalNameplate.lifecycle.remanufactured',
+  waste: 'digitalNameplate.lifecycle.waste',
 };
 
 export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<BatteryPassDigitalNameplate>> = ({
   data: rawData,
   semanticId,
 }) => {
+  const { t } = useTranslation('batteryPass');
   const data = unwrapSubmodelData<BatteryPassDigitalNameplate>(rawData);
   if (!data) return null;
   const addr = data.AddressInformation;
@@ -81,7 +83,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
 
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Digital Nameplate"
+      title={t('digitalNameplate.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -91,11 +93,11 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <FingerprintIcon color="primary" />
-              Product Identification
+              {t('digitalNameplate.sections.productIdentification')}
             </Typography>
             <Grid2 container spacing={2}>
               <Grid2 size={12}>
-                <Typography variant="subtitle2" color="text.secondary">Battery Passport URI</Typography>
+                <Typography variant="subtitle2" color="text.secondary">{t('digitalNameplate.fields.batteryPassportUri')}</Typography>
                 <Link
                   href={data.URIOfTheProduct}
                   target="_blank"
@@ -105,10 +107,10 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                   {data.URIOfTheProduct}
                 </Link>
               </Grid2>
-              <InfoRow label="Serial Number" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.SerialNumber}</Box>} />
-              <InfoRow label="Manufacturer Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.ManufacturerIdentifier}</Box>} />
+              <InfoRow label={t('digitalNameplate.fields.serialNumber')} value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.SerialNumber}</Box>} />
+              <InfoRow label={t('digitalNameplate.fields.manufacturerIdentifier')} value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.ManufacturerIdentifier}</Box>} />
               {data.OperatorIdentifier && (
-                <InfoRow label="Operator Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.OperatorIdentifier}</Box>} />
+                <InfoRow label={t('digitalNameplate.fields.operatorIdentifier')} value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.OperatorIdentifier}</Box>} />
               )}
             </Grid2>
           </CardContent>
@@ -119,7 +121,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BatteryChargingFullIcon color="primary" />
-              Lifecycle Status
+              {t('digitalNameplate.sections.lifecycleStatus')}
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
               <Chip
@@ -128,7 +130,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                 sx={{ fontWeight: 600, textTransform: 'capitalize' }}
               />
               <Typography variant="body2" color="text.secondary">
-                {LIFECYCLE_DESCRIPTIONS[data.LifeCycleStage]}
+                {t(LIFECYCLE_DESCRIPTIONS[data.LifeCycleStage])}
               </Typography>
             </Box>
           </CardContent>
@@ -139,14 +141,14 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <FactoryIcon color="primary" />
-              Manufacturing Details
+              {t('digitalNameplate.sections.manufacturingDetails')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Date of Manufacture" value={data.DateOfManufacture} />
+              <InfoRow label={t('digitalNameplate.fields.dateOfManufacture')} value={data.DateOfManufacture} />
               {data.DateOfPuttingIntoService && (
-                <InfoRow label="Date of Putting Into Service" value={data.DateOfPuttingIntoService} />
+                <InfoRow label={t('digitalNameplate.fields.dateOfPuttingIntoService')} value={data.DateOfPuttingIntoService} />
               )}
-              <InfoRow label="Unique Facility Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.UniqueFacilityIdentifier}</Box>} />
+              <InfoRow label={t('digitalNameplate.fields.uniqueFacilityIdentifier')} value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.UniqueFacilityIdentifier}</Box>} />
             </Grid2>
           </CardContent>
         </Card>
@@ -156,25 +158,25 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BusinessIcon color="primary" />
-              Manufacturer Information
+              {t('digitalNameplate.sections.manufacturerInformation')}
             </Typography>
             <Grid2 container spacing={2}>
               <InfoRow
-                label="Manufacturer Name"
+                label={t('digitalNameplate.fields.manufacturerName')}
                 value={getMultiLangValue(data.ManufacturerName)}
               />
               {addr.Company && (
-                <InfoRow label="Company" value={getMultiLangValue(addr.Company)} />
+                <InfoRow label={t('digitalNameplate.fields.company')} value={getMultiLangValue(addr.Company)} />
               )}
               {addr.Department && (
-                <InfoRow label="Department" value={getMultiLangValue(addr.Department)} />
+                <InfoRow label={t('digitalNameplate.fields.department')} value={getMultiLangValue(addr.Department)} />
               )}
               {addr.RoleOfContactPerson && (
-                <InfoRow label="Contact Role" value={addr.RoleOfContactPerson} />
+                <InfoRow label={t('digitalNameplate.fields.contactRole')} value={addr.RoleOfContactPerson} />
               )}
               {(addr.NameOfContact || addr.FirstName) && (
                 <InfoRow
-                  label="Contact Person"
+                  label={t('digitalNameplate.fields.contactPerson')}
                   value={[
                     addr.Title && getMultiLangValue(addr.Title),
                     addr.AcademicTitle && getMultiLangValue(addr.AcademicTitle),
@@ -190,23 +192,23 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
 
             <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
               <LocationOnIcon fontSize="small" color="action" />
-              Address
+              {t('digitalNameplate.sections.address')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Street" value={getMultiLangValue(addr.Street)} />
-              <InfoRow label="City / Town" value={getMultiLangValue(addr.CityTown)} />
-              <InfoRow label="Zip Code" value={getMultiLangValue(addr.ZipCode)} />
+              <InfoRow label={t('digitalNameplate.fields.street')} value={getMultiLangValue(addr.Street)} />
+              <InfoRow label={t('digitalNameplate.fields.cityTown')} value={getMultiLangValue(addr.CityTown)} />
+              <InfoRow label={t('digitalNameplate.fields.zipCode')} value={getMultiLangValue(addr.ZipCode)} />
               {addr.StateCounty && (
-                <InfoRow label="State / County" value={getMultiLangValue(addr.StateCounty)} />
+                <InfoRow label={t('digitalNameplate.fields.stateCounty')} value={getMultiLangValue(addr.StateCounty)} />
               )}
-              <InfoRow label="Country" value={getMultiLangValue(addr.NationalCode)} />
-              {addr.TimeZone && <InfoRow label="Time Zone" value={addr.TimeZone} />}
+              <InfoRow label={t('digitalNameplate.fields.country')} value={getMultiLangValue(addr.NationalCode)} />
+              {addr.TimeZone && <InfoRow label={t('digitalNameplate.fields.timeZone')} value={addr.TimeZone} />}
               {addr.POBox && (
-                <InfoRow label="P.O. Box" value={`${getMultiLangValue(addr.POBox)}${addr.ZipCodeOfPOBox ? ', ' + getMultiLangValue(addr.ZipCodeOfPOBox) : ''}`} />
+                <InfoRow label={t('digitalNameplate.fields.poBox')} value={`${getMultiLangValue(addr.POBox)}${addr.ZipCodeOfPOBox ? ', ' + getMultiLangValue(addr.ZipCodeOfPOBox) : ''}`} />
               )}
               {addr.AddressOfAdditionalLink && (
                 <Grid2 size={12}>
-                  <Typography variant="subtitle2" color="text.secondary">Website</Typography>
+                  <Typography variant="subtitle2" color="text.secondary">{t('digitalNameplate.fields.website')}</Typography>
                   <Link href={addr.AddressOfAdditionalLink} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.875rem' }}>
                     {addr.AddressOfAdditionalLink}
                   </Link>
@@ -219,18 +221,18 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                 <Divider sx={{ my: 2 }} />
                 <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
                   <PhoneIcon fontSize="small" color="action" />
-                  Contact
+                  {t('digitalNameplate.sections.contact')}
                 </Typography>
                 <Grid2 container spacing={2}>
                   {addr.Phone && (
                     <InfoRow
-                      label={`Phone${addr.Phone.TypeOfTelephone ? ` (${addr.Phone.TypeOfTelephone})` : ''}`}
+                      label={`${t('digitalNameplate.fields.phone')}${addr.Phone.TypeOfTelephone ? ` (${addr.Phone.TypeOfTelephone})` : ''}`}
                       value={getMultiLangValue(addr.Phone.TelephoneNumber)}
                     />
                   )}
                   {addr.Fax && (
                     <InfoRow
-                      label={`Fax${addr.Fax.TypeOfFaxNumber ? ` (${addr.Fax.TypeOfFaxNumber})` : ''}`}
+                      label={`${t('digitalNameplate.fields.fax')}${addr.Fax.TypeOfFaxNumber ? ` (${addr.Fax.TypeOfFaxNumber})` : ''}`}
                       value={getMultiLangValue(addr.Fax.FaxNumber)}
                     />
                   )}
@@ -238,7 +240,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                     <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
                       <Typography variant="subtitle2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                         <EmailIcon fontSize="small" />
-                        Email{addr.Email.TypeOfEmailAddress ? ` (${addr.Email.TypeOfEmailAddress})` : ''}
+                        {t('digitalNameplate.fields.email')}{addr.Email.TypeOfEmailAddress ? ` (${addr.Email.TypeOfEmailAddress})` : ''}
                       </Typography>
                       <Link href={`mailto:${addr.Email.EmailAddress}`} sx={{ fontSize: '0.875rem' }}>
                         {addr.Email.EmailAddress}
@@ -252,7 +254,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
             {addr.IPCommunicationChannels && addr.IPCommunicationChannels.length > 0 && (
               <>
                 <Divider sx={{ my: 2 }} />
-                <Typography variant="subtitle1" sx={{ mb: 1.5 }}>IP Communication Channels</Typography>
+                <Typography variant="subtitle1" sx={{ mb: 1.5 }}>{t('digitalNameplate.sections.ipCommunicationChannels')}</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {addr.IPCommunicationChannels.map((ch) => (
                     <Chip
@@ -279,7 +281,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <VerifiedIcon color="primary" />
-                Markings &amp; Certifications
+                {t('digitalNameplate.sections.markingsAndCertifications')}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 {data.Markings.map((marking) => (
@@ -300,16 +302,16 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                       </Box>
                       <Grid2 container spacing={1}>
                         {marking.IssueDate && (
-                          <InfoRow label="Issue Date" value={marking.IssueDate} />
+                          <InfoRow label={t('digitalNameplate.fields.issueDate')} value={marking.IssueDate} />
                         )}
                         {marking.ExpiryDate && (
-                          <InfoRow label="Expiry Date" value={marking.ExpiryDate} />
+                          <InfoRow label={t('digitalNameplate.fields.expiryDate')} value={marking.ExpiryDate} />
                         )}
                         {marking.MarkingAdditionalText && (
-                          <InfoRow label="Additional Info" value={marking.MarkingAdditionalText} />
+                          <InfoRow label={t('digitalNameplate.fields.additionalInfo')} value={marking.MarkingAdditionalText} />
                         )}
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Document</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('digitalNameplate.fields.document')}</Typography>
                           <Link
                             href={marking.MarkingFile.value}
                             target="_blank"
@@ -337,13 +339,13 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <GppGoodIcon color="primary" />
-                Compliance Documents
+                {t('digitalNameplate.sections.complianceDocuments')}
               </Typography>
               <Grid2 container spacing={2}>
                 {data.EUDeclarationOfConformity && data.EUDeclarationOfConformity.length > 0 && (
                   <Grid2 size={12}>
                     <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                      EU Declaration of Conformity
+                      {t('digitalNameplate.fields.euDeclarationOfConformity')}
                     </Typography>
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                       {data.EUDeclarationOfConformity.map((docId) => (
@@ -361,7 +363,7 @@ export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<Batt
                 {data.ResultsOfTestReportsProvingCompliance && data.ResultsOfTestReportsProvingCompliance.length > 0 && (
                   <Grid2 size={12}>
                     <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                      Results of Test Reports Proving Compliance
+                      {t('digitalNameplate.fields.resultsOfTestReportsProvingCompliance')}
                     </Typography>
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                       {data.ResultsOfTestReportsProvingCompliance.map((docId) => (

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/BatteryPassDigitalNameplateViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/BatteryPassDigitalNameplateViewer.tsx
@@ -1,0 +1,387 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Link,
+  Divider,
+} from '@mui/material';
+import BatteryChargingFullIcon from '@mui/icons-material/BatteryChargingFull';
+import BusinessIcon from '@mui/icons-material/Business';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import PhoneIcon from '@mui/icons-material/Phone';
+import EmailIcon from '@mui/icons-material/Email';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import FactoryIcon from '@mui/icons-material/Factory';
+import VerifiedIcon from '@mui/icons-material/Verified';
+import GppGoodIcon from '@mui/icons-material/GppGood';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { InfoRow } from '../battery-pass-shared/InfoRow';
+import {
+  BatteryPassDigitalNameplate,
+  BatteryLifeCycleStage,
+  getMultiLangValue,
+} from './types';
+
+const LIFECYCLE_COLORS: Record<BatteryLifeCycleStage, 'success' | 'info' | 'warning' | 'error' | 'default'> = {
+  original: 'success',
+  repurposed: 'info',
+  're-used': 'info',
+  remanufactured: 'warning',
+  waste: 'error',
+};
+
+const LIFECYCLE_DESCRIPTIONS: Record<BatteryLifeCycleStage, string> = {
+  original: 'Battery is new and has never been repurposed or remanufactured.',
+  repurposed: 'Battery has been repurposed for a different application.',
+  're-used': 'Battery has been reused in the same or similar application.',
+  remanufactured: 'Battery has been remanufactured to restore its performance.',
+  waste: 'Battery has reached end-of-life and is classified as waste.',
+};
+
+export const BatteryPassDigitalNameplateViewer: React.FC<SubmodelAddonProps<BatteryPassDigitalNameplate>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<BatteryPassDigitalNameplate>(rawData);
+  if (!data) return null;
+  const addr = data.AddressInformation;
+
+  const hasComplianceDocs =
+    (data.EUDeclarationOfConformity && data.EUDeclarationOfConformity.length > 0) ||
+    (data.ResultsOfTestReportsProvingCompliance && data.ResultsOfTestReportsProvingCompliance.length > 0);
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Digital Nameplate"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        {/* Product Identification */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <FingerprintIcon color="primary" />
+              Product Identification
+            </Typography>
+            <Grid2 container spacing={2}>
+              <Grid2 size={12}>
+                <Typography variant="subtitle2" color="text.secondary">Battery Passport URI</Typography>
+                <Link
+                  href={data.URIOfTheProduct}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{ fontFamily: 'monospace', fontSize: '0.85rem', wordBreak: 'break-all' }}
+                >
+                  {data.URIOfTheProduct}
+                </Link>
+              </Grid2>
+              <InfoRow label="Serial Number" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.SerialNumber}</Box>} />
+              <InfoRow label="Manufacturer Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.ManufacturerIdentifier}</Box>} />
+              {data.OperatorIdentifier && (
+                <InfoRow label="Operator Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.OperatorIdentifier}</Box>} />
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Lifecycle Status */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BatteryChargingFullIcon color="primary" />
+              Lifecycle Status
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+              <Chip
+                label={data.LifeCycleStage}
+                color={LIFECYCLE_COLORS[data.LifeCycleStage] ?? 'default'}
+                sx={{ fontWeight: 600, textTransform: 'capitalize' }}
+              />
+              <Typography variant="body2" color="text.secondary">
+                {LIFECYCLE_DESCRIPTIONS[data.LifeCycleStage]}
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Manufacturing Details */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <FactoryIcon color="primary" />
+              Manufacturing Details
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Date of Manufacture" value={data.DateOfManufacture} />
+              {data.DateOfPuttingIntoService && (
+                <InfoRow label="Date of Putting Into Service" value={data.DateOfPuttingIntoService} />
+              )}
+              <InfoRow label="Unique Facility Identifier" value={<Box component="span" sx={{ fontFamily: 'monospace' }}>{data.UniqueFacilityIdentifier}</Box>} />
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Manufacturer Information */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BusinessIcon color="primary" />
+              Manufacturer Information
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow
+                label="Manufacturer Name"
+                value={getMultiLangValue(data.ManufacturerName)}
+              />
+              {addr.Company && (
+                <InfoRow label="Company" value={getMultiLangValue(addr.Company)} />
+              )}
+              {addr.Department && (
+                <InfoRow label="Department" value={getMultiLangValue(addr.Department)} />
+              )}
+              {addr.RoleOfContactPerson && (
+                <InfoRow label="Contact Role" value={addr.RoleOfContactPerson} />
+              )}
+              {(addr.NameOfContact || addr.FirstName) && (
+                <InfoRow
+                  label="Contact Person"
+                  value={[
+                    addr.Title && getMultiLangValue(addr.Title),
+                    addr.AcademicTitle && getMultiLangValue(addr.AcademicTitle),
+                    addr.FirstName && getMultiLangValue(addr.FirstName),
+                    addr.MiddleNames && getMultiLangValue(addr.MiddleNames),
+                    addr.NameOfContact && getMultiLangValue(addr.NameOfContact),
+                  ].filter(Boolean).join(' ')}
+                />
+              )}
+            </Grid2>
+
+            <Divider sx={{ my: 2 }} />
+
+            <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+              <LocationOnIcon fontSize="small" color="action" />
+              Address
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Street" value={getMultiLangValue(addr.Street)} />
+              <InfoRow label="City / Town" value={getMultiLangValue(addr.CityTown)} />
+              <InfoRow label="Zip Code" value={getMultiLangValue(addr.ZipCode)} />
+              {addr.StateCounty && (
+                <InfoRow label="State / County" value={getMultiLangValue(addr.StateCounty)} />
+              )}
+              <InfoRow label="Country" value={getMultiLangValue(addr.NationalCode)} />
+              {addr.TimeZone && <InfoRow label="Time Zone" value={addr.TimeZone} />}
+              {addr.POBox && (
+                <InfoRow label="P.O. Box" value={`${getMultiLangValue(addr.POBox)}${addr.ZipCodeOfPOBox ? ', ' + getMultiLangValue(addr.ZipCodeOfPOBox) : ''}`} />
+              )}
+              {addr.AddressOfAdditionalLink && (
+                <Grid2 size={12}>
+                  <Typography variant="subtitle2" color="text.secondary">Website</Typography>
+                  <Link href={addr.AddressOfAdditionalLink} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.875rem' }}>
+                    {addr.AddressOfAdditionalLink}
+                  </Link>
+                </Grid2>
+              )}
+            </Grid2>
+
+            {(addr.Phone || addr.Fax || addr.Email) && (
+              <>
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+                  <PhoneIcon fontSize="small" color="action" />
+                  Contact
+                </Typography>
+                <Grid2 container spacing={2}>
+                  {addr.Phone && (
+                    <InfoRow
+                      label={`Phone${addr.Phone.TypeOfTelephone ? ` (${addr.Phone.TypeOfTelephone})` : ''}`}
+                      value={getMultiLangValue(addr.Phone.TelephoneNumber)}
+                    />
+                  )}
+                  {addr.Fax && (
+                    <InfoRow
+                      label={`Fax${addr.Fax.TypeOfFaxNumber ? ` (${addr.Fax.TypeOfFaxNumber})` : ''}`}
+                      value={getMultiLangValue(addr.Fax.FaxNumber)}
+                    />
+                  )}
+                  {addr.Email && (
+                    <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
+                      <Typography variant="subtitle2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        <EmailIcon fontSize="small" />
+                        Email{addr.Email.TypeOfEmailAddress ? ` (${addr.Email.TypeOfEmailAddress})` : ''}
+                      </Typography>
+                      <Link href={`mailto:${addr.Email.EmailAddress}`} sx={{ fontSize: '0.875rem' }}>
+                        {addr.Email.EmailAddress}
+                      </Link>
+                    </Grid2>
+                  )}
+                </Grid2>
+              </>
+            )}
+
+            {addr.IPCommunicationChannels && addr.IPCommunicationChannels.length > 0 && (
+              <>
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle1" sx={{ mb: 1.5 }}>IP Communication Channels</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {addr.IPCommunicationChannels.map((ch) => (
+                    <Chip
+                      key={ch.AddressOfAdditionalLink}
+                      label={`${ch.TypeOfCommunication ?? 'Link'}: ${ch.AddressOfAdditionalLink}`}
+                      variant="outlined"
+                      size="small"
+                      component="a"
+                      href={ch.AddressOfAdditionalLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      clickable
+                    />
+                  ))}
+                </Box>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Markings & Certifications */}
+        {data.Markings && data.Markings.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <VerifiedIcon color="primary" />
+                Markings &amp; Certifications
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {data.Markings.map((marking) => (
+                  <Card key={marking.MarkingName} variant="outlined">
+                    <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                      <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                          {marking.MarkingName}
+                        </Typography>
+                        {marking.DesignationOfCertificateOrApproval && (
+                          <Chip
+                            label={marking.DesignationOfCertificateOrApproval}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                          />
+                        )}
+                      </Box>
+                      <Grid2 container spacing={1}>
+                        {marking.IssueDate && (
+                          <InfoRow label="Issue Date" value={marking.IssueDate} />
+                        )}
+                        {marking.ExpiryDate && (
+                          <InfoRow label="Expiry Date" value={marking.ExpiryDate} />
+                        )}
+                        {marking.MarkingAdditionalText && (
+                          <InfoRow label="Additional Info" value={marking.MarkingAdditionalText} />
+                        )}
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Document</Typography>
+                          <Link
+                            href={marking.MarkingFile.value}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ fontSize: '0.8rem', fontFamily: 'monospace' }}
+                          >
+                            {marking.MarkingFile.value}
+                          </Link>
+                          <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                            ({marking.MarkingFile.contentType})
+                          </Typography>
+                        </Grid2>
+                      </Grid2>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Compliance Documents */}
+        {hasComplianceDocs && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <GppGoodIcon color="primary" />
+                Compliance Documents
+              </Typography>
+              <Grid2 container spacing={2}>
+                {data.EUDeclarationOfConformity && data.EUDeclarationOfConformity.length > 0 && (
+                  <Grid2 size={12}>
+                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                      EU Declaration of Conformity
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                      {data.EUDeclarationOfConformity.map((docId) => (
+                        <Chip
+                          key={docId}
+                          label={docId}
+                          variant="outlined"
+                          size="small"
+                          sx={{ fontFamily: 'monospace' }}
+                        />
+                      ))}
+                    </Box>
+                  </Grid2>
+                )}
+                {data.ResultsOfTestReportsProvingCompliance && data.ResultsOfTestReportsProvingCompliance.length > 0 && (
+                  <Grid2 size={12}>
+                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                      Results of Test Reports Proving Compliance
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                      {data.ResultsOfTestReportsProvingCompliance.map((docId) => (
+                        <Chip
+                          key={docId}
+                          label={docId}
+                          variant="outlined"
+                          size="small"
+                          sx={{ fontFamily: 'monospace' }}
+                        />
+                      ))}
+                    </Box>
+                  </Grid2>
+                )}
+              </Grid2>
+            </CardContent>
+          </Card>
+        )}
+
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  BatteryPassDigitalNameplate,
+  BATTERY_PASS_DIGITAL_NAMEPLATE_NAMESPACE,
+  BATTERY_PASS_DIGITAL_NAMEPLATE_MODEL_NAME,
+  BATTERY_PASS_DIGITAL_NAMEPLATE_SEMANTIC_ID,
+  isBatteryPassDigitalNameplate,
+} from './types';
+import { BatteryPassDigitalNameplateViewer } from '.';
+
+export const batteryPassDigitalNameplateAddon: VersionedSubmodelAddon<BatteryPassDigitalNameplate> = {
+  id: 'battery-pass-digital-nameplate',
+  name: 'Battery Pass Digital Nameplate',
+  description: 'Specialized visualization for IDTA BatteryPass Digital Nameplate submodels including product identification, lifecycle status, manufacturer details, and compliance information.',
+  namespace: BATTERY_PASS_DIGITAL_NAMEPLATE_NAMESPACE,
+  modelName: BATTERY_PASS_DIGITAL_NAMEPLATE_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_DIGITAL_NAMEPLATE_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isBatteryPassDigitalNameplate,
+  component: BatteryPassDigitalNameplateViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { BatteryPassDigitalNameplateViewer } from './BatteryPassDigitalNameplateViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-digital-nameplate/types.ts
@@ -1,0 +1,141 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Digital Nameplate submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryNameplate
+ */
+
+export const BATTERY_PASS_DIGITAL_NAMEPLATE_NAMESPACE =
+  'io.admin-shell.idta.batterypass.digital_nameplate';
+export const BATTERY_PASS_DIGITAL_NAMEPLATE_MODEL_NAME = 'BatteryNameplate';
+
+export const BATTERY_PASS_DIGITAL_NAMEPLATE_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_DIGITAL_NAMEPLATE_NAMESPACE}:1.0.0#${BATTERY_PASS_DIGITAL_NAMEPLATE_MODEL_NAME}`;
+
+import type { MultiLangEntry } from '../battery-pass-shared/types';
+export type { MultiLangEntry };
+export { getMultiLangValue } from '../battery-pass-shared/types';
+
+export interface PhoneEntity {
+  TelephoneNumber: MultiLangEntry | MultiLangEntry[];
+  TypeOfTelephone?: string;
+  AvailableTime?: MultiLangEntry | MultiLangEntry[];
+}
+
+export interface FaxEntity {
+  FaxNumber: MultiLangEntry | MultiLangEntry[];
+  TypeOfFaxNumber?: string;
+}
+
+export interface EmailEntity {
+  EmailAddress: string;
+  PublicKey?: MultiLangEntry | MultiLangEntry[];
+  TypeOfEmailAddress?: string;
+  TypeOfPublicKey?: MultiLangEntry | MultiLangEntry[];
+}
+
+export interface IpCommunicationChannel {
+  AddressOfAdditionalLink: string;
+  TypeOfCommunication?: string;
+  availableTime?: MultiLangEntry[];
+}
+
+export interface AddressInformation {
+  RoleOfContactPerson?: string;
+  NationalCode: MultiLangEntry[];
+  Languages?: string[];
+  TimeZone?: string;
+  CityTown: MultiLangEntry[];
+  Company?: MultiLangEntry[];
+  Department?: MultiLangEntry[];
+  Phone?: PhoneEntity;
+  Fax?: FaxEntity;
+  Email?: EmailEntity;
+  IPCommunicationChannels?: IpCommunicationChannel[];
+  Street: MultiLangEntry[];
+  ZipCode: MultiLangEntry[];
+  POBox?: MultiLangEntry[];
+  ZipCodeOfPOBox?: MultiLangEntry[];
+  StateCounty?: MultiLangEntry[];
+  NameOfContact?: MultiLangEntry[];
+  FirstName?: MultiLangEntry[];
+  MiddleNames?: MultiLangEntry[];
+  Title?: MultiLangEntry[];
+  AcademicTitle?: MultiLangEntry[];
+  FurtherDetailsOfContact?: MultiLangEntry[];
+  AddressOfAdditionalLink?: string;
+}
+
+export interface MarkingFile {
+  value: string;
+  contentType: string;
+}
+
+export interface Marking {
+  MarkingName: string;
+  DesignationOfCertificateOrApproval?: string;
+  IssueDate?: string;
+  ExpiryDate?: string;
+  MarkingFile: MarkingFile;
+  MarkingAdditionalText?: string;
+}
+
+export type BatteryLifeCycleStage =
+  | 'original'
+  | 'repurposed'
+  | 're-used'
+  | 'remanufactured'
+  | 'waste';
+
+export interface BatteryPassDigitalNameplate {
+  URIOfTheProduct: string;
+  ManufacturerName: MultiLangEntry[];
+  AddressInformation: AddressInformation;
+  SerialNumber: string;
+  DateOfManufacture: string;
+  DateOfPuttingIntoService?: string;
+  UniqueFacilityIdentifier: string;
+  LifeCycleStage: BatteryLifeCycleStage;
+  OperatorIdentifier?: string;
+  ManufacturerIdentifier: string;
+  Markings: Marking[];
+  EUDeclarationOfConformity: string[];
+  ResultsOfTestReportsProvingCompliance: string[];
+}
+
+export function isBatteryPassDigitalNameplate(
+  _semanticId: string,
+  data: unknown
+): data is BatteryPassDigitalNameplate {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'URIOfTheProduct' in obj &&
+    'ManufacturerName' in obj &&
+    'SerialNumber' in obj &&
+    'LifeCycleStage' in obj
+  );
+}
+

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/HandoverDocumentationBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/HandoverDocumentationBatteryViewer.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -45,17 +46,19 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
   semanticId,
 }) => {
   const data = unwrapSubmodelData<HandoverDocumentation>(rawData);
+  const { t } = useTranslation('batteryPass');
   if (!data) return null;
 
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Handover Documentation"
+      title={t('handover.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
 
+
         <Typography variant="body2" color="text.secondary">
-          {data.Documents.length} document{data.Documents.length !== 1 ? 's' : ''} available for handover
+          {t('handover.available', { count: data.Documents.length })}
         </Typography>
 
         {data.Documents.map((doc, i) => (
@@ -63,13 +66,13 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <FolderIcon color="primary" />
-                Document {i + 1}
+                {t('handover.documentIndex', { index: i + 1 })}
               </Typography>
 
               {/* Document IDs */}
               {doc.DocumentIds && doc.DocumentIds.length > 0 && (
                 <>
-                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Document Identifiers</Typography>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('handover.sections.documentIdentifiers')}</Typography>
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mb: 2 }}>
                     {doc.DocumentIds.map((docId) => (
                       <Box key={docId.DocumentDomainId + docId.DocumentIdentifier} sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
@@ -80,10 +83,10 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
                           sx={{ fontFamily: 'monospace' }}
                         />
                         <Typography variant="caption" color="text.secondary">
-                          Domain: {docId.DocumentDomainId}
+                          {t('handover.fields.domain', { id: docId.DocumentDomainId })}
                         </Typography>
                         {docId.DocumentIsPrimary && (
-                          <Chip label="Primary" size="small" color="primary" />
+                          <Chip label={t('handover.fields.primary')} size="small" color="primary" />
                         )}
                       </Box>
                     ))}
@@ -95,7 +98,7 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
               {doc.DocumentClassifications && doc.DocumentClassifications.length > 0 && (
                 <>
                   <Divider sx={{ my: 1.5 }} />
-                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Classifications</Typography>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>{t('handover.sections.classifications')}</Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
                     {doc.DocumentClassifications.map((cls) => (
                       <Chip
@@ -117,7 +120,7 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
                   <Divider sx={{ my: 1.5 }} />
                   <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1.5 }}>
                     <ArticleIcon fontSize="small" color="action" />
-                    Versions
+                    {t('handover.sections.versions')}
                   </Typography>
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                     {doc.DocumentVersions.map((ver, j) => (
@@ -158,7 +161,7 @@ export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<Han
                               <Divider sx={{ my: 1 }} />
                               <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
                                 <AttachFileIcon sx={{ fontSize: 14 }} />
-                                Digital Files
+                                {t('handover.sections.digitalFiles')}
                               </Typography>
                               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                                 {ver.DigitalFiles.map((file) => (

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/HandoverDocumentationBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/HandoverDocumentationBatteryViewer.tsx
@@ -1,0 +1,192 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Link,
+  Divider,
+} from '@mui/material';
+import FolderIcon from '@mui/icons-material/Folder';
+import ArticleIcon from '@mui/icons-material/Article';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { HandoverDocumentation, getMultiLangValue } from './types';
+
+export const HandoverDocumentationBatteryViewer: React.FC<SubmodelAddonProps<HandoverDocumentation>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<HandoverDocumentation>(rawData);
+  if (!data) return null;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Handover Documentation"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        <Typography variant="body2" color="text.secondary">
+          {data.Documents.length} document{data.Documents.length !== 1 ? 's' : ''} available for handover
+        </Typography>
+
+        {data.Documents.map((doc, i) => (
+          <Card key={doc.DocumentIds?.[0]?.DocumentIdentifier ?? i}>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <FolderIcon color="primary" />
+                Document {i + 1}
+              </Typography>
+
+              {/* Document IDs */}
+              {doc.DocumentIds && doc.DocumentIds.length > 0 && (
+                <>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Document Identifiers</Typography>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mb: 2 }}>
+                    {doc.DocumentIds.map((docId) => (
+                      <Box key={docId.DocumentDomainId + docId.DocumentIdentifier} sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                        <Chip
+                          label={docId.DocumentIdentifier}
+                          size="small"
+                          variant="outlined"
+                          sx={{ fontFamily: 'monospace' }}
+                        />
+                        <Typography variant="caption" color="text.secondary">
+                          Domain: {docId.DocumentDomainId}
+                        </Typography>
+                        {docId.DocumentIsPrimary && (
+                          <Chip label="Primary" size="small" color="primary" />
+                        )}
+                      </Box>
+                    ))}
+                  </Box>
+                </>
+              )}
+
+              {/* Classifications */}
+              {doc.DocumentClassifications && doc.DocumentClassifications.length > 0 && (
+                <>
+                  <Divider sx={{ my: 1.5 }} />
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Classifications</Typography>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                    {doc.DocumentClassifications.map((cls) => (
+                      <Chip
+                        key={cls.ClassId}
+                        label={`${getMultiLangValue(cls.ClassName)} (${cls.ClassId})`}
+                        size="small"
+                        color="info"
+                        variant="outlined"
+                        title={`System: ${cls.ClassificationSystem}`}
+                      />
+                    ))}
+                  </Box>
+                </>
+              )}
+
+              {/* Document Versions */}
+              {doc.DocumentVersions && doc.DocumentVersions.length > 0 && (
+                <>
+                  <Divider sx={{ my: 1.5 }} />
+                  <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1.5 }}>
+                    <ArticleIcon fontSize="small" color="action" />
+                    Versions
+                  </Typography>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {doc.DocumentVersions.map((ver, j) => (
+                      <Card key={ver.Version ?? j} variant="outlined">
+                        <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                          <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                              {getMultiLangValue(ver.Title)}
+                            </Typography>
+                            {ver.Version && <Chip label={`v${ver.Version}`} size="small" />}
+                          </Box>
+
+                          <Grid2 container spacing={1}>
+                            {ver.Subtitle && (
+                              <Grid2 size={12}>
+                                <Typography variant="body2" color="text.secondary">
+                                  {getMultiLangValue(ver.Subtitle)}
+                                </Typography>
+                              </Grid2>
+                            )}
+                            {ver.Description && (
+                              <Grid2 size={12}>
+                                <Typography variant="body2">{getMultiLangValue(ver.Description)}</Typography>
+                              </Grid2>
+                            )}
+                          </Grid2>
+
+                          {ver.Language && ver.Language.length > 0 && (
+                            <Box sx={{ display: 'flex', gap: 0.5, mt: 1, flexWrap: 'wrap' }}>
+                              {ver.Language.map((lang) => (
+                                <Chip key={lang} label={lang.toUpperCase()} size="small" variant="outlined" sx={{ fontSize: '0.7rem' }} />
+                              ))}
+                            </Box>
+                          )}
+
+                          {ver.DigitalFiles && ver.DigitalFiles.length > 0 && (
+                            <>
+                              <Divider sx={{ my: 1 }} />
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+                                <AttachFileIcon sx={{ fontSize: 14 }} />
+                                Digital Files
+                              </Typography>
+                              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                {ver.DigitalFiles.map((file) => (
+                                  <Box key={file.value} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Link
+                                      href={file.value}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      sx={{ fontSize: '0.8rem', fontFamily: 'monospace', wordBreak: 'break-all' }}
+                                    >
+                                      {file.value}
+                                    </Link>
+                                    <Chip label={file.contentType} size="small" variant="outlined" sx={{ fontSize: '0.7rem' }} />
+                                  </Box>
+                                ))}
+                              </Box>
+                            </>
+                          )}
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </Box>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  HandoverDocumentation,
+  BATTERY_PASS_HANDOVER_DOCUMENTATION_NAMESPACE,
+  BATTERY_PASS_HANDOVER_DOCUMENTATION_MODEL_NAME,
+  BATTERY_PASS_HANDOVER_DOCUMENTATION_SEMANTIC_ID,
+  isHandoverDocumentation,
+} from './types';
+import { HandoverDocumentationBatteryViewer } from '.';
+
+export const batteryPassHandoverDocumentationAddon: VersionedSubmodelAddon<HandoverDocumentation> = {
+  id: 'battery-pass-handover-documentation',
+  name: 'Battery Pass Handover Documentation',
+  description: 'Specialized visualization for IDTA BatteryPass Handover Documentation submodels including document versions, classifications, and digital files.',
+  namespace: BATTERY_PASS_HANDOVER_DOCUMENTATION_NAMESPACE,
+  modelName: BATTERY_PASS_HANDOVER_DOCUMENTATION_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_HANDOVER_DOCUMENTATION_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isHandoverDocumentation,
+  component: HandoverDocumentationBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { HandoverDocumentationBatteryViewer } from './HandoverDocumentationBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-handover-documentation/types.ts
@@ -1,0 +1,88 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Handover Documentation submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation
+ */
+
+export const BATTERY_PASS_HANDOVER_DOCUMENTATION_NAMESPACE =
+  'io.admin-shell.idta.batterypass.handover_documentation';
+export const BATTERY_PASS_HANDOVER_DOCUMENTATION_MODEL_NAME = 'HandoverDocumentation';
+
+export const BATTERY_PASS_HANDOVER_DOCUMENTATION_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_HANDOVER_DOCUMENTATION_NAMESPACE}:1.0.0#${BATTERY_PASS_HANDOVER_DOCUMENTATION_MODEL_NAME}`;
+
+import type { MultiLangEntry } from '../battery-pass-shared/types';
+export type { MultiLangEntry };
+export { getMultiLangValue } from '../battery-pass-shared/types';
+
+export interface DocumentId {
+  DocumentDomainId: string;
+  DocumentIdentifier: string;
+  DocumentIsPrimary?: boolean;
+}
+
+export interface DocumentClassification {
+  ClassId: string;
+  ClassName: MultiLangEntry[];
+  ClassificationSystem: string;
+}
+
+export interface DigitalFile {
+  value: string;
+  contentType: string;
+}
+
+export interface DocumentVersion {
+  Language: string[];
+  Version?: string;
+  Title: MultiLangEntry[];
+  Subtitle?: MultiLangEntry[];
+  Description?: MultiLangEntry[];
+  DigitalFiles: DigitalFile[];
+}
+
+export interface HandoverDocument {
+  DocumentIds: DocumentId[];
+  DocumentClassifications: DocumentClassification[];
+  DocumentVersions: DocumentVersion[];
+}
+
+export interface HandoverDocumentation {
+  Documents: HandoverDocument[];
+}
+
+export function isHandoverDocumentation(
+  _semanticId: string,
+  data: unknown
+): data is HandoverDocumentation {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'Documents' in obj &&
+    Array.isArray((obj as HandoverDocumentation).Documents)
+  );
+}
+

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/MaterialCompositionBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/MaterialCompositionBatteryViewer.tsx
@@ -20,8 +20,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -43,33 +43,30 @@ import { SubmodelAddonProps } from '../shared/types';
 import { unwrapSubmodelData } from '../shared/utils';
 import { SubmodelAddonWrapper } from '../BaseAddon';
 import { MaterialComposition, HazardousSubstanceClass } from './types';
-
 const HAZARDOUS_CLASS_LABELS: Record<HazardousSubstanceClass, string> = {
-  AcuteToxicity: 'Acute Toxicity',
-  SkinCorrosionOrIrritation: 'Skin Corrosion / Irritation',
-  EyeDamageOrIrritation: 'Eye Damage / Irritation',
+  AcuteToxicity: 'materialComposition.hazardousClass.AcuteToxicity',
+  SkinCorrosionOrIrritation: 'materialComposition.hazardousClass.SkinCorrosionOrIrritation',
+  EyeDamageOrIrritation: 'materialComposition.hazardousClass.EyeDamageOrIrritation',
 };
-
 export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<MaterialComposition>> = ({
   data: rawData,
   semanticId,
 }) => {
+  const { t } = useTranslation('batteryPass');
   const data = unwrapSubmodelData<MaterialComposition>(rawData);
   if (!data) return null;
-
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Material Composition"
+      title={t('materialComposition.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-
         {/* Battery Chemistry */}
         <Card>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <ScienceIcon color="primary" />
-              Battery Chemistry
+              {t('materialComposition.sections.batteryChemistry')}
             </Typography>
             <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
               <Chip label={data.BatteryChemistry.ShortName} color="primary" sx={{ fontWeight: 700, fontSize: '1rem', px: 1 }} />
@@ -77,24 +74,23 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
             </Box>
           </CardContent>
         </Card>
-
         {/* Battery Materials */}
         {data.BatteryMaterials && data.BatteryMaterials.length > 0 && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <CategoryIcon color="primary" />
-                Battery Materials
+                {t('materialComposition.sections.batteryMaterials')}
               </Typography>
               <Box sx={{ overflowX: 'auto' }}>
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell><Typography variant="subtitle2">Material</Typography></TableCell>
-                      <TableCell><Typography variant="subtitle2">Identifier</Typography></TableCell>
-                      <TableCell><Typography variant="subtitle2">Mass (kg)</Typography></TableCell>
-                      <TableCell><Typography variant="subtitle2">Location</Typography></TableCell>
-                      <TableCell><Typography variant="subtitle2">Critical</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">{t('materialComposition.table.material')}</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">{t('materialComposition.table.identifier')}</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">{t('materialComposition.table.mass')}</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">{t('materialComposition.table.location')}</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">{t('materialComposition.table.critical')}</Typography></TableCell>
                     </TableRow>
                   </TableHead>
                   <TableBody>
@@ -120,9 +116,9 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
                         </TableCell>
                         <TableCell>
                           {mat.IsCriticalRawMaterial ? (
-                            <Chip label="Critical" size="small" color="warning" />
+                            <Chip label={t('materialComposition.table.criticalChip')} size="small" color="warning" />
                           ) : (
-                            <Chip label="Standard" size="small" variant="outlined" />
+                            <Chip label={t('materialComposition.table.standardChip')} size="small" variant="outlined" />
                           )}
                         </TableCell>
                       </TableRow>
@@ -134,21 +130,20 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
                   <WarningAmberIcon color="warning" fontSize="small" />
                   <Typography variant="caption" color="text.secondary">
-                    {data.BatteryMaterials.filter(m => m.IsCriticalRawMaterial).length} critical raw material(s) identified
+                    {t('materialComposition.criticalCount', { count: data.BatteryMaterials.filter(m => m.IsCriticalRawMaterial).length })}
                   </Typography>
                 </Box>
               )}
             </CardContent>
           </Card>
         )}
-
         {/* Hazardous Substances */}
         {data.HazardousSubstances && data.HazardousSubstances.length > 0 && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <WarningAmberIcon color="error" />
-                Hazardous Substances
+                {t('materialComposition.sections.hazardousSubstances')}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 {data.HazardousSubstances.map((sub) => (
@@ -159,25 +154,25 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
                           {sub.HazardousSubstanceName}
                         </Typography>
                         <Chip
-                          label={HAZARDOUS_CLASS_LABELS[sub.HazardousSubstanceClass]}
+                          label={t(HAZARDOUS_CLASS_LABELS[sub.HazardousSubstanceClass])}
                           size="small"
                           color="warning"
                         />
                       </Box>
                       <Grid2 container spacing={1}>
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Identifier</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('materialComposition.fields.identifier')}</Typography>
                           <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
                             {sub.HazardousSubstanceIdentifier}
                           </Typography>
                         </Grid2>
                         <Grid2 size={{ xs: 12, sm: 6 }}>
-                          <Typography variant="subtitle2" color="text.secondary">Concentration</Typography>
+                          <Typography variant="subtitle2" color="text.secondary">{t('materialComposition.fields.concentration')}</Typography>
                           <Typography variant="body2">{sub.HazardousSubstanceConcentration}%</Typography>
                         </Grid2>
                         {sub.HazardousSubstanceLocation && (sub.HazardousSubstanceLocation.ComponentName || sub.HazardousSubstanceLocation.ComponentId) && (
                           <Grid2 size={12}>
-                            <Typography variant="subtitle2" color="text.secondary">Location</Typography>
+                            <Typography variant="subtitle2" color="text.secondary">{t('materialComposition.fields.location')}</Typography>
                             <Typography variant="body2">
                               {sub.HazardousSubstanceLocation.ComponentName ?? sub.HazardousSubstanceLocation.ComponentId}
                             </Typography>
@@ -185,7 +180,7 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
                         )}
                         {sub.HazardousSubstanceImpact && sub.HazardousSubstanceImpact.length > 0 && (
                           <Grid2 size={12}>
-                            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>Impact</Typography>
+                            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>{t('materialComposition.fields.impact')}</Typography>
                             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                               {sub.HazardousSubstanceImpact.map((impact) => (
                                 <Chip key={impact} label={impact} size="small" variant="outlined" color="error" />
@@ -200,7 +195,7 @@ export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<Mater
               </Box>
               <Divider sx={{ my: 2 }} />
               <Typography variant="caption" color="text.secondary">
-                {data.HazardousSubstances.length} hazardous substance(s) declared in this battery
+                {t('materialComposition.hazardousCount', { count: data.HazardousSubstances.length })}
               </Typography>
             </CardContent>
           </Card>

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/MaterialCompositionBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/MaterialCompositionBatteryViewer.tsx
@@ -1,0 +1,211 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import ScienceIcon from '@mui/icons-material/Science';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import CategoryIcon from '@mui/icons-material/Category';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { MaterialComposition, HazardousSubstanceClass } from './types';
+
+const HAZARDOUS_CLASS_LABELS: Record<HazardousSubstanceClass, string> = {
+  AcuteToxicity: 'Acute Toxicity',
+  SkinCorrosionOrIrritation: 'Skin Corrosion / Irritation',
+  EyeDamageOrIrritation: 'Eye Damage / Irritation',
+};
+
+export const MaterialCompositionBatteryViewer: React.FC<SubmodelAddonProps<MaterialComposition>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<MaterialComposition>(rawData);
+  if (!data) return null;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Material Composition"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        {/* Battery Chemistry */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <ScienceIcon color="primary" />
+              Battery Chemistry
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+              <Chip label={data.BatteryChemistry.ShortName} color="primary" sx={{ fontWeight: 700, fontSize: '1rem', px: 1 }} />
+              <Typography variant="body1">{data.BatteryChemistry.ClearName}</Typography>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Battery Materials */}
+        {data.BatteryMaterials && data.BatteryMaterials.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <CategoryIcon color="primary" />
+                Battery Materials
+              </Typography>
+              <Box sx={{ overflowX: 'auto' }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell><Typography variant="subtitle2">Material</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">Identifier</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">Mass (kg)</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">Location</Typography></TableCell>
+                      <TableCell><Typography variant="subtitle2">Critical</Typography></TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {data.BatteryMaterials.map((mat) => (
+                      <TableRow key={mat.BatteryMaterialIdentifier} sx={{ '&:hover': { bgcolor: 'action.hover' } }}>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontWeight: mat.IsCriticalRawMaterial ? 600 : 400 }}>
+                            {mat.BatteryMaterialName}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                            {mat.BatteryMaterialIdentifier}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">{mat.BatteryMaterialMass}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" color="text.secondary">
+                            {mat.BatteryMaterialLocation.ComponentName ?? mat.BatteryMaterialLocation.ComponentId ?? '—'}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          {mat.IsCriticalRawMaterial ? (
+                            <Chip label="Critical" size="small" color="warning" />
+                          ) : (
+                            <Chip label="Standard" size="small" variant="outlined" />
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Box>
+              {data.BatteryMaterials.some(m => m.IsCriticalRawMaterial) && (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
+                  <WarningAmberIcon color="warning" fontSize="small" />
+                  <Typography variant="caption" color="text.secondary">
+                    {data.BatteryMaterials.filter(m => m.IsCriticalRawMaterial).length} critical raw material(s) identified
+                  </Typography>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Hazardous Substances */}
+        {data.HazardousSubstances && data.HazardousSubstances.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <WarningAmberIcon color="error" />
+                Hazardous Substances
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {data.HazardousSubstances.map((sub) => (
+                  <Card key={sub.HazardousSubstanceIdentifier} variant="outlined" sx={{ borderColor: 'warning.light' }}>
+                    <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                      <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                          {sub.HazardousSubstanceName}
+                        </Typography>
+                        <Chip
+                          label={HAZARDOUS_CLASS_LABELS[sub.HazardousSubstanceClass]}
+                          size="small"
+                          color="warning"
+                        />
+                      </Box>
+                      <Grid2 container spacing={1}>
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Identifier</Typography>
+                          <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                            {sub.HazardousSubstanceIdentifier}
+                          </Typography>
+                        </Grid2>
+                        <Grid2 size={{ xs: 12, sm: 6 }}>
+                          <Typography variant="subtitle2" color="text.secondary">Concentration</Typography>
+                          <Typography variant="body2">{sub.HazardousSubstanceConcentration}%</Typography>
+                        </Grid2>
+                        {sub.HazardousSubstanceLocation && (sub.HazardousSubstanceLocation.ComponentName || sub.HazardousSubstanceLocation.ComponentId) && (
+                          <Grid2 size={12}>
+                            <Typography variant="subtitle2" color="text.secondary">Location</Typography>
+                            <Typography variant="body2">
+                              {sub.HazardousSubstanceLocation.ComponentName ?? sub.HazardousSubstanceLocation.ComponentId}
+                            </Typography>
+                          </Grid2>
+                        )}
+                        {sub.HazardousSubstanceImpact && sub.HazardousSubstanceImpact.length > 0 && (
+                          <Grid2 size={12}>
+                            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>Impact</Typography>
+                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                              {sub.HazardousSubstanceImpact.map((impact) => (
+                                <Chip key={impact} label={impact} size="small" variant="outlined" color="error" />
+                              ))}
+                            </Box>
+                          </Grid2>
+                        )}
+                      </Grid2>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Box>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="caption" color="text.secondary">
+                {data.HazardousSubstances.length} hazardous substance(s) declared in this battery
+              </Typography>
+            </CardContent>
+          </Card>
+        )}
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  MaterialComposition,
+  BATTERY_PASS_MATERIAL_COMPOSITION_NAMESPACE,
+  BATTERY_PASS_MATERIAL_COMPOSITION_MODEL_NAME,
+  BATTERY_PASS_MATERIAL_COMPOSITION_SEMANTIC_ID,
+  isMaterialComposition,
+} from './types';
+import { MaterialCompositionBatteryViewer } from '.';
+
+export const batteryPassMaterialCompositionAddon: VersionedSubmodelAddon<MaterialComposition> = {
+  id: 'battery-pass-material-composition',
+  name: 'Battery Pass Material Composition',
+  description: 'Specialized visualization for IDTA BatteryPass Material Composition submodels including battery chemistry, materials, and hazardous substances.',
+  namespace: BATTERY_PASS_MATERIAL_COMPOSITION_NAMESPACE,
+  modelName: BATTERY_PASS_MATERIAL_COMPOSITION_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_MATERIAL_COMPOSITION_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isMaterialComposition,
+  component: MaterialCompositionBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { MaterialCompositionBatteryViewer } from './MaterialCompositionBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-material-composition/types.ts
@@ -1,0 +1,86 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Material Composition submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.material_composition:1.0.0#MaterialComposition
+ */
+
+export const BATTERY_PASS_MATERIAL_COMPOSITION_NAMESPACE =
+  'io.admin-shell.idta.batterypass.material_composition';
+export const BATTERY_PASS_MATERIAL_COMPOSITION_MODEL_NAME = 'MaterialComposition';
+
+export const BATTERY_PASS_MATERIAL_COMPOSITION_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_MATERIAL_COMPOSITION_NAMESPACE}:1.0.0#${BATTERY_PASS_MATERIAL_COMPOSITION_MODEL_NAME}`;
+
+export type HazardousSubstanceClass =
+  | 'AcuteToxicity'
+  | 'SkinCorrosionOrIrritation'
+  | 'EyeDamageOrIrritation';
+
+export interface BatteryChemistry {
+  ShortName: string;
+  ClearName: string;
+}
+
+export interface BatteryLocation {
+  ComponentName?: string;
+  ComponentId?: string;
+}
+
+export interface BatteryMaterial {
+  BatteryMaterialLocation: BatteryLocation;
+  BatteryMaterialIdentifier: string;
+  BatteryMaterialName: string;
+  BatteryMaterialMass: number;
+  IsCriticalRawMaterial: boolean;
+}
+
+export interface HazardousSubstance {
+  HazardousSubstanceClass: HazardousSubstanceClass;
+  HazardousSubstanceName: string;
+  HazardousSubstanceConcentration: number;
+  HazardousSubstanceImpact: string[];
+  HazardousSubstanceLocation: BatteryLocation;
+  HazardousSubstanceIdentifier: string;
+}
+
+export interface MaterialComposition {
+  BatteryChemistry: BatteryChemistry;
+  BatteryMaterials: BatteryMaterial[];
+  HazardousSubstances: HazardousSubstance[];
+}
+
+export function isMaterialComposition(
+  _semanticId: string,
+  data: unknown
+): data is MaterialComposition {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'BatteryChemistry' in obj &&
+    'BatteryMaterials' in obj &&
+    'HazardousSubstances' in obj
+  );
+}

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/ProductConditionBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/ProductConditionBatteryViewer.tsx
@@ -20,8 +20,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -42,7 +42,6 @@ import { SubmodelAddonProps } from '../shared/types';
 import { unwrapSubmodelData } from '../shared/utils';
 import { SubmodelAddonWrapper } from '../BaseAddon';
 import { ProductCondition } from './types';
-
 function MetricRow({
   label,
   value,
@@ -81,31 +80,29 @@ function MetricRow({
     </Grid2>
   );
 }
-
 export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductCondition>> = ({
   data: rawData,
   semanticId,
 }) => {
+  const { t } = useTranslation('batteryPass');
   const data = unwrapSubmodelData<ProductCondition>(rawData);
   if (!data) return null;
-
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Product Condition"
+      title={t('productCondition.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-
         {/* State of Charge */}
         <Card>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BatteryFullIcon color="primary" />
-              Current State
+              {t('productCondition.sections.currentState')}
             </Typography>
             <Grid2 container spacing={2}>
               <Grid2 size={{ xs: 12, sm: 6 }}>
-                <Typography variant="subtitle2" color="text.secondary">State of Charge</Typography>
+                <Typography variant="subtitle2" color="text.secondary">{t('productCondition.fields.stateOfCharge')}</Typography>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 0.5 }}>
                   <Box sx={{ flex: 1 }}>
                     <LinearProgress
@@ -120,53 +117,52 @@ export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductC
                   </Typography>
                 </Box>
                 <Typography variant="caption" color="text.secondary">
-                  Updated: {data.StateOfCharge.LastUpdate}
+                  {t('productCondition.fields.updated', { date: data.StateOfCharge.LastUpdate })}
                 </Typography>
               </Grid2>
               <MetricRow
-                label="Number of Full Cycles"
+                label={t('productCondition.fields.numberOfFullCycles')}
                 value={data.NumberOfFullCycles.NumberOfFullCyclesValue}
                 lastUpdate={data.NumberOfFullCycles.LastUpdate}
               />
             </Grid2>
           </CardContent>
         </Card>
-
         {/* Energy & Capacity */}
         {(data.EnergyThroughput || data.CapacityThroughput || data.RemainingEnergy || data.RemainingCapacity || data.StateOfCertifiedEnergy) && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <ThunderstormIcon color="primary" />
-                Energy &amp; Capacity
+                {t('productCondition.sections.energyAndCapacity')}
               </Typography>
               <Grid2 container spacing={2}>
                 <MetricRow
-                  label="Energy Throughput"
+                  label={t('productCondition.fields.energyThroughput')}
                   value={data.EnergyThroughput?.EnergyThroughputValue}
                   unit="kWh"
                   lastUpdate={data.EnergyThroughput?.LastUpdate}
                 />
                 <MetricRow
-                  label="Capacity Throughput"
+                  label={t('productCondition.fields.capacityThroughput')}
                   value={data.CapacityThroughput?.CapacityThroughputValue}
                   unit="Ah"
                   lastUpdate={data.CapacityThroughput?.LastUpdate}
                 />
                 <MetricRow
-                  label="Remaining Energy"
+                  label={t('productCondition.fields.remainingEnergy')}
                   value={data.RemainingEnergy?.RemainingEnergyValue}
                   unit="kWh"
                   lastUpdate={data.RemainingEnergy?.LastUpdate}
                 />
                 <MetricRow
-                  label="Remaining Capacity"
+                  label={t('productCondition.fields.remainingCapacity')}
                   value={data.RemainingCapacity?.RemainingCapacityValue}
                   unit="Ah"
                   lastUpdate={data.RemainingCapacity?.LastUpdate}
                 />
                 <MetricRow
-                  label="State of Certified Energy"
+                  label={t('productCondition.fields.stateOfCertifiedEnergy')}
                   value={data.StateOfCertifiedEnergy?.StateOfCertifiedEnergyValue}
                   unit="%"
                   showProgress={true}
@@ -176,31 +172,30 @@ export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductC
             </CardContent>
           </Card>
         )}
-
         {/* Efficiency & Discharge */}
         {(data.RemainingRoundTripEnergyEfficiency || data.CurrentSelfDischargingRate || data.EvolutionOfSelfDischarge) && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <SpeedIcon color="primary" />
-                Efficiency &amp; Self-Discharge
+                {t('productCondition.sections.efficiencyAndSelfDischarge')}
               </Typography>
               <Grid2 container spacing={2}>
                 <MetricRow
-                  label="Remaining Round Trip Energy Efficiency"
+                  label={t('productCondition.fields.remainingRoundTripEnergyEfficiency')}
                   value={data.RemainingRoundTripEnergyEfficiency?.RemainingRoundTripEnergyEfficiencyValue}
                   unit="%"
                   showProgress={true}
                   lastUpdate={data.RemainingRoundTripEnergyEfficiency?.LastUpdate}
                 />
                 <MetricRow
-                  label="Current Self-Discharging Rate"
+                  label={t('productCondition.fields.currentSelfDischargingRate')}
                   value={data.CurrentSelfDischargingRate?.CurrentSelfDischargingRateValue}
                   unit="%/month"
                   lastUpdate={data.CurrentSelfDischargingRate?.LastUpdate}
                 />
                 <MetricRow
-                  label="Evolution of Self-Discharge"
+                  label={t('productCondition.fields.evolutionOfSelfDischarge')}
                   value={data.EvolutionOfSelfDischarge?.EvolutionOfSelfDischargeValue}
                   lastUpdate={data.EvolutionOfSelfDischarge?.LastUpdate}
                 />
@@ -208,49 +203,47 @@ export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductC
             </CardContent>
           </Card>
         )}
-
         {/* Temperature Information */}
         <Card>
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <ThermostatIcon color="primary" />
-              Temperature History
+              {t('productCondition.sections.temperatureHistory')}
             </Typography>
             <Grid2 container spacing={2}>
               <MetricRow
-                label="Time at Extreme High Temperature"
+                label={t('productCondition.fields.timeAtExtremeHighTemperature')}
                 value={data.TemperatureInformation.TimeExtremeHighTemp}
                 unit="h"
               />
               <MetricRow
-                label="Time at Extreme Low Temperature"
+                label={t('productCondition.fields.timeAtExtremeLowTemperature')}
                 value={data.TemperatureInformation.TimeExtremeLowTemp}
                 unit="h"
               />
               <MetricRow
-                label="Time at Extreme High Temp (Charging)"
+                label={t('productCondition.fields.timeAtExtremeHighTempCharging')}
                 value={data.TemperatureInformation.TimeExtremeHighTempCharging}
                 unit="h"
               />
               <MetricRow
-                label="Time at Extreme Low Temp (Charging)"
+                label={t('productCondition.fields.timeAtExtremeLowTempCharging')}
                 value={data.TemperatureInformation.TimeExtremeLowTempCharging}
                 unit="h"
               />
             </Grid2>
             <Typography variant="caption" color="text.secondary">
-              Updated: {data.TemperatureInformation.LastUpdate}
+              {t('productCondition.fields.updated', { date: data.TemperatureInformation.LastUpdate })}
             </Typography>
           </CardContent>
         </Card>
-
         {/* Negative Events */}
         {data.NegativeEvents && data.NegativeEvents.length > 0 && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <WarningAmberIcon color="warning" />
-                Negative Events
+                {t('productCondition.sections.negativeEvents')}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
                 {data.NegativeEvents.map((event) => (
@@ -263,14 +256,13 @@ export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductC
             </CardContent>
           </Card>
         )}
-
         {/* Accidents & Compliance */}
         {data.InformationOnAccidents && data.InformationOnAccidents.length > 0 && (
           <Card>
             <CardContent>
               <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                 <EventNoteIcon color="primary" />
-                Information on Accidents
+                {t('productCondition.sections.informationOnAccidents')}
               </Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                 {data.InformationOnAccidents.map((doc) => (
@@ -279,7 +271,7 @@ export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductC
               </Box>
               <Divider sx={{ my: 1.5 }} />
               <Typography variant="caption" color="text.secondary">
-                {data.InformationOnAccidents.length} accident report document(s) on record
+                {t('productCondition.accidentReports', { count: data.InformationOnAccidents.length })}
               </Typography>
             </CardContent>
           </Card>

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/ProductConditionBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/ProductConditionBatteryViewer.tsx
@@ -1,0 +1,290 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Divider,
+  LinearProgress,
+} from '@mui/material';
+import BatteryFullIcon from '@mui/icons-material/BatteryFull';
+import ThunderstormIcon from '@mui/icons-material/Thunderstorm';
+import SpeedIcon from '@mui/icons-material/Speed';
+import ThermostatIcon from '@mui/icons-material/Thermostat';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { ProductCondition } from './types';
+
+function MetricRow({
+  label,
+  value,
+  unit,
+  lastUpdate,
+  showProgress,
+  progressMax,
+}: {
+  label: string;
+  value?: number;
+  unit?: string;
+  lastUpdate?: string;
+  showProgress?: boolean;
+  progressMax?: number;
+}) {
+  if (value === undefined) return null;
+  const progressValue = progressMax ? Math.min((value / progressMax) * 100, 100) : Math.min(value, 100);
+  return (
+    <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
+      <Typography variant="subtitle2" color="text.secondary">{label}</Typography>
+      <Typography variant="body1" sx={{ fontWeight: 600 }}>
+        {value}{unit ? ` ${unit}` : ''}
+      </Typography>
+      {showProgress && (
+        <LinearProgress
+          variant="determinate"
+          value={progressValue}
+          sx={{ mt: 0.5, height: 4, borderRadius: 2 }}
+        />
+      )}
+      {lastUpdate && (
+        <Typography variant="caption" color="text.secondary">
+          Updated: {lastUpdate}
+        </Typography>
+      )}
+    </Grid2>
+  );
+}
+
+export const ProductConditionBatteryViewer: React.FC<SubmodelAddonProps<ProductCondition>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<ProductCondition>(rawData);
+  if (!data) return null;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Product Condition"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        {/* State of Charge */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BatteryFullIcon color="primary" />
+              Current State
+            </Typography>
+            <Grid2 container spacing={2}>
+              <Grid2 size={{ xs: 12, sm: 6 }}>
+                <Typography variant="subtitle2" color="text.secondary">State of Charge</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 0.5 }}>
+                  <Box sx={{ flex: 1 }}>
+                    <LinearProgress
+                      variant="determinate"
+                      value={data.StateOfCharge.StateOfChargeValue}
+                      color={data.StateOfCharge.StateOfChargeValue > 50 ? 'success' : data.StateOfCharge.StateOfChargeValue > 20 ? 'warning' : 'error'}
+                      sx={{ height: 12, borderRadius: 6 }}
+                    />
+                  </Box>
+                  <Typography variant="body1" sx={{ fontWeight: 700, minWidth: 50 }}>
+                    {data.StateOfCharge.StateOfChargeValue}%
+                  </Typography>
+                </Box>
+                <Typography variant="caption" color="text.secondary">
+                  Updated: {data.StateOfCharge.LastUpdate}
+                </Typography>
+              </Grid2>
+              <MetricRow
+                label="Number of Full Cycles"
+                value={data.NumberOfFullCycles.NumberOfFullCyclesValue}
+                lastUpdate={data.NumberOfFullCycles.LastUpdate}
+              />
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Energy & Capacity */}
+        {(data.EnergyThroughput || data.CapacityThroughput || data.RemainingEnergy || data.RemainingCapacity || data.StateOfCertifiedEnergy) && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <ThunderstormIcon color="primary" />
+                Energy &amp; Capacity
+              </Typography>
+              <Grid2 container spacing={2}>
+                <MetricRow
+                  label="Energy Throughput"
+                  value={data.EnergyThroughput?.EnergyThroughputValue}
+                  unit="kWh"
+                  lastUpdate={data.EnergyThroughput?.LastUpdate}
+                />
+                <MetricRow
+                  label="Capacity Throughput"
+                  value={data.CapacityThroughput?.CapacityThroughputValue}
+                  unit="Ah"
+                  lastUpdate={data.CapacityThroughput?.LastUpdate}
+                />
+                <MetricRow
+                  label="Remaining Energy"
+                  value={data.RemainingEnergy?.RemainingEnergyValue}
+                  unit="kWh"
+                  lastUpdate={data.RemainingEnergy?.LastUpdate}
+                />
+                <MetricRow
+                  label="Remaining Capacity"
+                  value={data.RemainingCapacity?.RemainingCapacityValue}
+                  unit="Ah"
+                  lastUpdate={data.RemainingCapacity?.LastUpdate}
+                />
+                <MetricRow
+                  label="State of Certified Energy"
+                  value={data.StateOfCertifiedEnergy?.StateOfCertifiedEnergyValue}
+                  unit="%"
+                  showProgress={true}
+                  lastUpdate={data.StateOfCertifiedEnergy?.LastUpdate}
+                />
+              </Grid2>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Efficiency & Discharge */}
+        {(data.RemainingRoundTripEnergyEfficiency || data.CurrentSelfDischargingRate || data.EvolutionOfSelfDischarge) && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <SpeedIcon color="primary" />
+                Efficiency &amp; Self-Discharge
+              </Typography>
+              <Grid2 container spacing={2}>
+                <MetricRow
+                  label="Remaining Round Trip Energy Efficiency"
+                  value={data.RemainingRoundTripEnergyEfficiency?.RemainingRoundTripEnergyEfficiencyValue}
+                  unit="%"
+                  showProgress={true}
+                  lastUpdate={data.RemainingRoundTripEnergyEfficiency?.LastUpdate}
+                />
+                <MetricRow
+                  label="Current Self-Discharging Rate"
+                  value={data.CurrentSelfDischargingRate?.CurrentSelfDischargingRateValue}
+                  unit="%/month"
+                  lastUpdate={data.CurrentSelfDischargingRate?.LastUpdate}
+                />
+                <MetricRow
+                  label="Evolution of Self-Discharge"
+                  value={data.EvolutionOfSelfDischarge?.EvolutionOfSelfDischargeValue}
+                  lastUpdate={data.EvolutionOfSelfDischarge?.LastUpdate}
+                />
+              </Grid2>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Temperature Information */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <ThermostatIcon color="primary" />
+              Temperature History
+            </Typography>
+            <Grid2 container spacing={2}>
+              <MetricRow
+                label="Time at Extreme High Temperature"
+                value={data.TemperatureInformation.TimeExtremeHighTemp}
+                unit="h"
+              />
+              <MetricRow
+                label="Time at Extreme Low Temperature"
+                value={data.TemperatureInformation.TimeExtremeLowTemp}
+                unit="h"
+              />
+              <MetricRow
+                label="Time at Extreme High Temp (Charging)"
+                value={data.TemperatureInformation.TimeExtremeHighTempCharging}
+                unit="h"
+              />
+              <MetricRow
+                label="Time at Extreme Low Temp (Charging)"
+                value={data.TemperatureInformation.TimeExtremeLowTempCharging}
+                unit="h"
+              />
+            </Grid2>
+            <Typography variant="caption" color="text.secondary">
+              Updated: {data.TemperatureInformation.LastUpdate}
+            </Typography>
+          </CardContent>
+        </Card>
+
+        {/* Negative Events */}
+        {data.NegativeEvents && data.NegativeEvents.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <WarningAmberIcon color="warning" />
+                Negative Events
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {data.NegativeEvents.map((event) => (
+                  <Box key={`${event.NegativeEventValue}-${event.LastUpdate}`} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
+                    <Chip label={event.NegativeEventValue} color="warning" variant="outlined" />
+                    <Typography variant="caption" color="text.secondary">{event.LastUpdate}</Typography>
+                  </Box>
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Accidents & Compliance */}
+        {data.InformationOnAccidents && data.InformationOnAccidents.length > 0 && (
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <EventNoteIcon color="primary" />
+                Information on Accidents
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {data.InformationOnAccidents.map((doc) => (
+                  <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+                ))}
+              </Box>
+              <Divider sx={{ my: 1.5 }} />
+              <Typography variant="caption" color="text.secondary">
+                {data.InformationOnAccidents.length} accident report document(s) on record
+              </Typography>
+            </CardContent>
+          </Card>
+        )}
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  ProductCondition,
+  BATTERY_PASS_PRODUCT_CONDITION_NAMESPACE,
+  BATTERY_PASS_PRODUCT_CONDITION_MODEL_NAME,
+  BATTERY_PASS_PRODUCT_CONDITION_SEMANTIC_ID,
+  isProductCondition,
+} from './types';
+import { ProductConditionBatteryViewer } from '.';
+
+export const batteryPassProductConditionAddon: VersionedSubmodelAddon<ProductCondition> = {
+  id: 'battery-pass-product-condition',
+  name: 'Battery Pass Product Condition',
+  description: 'Specialized visualization for IDTA BatteryPass Product Condition submodels including state of charge, energy throughput, temperature history, and negative events.',
+  namespace: BATTERY_PASS_PRODUCT_CONDITION_NAMESPACE,
+  modelName: BATTERY_PASS_PRODUCT_CONDITION_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_PRODUCT_CONDITION_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isProductCondition,
+  component: ProductConditionBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { ProductConditionBatteryViewer } from './ProductConditionBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-product-condition/types.ts
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Product Condition submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.product_condition:1.0.0#ProductCondition
+ */
+
+export const BATTERY_PASS_PRODUCT_CONDITION_NAMESPACE =
+  'io.admin-shell.idta.batterypass.product_condition';
+export const BATTERY_PASS_PRODUCT_CONDITION_MODEL_NAME = 'ProductCondition';
+
+export const BATTERY_PASS_PRODUCT_CONDITION_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_PRODUCT_CONDITION_NAMESPACE}:1.0.0#${BATTERY_PASS_PRODUCT_CONDITION_MODEL_NAME}`;
+
+export interface NegativeEvent {
+  NegativeEventValue: string;
+  LastUpdate: string;
+}
+
+export interface TemperatureInformation {
+  TimeExtremeHighTemp?: number;
+  TimeExtremeLowTemp?: number;
+  TimeExtremeHighTempCharging?: number;
+  TimeExtremeLowTempCharging?: number;
+  LastUpdate: string;
+}
+
+export interface ProductCondition {
+  EnergyThroughput?: { EnergyThroughputValue: number; LastUpdate: string };
+  CapacityThroughput?: { CapacityThroughputValue: number; LastUpdate: string };
+  NumberOfFullCycles: { NumberOfFullCyclesValue: number; LastUpdate: string };
+  StateOfCertifiedEnergy?: { StateOfCertifiedEnergyValue: number; LastUpdate: string };
+  RemainingEnergy?: { RemainingEnergyValue: number; LastUpdate: string };
+  RemainingCapacity?: { RemainingCapacityValue: number; LastUpdate: string };
+  NegativeEvents?: NegativeEvent[];
+  InformationOnAccidents: string[];
+  TemperatureInformation: TemperatureInformation;
+  RemainingPowerCapability?: { RemainingPowerCapabilityValue: Record<string, unknown>; LastUpdate: string };
+  EvolutionOfSelfDischarge?: { EvolutionOfSelfDischargeValue: number; LastUpdate: string };
+  CurrentSelfDischargingRate?: { CurrentSelfDischargingRateValue: number; LastUpdate: string };
+  RemainingRoundTripEnergyEfficiency?: { RemainingRoundTripEnergyEfficiencyValue: number; LastUpdate: string };
+  StateOfCharge: { StateOfChargeValue: number; LastUpdate: string };
+}
+
+export function isProductCondition(
+  _semanticId: string,
+  data: unknown
+): data is ProductCondition {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'NumberOfFullCycles' in obj &&
+    'StateOfCharge' in obj &&
+    'TemperatureInformation' in obj
+  );
+}

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-shared/InfoRow.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-shared/InfoRow.tsx
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import { Grid2, Typography } from '@mui/material';
+
+export function InfoRow({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value?: React.ReactNode;
+  unit?: string;
+}) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
+      <Typography variant="subtitle2" color="text.secondary">{label}</Typography>
+      <Typography variant="body2">
+        {value}{unit ? ` ${unit}` : ''}
+      </Typography>
+    </Grid2>
+  );
+}

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-shared/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-shared/types.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/** Multi-language text entry: an object with a language code as key, e.g. { "en": "Hello" } */
+export type MultiLangEntry = Record<string, string>;
+
+/** Extract the display value from a MultiLangEntry or array of entries, preferring English. */
+export function getMultiLangValue(
+  entries: MultiLangEntry | MultiLangEntry[] | undefined,
+  preferredLang = 'en'
+): string {
+  if (!entries) return '';
+  const arr = Array.isArray(entries) ? entries : [entries];
+  if (arr.length === 0) return '';
+  const preferred = arr.find(e => e[preferredLang]);
+  if (preferred) return preferred[preferredLang];
+  const first = arr[0];
+  return Object.values(first)[0] ?? '';
+}

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/TechnicalDataBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/TechnicalDataBatteryViewer.tsx
@@ -22,6 +22,7 @@
  ********************************************************************************/
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Box,
   Typography,
@@ -44,16 +45,17 @@ import { InfoRow } from '../battery-pass-shared/InfoRow';
 import { TechnicalData, BatteryCategory, getMultiLangValue } from './types';
 
 const CATEGORY_LABELS: Record<BatteryCategory, string> = {
-  lmt: 'Light Means of Transport (LMT)',
-  ev: 'Electric Vehicle (EV)',
-  industrial: 'Industrial',
-  stationary: 'Stationary Energy Storage',
+  lmt: 'technicalData.categories.lmt',
+  ev: 'technicalData.categories.ev',
+  industrial: 'technicalData.categories.industrial',
+  stationary: 'technicalData.categories.stationary',
 };
 
 export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalData>> = ({
   data: rawData,
   semanticId,
 }) => {
+  const { t } = useTranslation('batteryPass');
   const data = unwrapSubmodelData<TechnicalData>(rawData);
   if (!data) return null;
   const generalInfo = data.GeneralInformation;
@@ -61,7 +63,7 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
 
   return (
     <SubmodelAddonWrapper
-      title="Battery Pass — Technical Data"
+      title={t('technicalData.title')}
       subtitle={`Semantic ID: ${semanticId}`}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -71,23 +73,23 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BusinessIcon color="primary" />
-              General Information
+              {t('technicalData.sections.generalInformation')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Manufacturer" value={generalInfo.ManufacturerName} />
+              <InfoRow label={t('technicalData.fields.manufacturer')} value={generalInfo.ManufacturerName} />
               <InfoRow
-                label="Product Designation"
+                label={t('technicalData.fields.productDesignation')}
                 value={getMultiLangValue(generalInfo.ManufacturerProductDesignation)}
               />
-              <InfoRow label="Article Number" value={generalInfo.ManufacturerArticleNumber} />
-              <InfoRow label="Order Code" value={generalInfo.ManufacturerOrderCode} />
-              <InfoRow label="Manufacturer Identifier" value={generalInfo.ManufacturerIdentifier} />
-              <InfoRow label="Warranty Period" value={generalInfo.WarrantyPeriod} />
-              <InfoRow label="Battery Mass" value={generalInfo.BatteryMass} unit="kg" />
+              <InfoRow label={t('technicalData.fields.articleNumber')} value={generalInfo.ManufacturerArticleNumber} />
+              <InfoRow label={t('technicalData.fields.orderCode')} value={generalInfo.ManufacturerOrderCode} />
+              <InfoRow label={t('technicalData.fields.manufacturerIdentifier')} value={generalInfo.ManufacturerIdentifier} />
+              <InfoRow label={t('technicalData.fields.warrantyPeriod')} value={generalInfo.WarrantyPeriod} />
+              <InfoRow label={t('technicalData.fields.batteryMass')} value={generalInfo.BatteryMass} unit="kg" />
               <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
-                <Typography variant="subtitle2" color="text.secondary">Battery Category</Typography>
+                <Typography variant="subtitle2" color="text.secondary">{t('technicalData.fields.batteryCategory')}</Typography>
                 <Chip
-                  label={CATEGORY_LABELS[generalInfo.BatteryCategory] ?? generalInfo.BatteryCategory}
+                  label={t(CATEGORY_LABELS[generalInfo.BatteryCategory] ?? generalInfo.BatteryCategory)}
                   color="primary"
                   size="small"
                   variant="outlined"
@@ -102,18 +104,18 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BoltIcon color="primary" />
-              Capacity, Energy &amp; Voltage
+              {t('technicalData.sections.capacityEnergyVoltage')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Nominal Voltage" value={techAreas.CapacityEnergyVoltage.NominalVoltage} unit="V" />
-              <InfoRow label="Minimum Voltage" value={techAreas.CapacityEnergyVoltage.MinVoltage} unit="V" />
-              <InfoRow label="Maximum Voltage" value={techAreas.CapacityEnergyVoltage.MaxVoltage} unit="V" />
-              <InfoRow label="Rated Capacity" value={techAreas.CapacityEnergyVoltage.RatedCapacity} unit="Ah" />
+              <InfoRow label={t('technicalData.fields.nominalVoltage')} value={techAreas.CapacityEnergyVoltage.NominalVoltage} unit="V" />
+              <InfoRow label={t('technicalData.fields.minimumVoltage')} value={techAreas.CapacityEnergyVoltage.MinVoltage} unit="V" />
+              <InfoRow label={t('technicalData.fields.maximumVoltage')} value={techAreas.CapacityEnergyVoltage.MaxVoltage} unit="V" />
+              <InfoRow label={t('technicalData.fields.ratedCapacity')} value={techAreas.CapacityEnergyVoltage.RatedCapacity} unit="Ah" />
               {techAreas.CapacityEnergyVoltage.CapacityFade !== undefined && (
-                <InfoRow label="Capacity Fade" value={techAreas.CapacityEnergyVoltage.CapacityFade} unit="%" />
+                <InfoRow label={t('technicalData.fields.capacityFade')} value={techAreas.CapacityEnergyVoltage.CapacityFade} unit="%" />
               )}
               {techAreas.CapacityEnergyVoltage.CertifiedUsableBatteryEnergy !== undefined && (
-                <InfoRow label="Certified Usable Battery Energy" value={techAreas.CapacityEnergyVoltage.CertifiedUsableBatteryEnergy} unit="kWh" />
+                <InfoRow label={t('technicalData.fields.certifiedUsableBatteryEnergy')} value={techAreas.CapacityEnergyVoltage.CertifiedUsableBatteryEnergy} unit="kWh" />
               )}
             </Grid2>
           </CardContent>
@@ -124,16 +126,16 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <SpeedIcon color="primary" />
-              Round Trip Energy Efficiency
+              {t('technicalData.sections.roundTripEnergyEfficiency')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Initial Efficiency" value={techAreas.RoundTripEnergyEfficiency.InitialRoundTripEnergyEfficiency} unit="%" />
-              <InfoRow label="Efficiency at 50% Cycle Life" value={techAreas.RoundTripEnergyEfficiency.RoundTripEnergyEfficiencyAt50PercentOfCycleLife} unit="%" />
+              <InfoRow label={t('technicalData.fields.initialEfficiency')} value={techAreas.RoundTripEnergyEfficiency.InitialRoundTripEnergyEfficiency} unit="%" />
+              <InfoRow label={t('technicalData.fields.efficiencyAt50PercentCycleLife')} value={techAreas.RoundTripEnergyEfficiency.RoundTripEnergyEfficiencyAt50PercentOfCycleLife} unit="%" />
               {techAreas.RoundTripEnergyEfficiency.EnergyRoundTripEfficiencyFade !== undefined && (
-                <InfoRow label="Efficiency Fade" value={techAreas.RoundTripEnergyEfficiency.EnergyRoundTripEfficiencyFade} unit="%" />
+                <InfoRow label={t('technicalData.fields.efficiencyFade')} value={techAreas.RoundTripEnergyEfficiency.EnergyRoundTripEfficiencyFade} unit="%" />
               )}
               {techAreas.RoundTripEnergyEfficiency.InitialSelfDischargingRate !== undefined && (
-                <InfoRow label="Initial Self-Discharging Rate" value={techAreas.RoundTripEnergyEfficiency.InitialSelfDischargingRate} unit="%/month" />
+                <InfoRow label={t('technicalData.fields.initialSelfDischargingRate')} value={techAreas.RoundTripEnergyEfficiency.InitialSelfDischargingRate} unit="%/month" />
               )}
             </Grid2>
           </CardContent>
@@ -144,23 +146,23 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BuildIcon color="primary" />
-              Internal Resistance
+              {t('technicalData.sections.internalResistance')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Cell Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryCellLevel} unit="mΩ" />
-              <InfoRow label="Pack Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryPackLevel} unit="mΩ" />
+              <InfoRow label={t('technicalData.fields.cellLevelInitial')} value={techAreas.Resistance.InitialInternalResistanceAtBatteryCellLevel} unit="mΩ" />
+              <InfoRow label={t('technicalData.fields.packLevelInitial')} value={techAreas.Resistance.InitialInternalResistanceAtBatteryPackLevel} unit="mΩ" />
               {techAreas.Resistance.InitialInternalResistanceAtBatteryModuleLevel !== undefined && (
-                <InfoRow label="Module Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryModuleLevel} unit="mΩ" />
+                <InfoRow label={t('technicalData.fields.moduleLevelInitial')} value={techAreas.Resistance.InitialInternalResistanceAtBatteryModuleLevel} unit="mΩ" />
               )}
               <Grid2 size={12}>
                 <Divider sx={{ my: 0.5 }} />
               </Grid2>
-              <InfoRow label="Pack Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryPackLevel} unit="%" />
+              <InfoRow label={t('technicalData.fields.packLevelIncrease')} value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryPackLevel} unit="%" />
               {techAreas.Resistance.InternalResistanceIncreaseAtBatteryCellLevel !== undefined && (
-                <InfoRow label="Cell Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryCellLevel} unit="%" />
+                <InfoRow label={t('technicalData.fields.cellLevelIncrease')} value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryCellLevel} unit="%" />
               )}
               {techAreas.Resistance.InternalResistanceIncreaseAtBatteryModuleLevel !== undefined && (
-                <InfoRow label="Module Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryModuleLevel} unit="%" />
+                <InfoRow label={t('technicalData.fields.moduleLevelIncrease')} value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryModuleLevel} unit="%" />
               )}
             </Grid2>
           </CardContent>
@@ -171,18 +173,18 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
           <CardContent>
             <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <BoltIcon color="primary" />
-              Power Capability
+              {t('technicalData.sections.powerCapability')}
             </Typography>
             <Grid2 container spacing={2}>
-              <InfoRow label="Maximum Permitted Power" value={techAreas.PowerCapability.MaximumPermittedBatteryPower} unit="W" />
-              <InfoRow label="Power Fade" value={techAreas.PowerCapability.PowerFade} unit="%" />
-              <InfoRow label="Power-to-Energy Ratio" value={techAreas.PowerCapability.RatioNominalBatteryPowerAndBatteryEnergy} unit="W/Wh" />
+              <InfoRow label={t('technicalData.fields.maximumPermittedPower')} value={techAreas.PowerCapability.MaximumPermittedBatteryPower} unit="W" />
+              <InfoRow label={t('technicalData.fields.powerFade')} value={techAreas.PowerCapability.PowerFade} unit="%" />
+              <InfoRow label={t('technicalData.fields.powerToEnergyRatio')} value={techAreas.PowerCapability.RatioNominalBatteryPowerAndBatteryEnergy} unit="W/Wh" />
             </Grid2>
             {techAreas.PowerCapability.OriginalPowerCapability && techAreas.PowerCapability.OriginalPowerCapability.length > 0 && (
               <>
                 <Divider sx={{ my: 2 }} />
                 <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                  Power Capability at State of Charge
+                  {t('technicalData.sections.powerCapabilityAtSoC')}
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {techAreas.PowerCapability.OriginalPowerCapability.map((pc) => (
@@ -206,11 +208,11 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
               <CardContent>
                 <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                   <ThermostatIcon color="primary" />
-                  Temperature Range (Idle)
+                  {t('technicalData.sections.temperatureRange')}
                 </Typography>
                 <Grid2 container spacing={2}>
-                  <InfoRow label="Lower Boundary" value={techAreas.Temperature.TemperatureRangeIdleState_LowerBoundary} unit="°C" />
-                  <InfoRow label="Upper Boundary" value={techAreas.Temperature.TemperatureRangeIdleState_UpperBoundary} unit="°C" />
+                  <InfoRow label={t('technicalData.fields.lowerBoundary')} value={techAreas.Temperature.TemperatureRangeIdleState_LowerBoundary} unit="°C" />
+                  <InfoRow label={t('technicalData.fields.upperBoundary')} value={techAreas.Temperature.TemperatureRangeIdleState_UpperBoundary} unit="°C" />
                 </Grid2>
               </CardContent>
             </Card>
@@ -220,18 +222,18 @@ export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalDa
               <CardContent>
                 <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
                   <TimerIcon color="primary" />
-                  Lifetime
+                  {t('technicalData.sections.lifetime')}
                 </Typography>
                 <Grid2 container spacing={2}>
-                  <InfoRow label="Expected Lifetime" value={techAreas.Lifetime.ExpectedLifetimeInCalendarYears} unit="years" />
-                  <InfoRow label="Expected Cycles" value={techAreas.Lifetime.ExpectedNumberOfCycles} />
-                  <InfoRow label="Capacity Threshold for Exhaustion" value={techAreas.Lifetime.CapacityThresholdExhaustion} unit="%" />
-                  <InfoRow label="C-Rate (Cycle Life Test)" value={techAreas.Lifetime.CrateOfRelevantCycleLifeTest} />
+                  <InfoRow label={t('technicalData.fields.expectedLifetime')} value={techAreas.Lifetime.ExpectedLifetimeInCalendarYears} unit="years" />
+                  <InfoRow label={t('technicalData.fields.expectedCycles')} value={techAreas.Lifetime.ExpectedNumberOfCycles} />
+                  <InfoRow label={t('technicalData.fields.capacityThresholdForExhaustion')} value={techAreas.Lifetime.CapacityThresholdExhaustion} unit="%" />
+                  <InfoRow label={t('technicalData.fields.cRateCycleLifeTest')} value={techAreas.Lifetime.CrateOfRelevantCycleLifeTest} />
                 </Grid2>
                 {techAreas.Lifetime.CycleLifeReferenceTest && techAreas.Lifetime.CycleLifeReferenceTest.length > 0 && (
                   <>
                     <Divider sx={{ my: 1.5 }} />
-                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>Reference Test Documents</Typography>
+                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>{t('technicalData.sections.referenceTestDocuments')}</Typography>
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                       {techAreas.Lifetime.CycleLifeReferenceTest.map((doc) => (
                         <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }} />

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/TechnicalDataBatteryViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/TechnicalDataBatteryViewer.tsx
@@ -1,0 +1,250 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Grid2,
+  Divider,
+} from '@mui/material';
+import BusinessIcon from '@mui/icons-material/Business';
+import BoltIcon from '@mui/icons-material/Bolt';
+import ThermostatIcon from '@mui/icons-material/Thermostat';
+import TimerIcon from '@mui/icons-material/Timer';
+import SpeedIcon from '@mui/icons-material/Speed';
+import BuildIcon from '@mui/icons-material/Build';
+import { SubmodelAddonProps } from '../shared/types';
+import { unwrapSubmodelData } from '../shared/utils';
+import { SubmodelAddonWrapper } from '../BaseAddon';
+import { InfoRow } from '../battery-pass-shared/InfoRow';
+import { TechnicalData, BatteryCategory, getMultiLangValue } from './types';
+
+const CATEGORY_LABELS: Record<BatteryCategory, string> = {
+  lmt: 'Light Means of Transport (LMT)',
+  ev: 'Electric Vehicle (EV)',
+  industrial: 'Industrial',
+  stationary: 'Stationary Energy Storage',
+};
+
+export const TechnicalDataBatteryViewer: React.FC<SubmodelAddonProps<TechnicalData>> = ({
+  data: rawData,
+  semanticId,
+}) => {
+  const data = unwrapSubmodelData<TechnicalData>(rawData);
+  if (!data) return null;
+  const generalInfo = data.GeneralInformation;
+  const techAreas = data.TechnicalPropertyAreas;
+
+  return (
+    <SubmodelAddonWrapper
+      title="Battery Pass — Technical Data"
+      subtitle={`Semantic ID: ${semanticId}`}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        {/* General Information */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BusinessIcon color="primary" />
+              General Information
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Manufacturer" value={generalInfo.ManufacturerName} />
+              <InfoRow
+                label="Product Designation"
+                value={getMultiLangValue(generalInfo.ManufacturerProductDesignation)}
+              />
+              <InfoRow label="Article Number" value={generalInfo.ManufacturerArticleNumber} />
+              <InfoRow label="Order Code" value={generalInfo.ManufacturerOrderCode} />
+              <InfoRow label="Manufacturer Identifier" value={generalInfo.ManufacturerIdentifier} />
+              <InfoRow label="Warranty Period" value={generalInfo.WarrantyPeriod} />
+              <InfoRow label="Battery Mass" value={generalInfo.BatteryMass} unit="kg" />
+              <Grid2 size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="subtitle2" color="text.secondary">Battery Category</Typography>
+                <Chip
+                  label={CATEGORY_LABELS[generalInfo.BatteryCategory] ?? generalInfo.BatteryCategory}
+                  color="primary"
+                  size="small"
+                  variant="outlined"
+                />
+              </Grid2>
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Capacity, Energy, Voltage */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BoltIcon color="primary" />
+              Capacity, Energy &amp; Voltage
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Nominal Voltage" value={techAreas.CapacityEnergyVoltage.NominalVoltage} unit="V" />
+              <InfoRow label="Minimum Voltage" value={techAreas.CapacityEnergyVoltage.MinVoltage} unit="V" />
+              <InfoRow label="Maximum Voltage" value={techAreas.CapacityEnergyVoltage.MaxVoltage} unit="V" />
+              <InfoRow label="Rated Capacity" value={techAreas.CapacityEnergyVoltage.RatedCapacity} unit="Ah" />
+              {techAreas.CapacityEnergyVoltage.CapacityFade !== undefined && (
+                <InfoRow label="Capacity Fade" value={techAreas.CapacityEnergyVoltage.CapacityFade} unit="%" />
+              )}
+              {techAreas.CapacityEnergyVoltage.CertifiedUsableBatteryEnergy !== undefined && (
+                <InfoRow label="Certified Usable Battery Energy" value={techAreas.CapacityEnergyVoltage.CertifiedUsableBatteryEnergy} unit="kWh" />
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Round Trip Energy Efficiency */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <SpeedIcon color="primary" />
+              Round Trip Energy Efficiency
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Initial Efficiency" value={techAreas.RoundTripEnergyEfficiency.InitialRoundTripEnergyEfficiency} unit="%" />
+              <InfoRow label="Efficiency at 50% Cycle Life" value={techAreas.RoundTripEnergyEfficiency.RoundTripEnergyEfficiencyAt50PercentOfCycleLife} unit="%" />
+              {techAreas.RoundTripEnergyEfficiency.EnergyRoundTripEfficiencyFade !== undefined && (
+                <InfoRow label="Efficiency Fade" value={techAreas.RoundTripEnergyEfficiency.EnergyRoundTripEfficiencyFade} unit="%" />
+              )}
+              {techAreas.RoundTripEnergyEfficiency.InitialSelfDischargingRate !== undefined && (
+                <InfoRow label="Initial Self-Discharging Rate" value={techAreas.RoundTripEnergyEfficiency.InitialSelfDischargingRate} unit="%/month" />
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Resistance */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BuildIcon color="primary" />
+              Internal Resistance
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Cell Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryCellLevel} unit="mΩ" />
+              <InfoRow label="Pack Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryPackLevel} unit="mΩ" />
+              {techAreas.Resistance.InitialInternalResistanceAtBatteryModuleLevel !== undefined && (
+                <InfoRow label="Module Level (Initial)" value={techAreas.Resistance.InitialInternalResistanceAtBatteryModuleLevel} unit="mΩ" />
+              )}
+              <Grid2 size={12}>
+                <Divider sx={{ my: 0.5 }} />
+              </Grid2>
+              <InfoRow label="Pack Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryPackLevel} unit="%" />
+              {techAreas.Resistance.InternalResistanceIncreaseAtBatteryCellLevel !== undefined && (
+                <InfoRow label="Cell Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryCellLevel} unit="%" />
+              )}
+              {techAreas.Resistance.InternalResistanceIncreaseAtBatteryModuleLevel !== undefined && (
+                <InfoRow label="Module Level (Increase)" value={techAreas.Resistance.InternalResistanceIncreaseAtBatteryModuleLevel} unit="%" />
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        {/* Power Capability */}
+        <Card>
+          <CardContent>
+            <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+              <BoltIcon color="primary" />
+              Power Capability
+            </Typography>
+            <Grid2 container spacing={2}>
+              <InfoRow label="Maximum Permitted Power" value={techAreas.PowerCapability.MaximumPermittedBatteryPower} unit="W" />
+              <InfoRow label="Power Fade" value={techAreas.PowerCapability.PowerFade} unit="%" />
+              <InfoRow label="Power-to-Energy Ratio" value={techAreas.PowerCapability.RatioNominalBatteryPowerAndBatteryEnergy} unit="W/Wh" />
+            </Grid2>
+            {techAreas.PowerCapability.OriginalPowerCapability && techAreas.PowerCapability.OriginalPowerCapability.length > 0 && (
+              <>
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                  Power Capability at State of Charge
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {techAreas.PowerCapability.OriginalPowerCapability.map((pc) => (
+                    <Chip
+                      key={`soc-${pc.atSoC}`}
+                      label={`SoC ${pc.atSoC}%: ${pc.powerCapabilityAt} W`}
+                      size="small"
+                      variant="outlined"
+                    />
+                  ))}
+                </Box>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Temperature & Lifetime */}
+        <Grid2 container spacing={2}>
+          <Grid2 size={{ xs: 12, md: 6 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                  <ThermostatIcon color="primary" />
+                  Temperature Range (Idle)
+                </Typography>
+                <Grid2 container spacing={2}>
+                  <InfoRow label="Lower Boundary" value={techAreas.Temperature.TemperatureRangeIdleState_LowerBoundary} unit="°C" />
+                  <InfoRow label="Upper Boundary" value={techAreas.Temperature.TemperatureRangeIdleState_UpperBoundary} unit="°C" />
+                </Grid2>
+              </CardContent>
+            </Card>
+          </Grid2>
+          <Grid2 size={{ xs: 12, md: 6 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                  <TimerIcon color="primary" />
+                  Lifetime
+                </Typography>
+                <Grid2 container spacing={2}>
+                  <InfoRow label="Expected Lifetime" value={techAreas.Lifetime.ExpectedLifetimeInCalendarYears} unit="years" />
+                  <InfoRow label="Expected Cycles" value={techAreas.Lifetime.ExpectedNumberOfCycles} />
+                  <InfoRow label="Capacity Threshold for Exhaustion" value={techAreas.Lifetime.CapacityThresholdExhaustion} unit="%" />
+                  <InfoRow label="C-Rate (Cycle Life Test)" value={techAreas.Lifetime.CrateOfRelevantCycleLifeTest} />
+                </Grid2>
+                {techAreas.Lifetime.CycleLifeReferenceTest && techAreas.Lifetime.CycleLifeReferenceTest.length > 0 && (
+                  <>
+                    <Divider sx={{ my: 1.5 }} />
+                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>Reference Test Documents</Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {techAreas.Lifetime.CycleLifeReferenceTest.map((doc) => (
+                        <Chip key={doc} label={doc} size="small" variant="outlined" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }} />
+                      ))}
+                    </Box>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          </Grid2>
+        </Grid2>
+
+      </Box>
+    </SubmodelAddonWrapper>
+  );
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/addon.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/addon.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { VersionedSubmodelAddon } from '../shared/types';
+import {
+  TechnicalData,
+  BATTERY_PASS_TECHNICAL_DATA_NAMESPACE,
+  BATTERY_PASS_TECHNICAL_DATA_MODEL_NAME,
+  BATTERY_PASS_TECHNICAL_DATA_SEMANTIC_ID,
+  isTechnicalData,
+} from './types';
+import { TechnicalDataBatteryViewer } from '.';
+
+export const batteryPassTechnicalDataAddon: VersionedSubmodelAddon<TechnicalData> = {
+  id: 'battery-pass-technical-data',
+  name: 'Battery Pass Technical Data',
+  description: 'Specialized visualization for IDTA BatteryPass Technical Data submodels including general information, capacity/voltage, efficiency, resistance, power capability, and lifetime.',
+  namespace: BATTERY_PASS_TECHNICAL_DATA_NAMESPACE,
+  modelName: BATTERY_PASS_TECHNICAL_DATA_MODEL_NAME,
+  supportedSemanticIds: [BATTERY_PASS_TECHNICAL_DATA_SEMANTIC_ID],
+  priority: 10,
+  isValidData: isTechnicalData,
+  component: TechnicalDataBatteryViewer,
+};

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/index.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/index.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export { TechnicalDataBatteryViewer } from './TechnicalDataBatteryViewer';

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/types.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/battery-pass-technical-data/types.ts
@@ -1,0 +1,130 @@
+/********************************************************************************
+ * Eclipse Tractus-X - Industry Core Hub Frontend
+ *
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the
+ * License for the specific language govern in permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Type definitions for IDTA BatteryPass Technical Data submodel
+ * Semantic Model: urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#TechnicalData
+ */
+
+export const BATTERY_PASS_TECHNICAL_DATA_NAMESPACE =
+  'io.admin-shell.idta.batterypass.technical_data';
+export const BATTERY_PASS_TECHNICAL_DATA_MODEL_NAME = 'TechnicalData';
+
+export const BATTERY_PASS_TECHNICAL_DATA_SEMANTIC_ID =
+  `urn:samm:${BATTERY_PASS_TECHNICAL_DATA_NAMESPACE}:1.0.0#${BATTERY_PASS_TECHNICAL_DATA_MODEL_NAME}`;
+
+import type { MultiLangEntry } from '../battery-pass-shared/types';
+export type { MultiLangEntry };
+export { getMultiLangValue } from '../battery-pass-shared/types';
+
+export type BatteryCategory = 'lmt' | 'ev' | 'industrial' | 'stationary';
+
+export interface GeneralInformation {
+  ManufacturerName: string;
+  CompanyLogo?: string;
+  ManufacturerProductDesignation: MultiLangEntry[];
+  ManufacturerArticleNumber: string;
+  ManufacturerOrderCode: string;
+  ManufacturerIdentifier: string;
+  WarrantyPeriod: string;
+  BatteryCategory: BatteryCategory;
+  BatteryMass: number;
+}
+
+export interface PowerCapabilityAt {
+  atSoC: number;
+  powerCapabilityAt: number;
+}
+
+export interface CapacityEnergyVoltage {
+  NominalVoltage: number;
+  MinVoltage: number;
+  MaxVoltage: number;
+  RatedCapacity: number;
+  CapacityFade?: number;
+  CertifiedUsableBatteryEnergy?: number;
+}
+
+export interface RoundTripEnergyEfficiency {
+  InitialRoundTripEnergyEfficiency: number;
+  RoundTripEnergyEfficiencyAt50PercentOfCycleLife: number;
+  EnergyRoundTripEfficiencyFade?: number;
+  InitialSelfDischargingRate?: number;
+}
+
+export interface Resistance {
+  InitialInternalResistanceAtBatteryCellLevel: number;
+  InitialInternalResistanceAtBatteryPackLevel: number;
+  InitialInternalResistanceAtBatteryModuleLevel?: number;
+  InternalResistanceIncreaseAtBatteryCellLevel?: number;
+  InternalResistanceIncreaseAtBatteryPackLevel: number;
+  InternalResistanceIncreaseAtBatteryModuleLevel?: number;
+}
+
+export interface PowerCapability {
+  MaximumPermittedBatteryPower: number;
+  PowerFade: number;
+  RatioNominalBatteryPowerAndBatteryEnergy: number;
+  OriginalPowerCapability: PowerCapabilityAt[];
+}
+
+export interface Temperature {
+  TemperatureRangeIdleState_LowerBoundary: number;
+  TemperatureRangeIdleState_UpperBoundary: number;
+}
+
+export interface Lifetime {
+  ExpectedLifetimeInCalendarYears: number;
+  ExpectedNumberOfCycles: number;
+  CapacityThresholdExhaustion: number;
+  CycleLifeReferenceTest: string[];
+  CrateOfRelevantCycleLifeTest: number;
+}
+
+export interface TechnicalAttributes {
+  CapacityEnergyVoltage: CapacityEnergyVoltage;
+  RoundTripEnergyEfficiency: RoundTripEnergyEfficiency;
+  Resistance: Resistance;
+  PowerCapability: PowerCapability;
+  Temperature: Temperature;
+  Lifetime: Lifetime;
+}
+
+export interface TechnicalData {
+  GeneralInformation: GeneralInformation;
+  TechnicalPropertyAreas: TechnicalAttributes;
+}
+
+export function isTechnicalData(
+  _semanticId: string,
+  data: unknown
+): data is TechnicalData {
+  const obj = Array.isArray(data) ? data[0] : data;
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'GeneralInformation' in obj &&
+    'TechnicalPropertyAreas' in obj
+  );
+}
+

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/shared/semantic-id-utils.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/shared/semantic-id-utils.ts
@@ -1,7 +1,8 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -45,13 +46,28 @@ export interface ParsedSemanticId {
 }
 
 /**
- * Regular expression for parsing Catena-X semantic IDs
+ * Regular expression for parsing Catena-X semantic IDs.
+ * Captures the namespace portion after 'io.catenax.' so that existing addons
+ * referencing e.g. 'us_tariff_information' continue to work unchanged.
  */
-const SEMANTIC_ID_REGEX = /^urn:samm:io\.catenax\.([\w.]+):(\d+\.\d+\.\d+)#(\w+)$/;
+const CATENA_X_SEMANTIC_ID_REGEX = /^urn:samm:io\.catenax\.([\w.]+):(\d+\.\d+\.\d+)#(\w+)$/;
 
 /**
- * Parses a Catena-X semantic ID into its components
- * 
+ * Fallback regex for any other SAMM-based semantic ID (e.g. IDTA models).
+ * The full domain path (e.g. 'io.admin-shell.idta.batterypass.digital_nameplate')
+ * is used as the namespace so that addons can reference it directly.
+ */
+const GENERIC_SAMM_SEMANTIC_ID_REGEX = /^urn:samm:([\w.-]+):(\d+\.\d+\.\d+)#(\w+)$/;
+
+/**
+ * Parses a semantic ID into its components.
+ * Supports both Catena-X ('urn:samm:io.catenax.*') and generic SAMM URNs.
+ *
+ * For Catena-X IDs the namespace is the short name after 'io.catenax.'
+ * (e.g. 'us_tariff_information'), preserving backward compatibility.
+ * For all other SAMM IDs the full domain path is used as namespace
+ * (e.g. 'io.admin-shell.idta.batterypass.digital_nameplate').
+ *
  * @param semanticId - The semantic ID to parse
  * @returns Parsed components or null if invalid format
  * 
@@ -67,17 +83,27 @@ const SEMANTIC_ID_REGEX = /^urn:samm:io\.catenax\.([\w.]+):(\d+\.\d+\.\d+)#(\w+)
  * ```
  */
 export function parseSemanticId(semanticId: string): ParsedSemanticId | null {
-  const match = semanticId.match(SEMANTIC_ID_REGEX);
-  if (!match) {
-    return null;
+  const cxMatch = semanticId.match(CATENA_X_SEMANTIC_ID_REGEX);
+  if (cxMatch) {
+    return {
+      namespace: cxMatch[1],
+      version: cxMatch[2],
+      modelName: cxMatch[3],
+      fullUrn: semanticId
+    };
   }
-  
-  return {
-    namespace: match[1],
-    version: match[2],
-    modelName: match[3],
-    fullUrn: semanticId
-  };
+
+  const genericMatch = semanticId.match(GENERIC_SAMM_SEMANTIC_ID_REGEX);
+  if (genericMatch) {
+    return {
+      namespace: genericMatch[1],
+      version: genericMatch[2],
+      modelName: genericMatch[3],
+      fullUrn: semanticId
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/shared/utils.ts
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/shared/utils.ts
@@ -1,7 +1,8 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -160,15 +161,15 @@ export function isValidSemanticId(semanticId: string): boolean {
  * @returns Array of versions sorted in ascending order
  */
 export function getSupportedVersionsForModel(
-  semanticIds: string[], 
-  namespace: string, 
+  semanticIds: string[],
+  namespace: string,
   modelName: string
 ): string[] {
   return semanticIds
     .map(parseSemanticId)
-    .filter((parsed): parsed is ParsedSemanticId => 
-      parsed !== null && 
-      parsed.namespace === namespace && 
+    .filter((parsed): parsed is ParsedSemanticId =>
+      parsed !== null &&
+      parsed.namespace === namespace &&
       parsed.fragment === modelName
     )
     .map(parsed => `${parsed.version.major}.${parsed.version.minor}.${parsed.version.patch}`)
@@ -178,4 +179,13 @@ export function getSupportedVersionsForModel(
       const versionB = { major: parseInt(b.split('.')[0]), minor: parseInt(b.split('.')[1]), patch: parseInt(b.split('.')[2]) };
       return compareVersions(versionA, versionB);
     });
+}
+
+/**
+ * Unwraps submodel data that may arrive as a single object or a single-element array.
+ * Some backends wrap the submodel payload in an array; this normalises both forms.
+ */
+export function unwrapSubmodelData<T>(data: T | T[]): T | undefined {
+  if (!Array.isArray(data)) return data;
+  return data.length > 0 ? data[0] : undefined;
 }

--- a/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel/SubmodelViewer.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel/SubmodelViewer.tsx
@@ -1,7 +1,8 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -61,6 +62,13 @@ import { submodelAddonRegistry } from '../submodel-addons/shared/registry';
 import { usTariffInformationAddon } from '../submodel-addons/us-tariff-information/addon';
 import { partTypeInformationAddon } from '../submodel-addons/part-type-information/addon';
 import { serialPartAddon } from '../submodel-addons/serial-part/addon';
+import { batteryPassDigitalNameplateAddon } from '../submodel-addons/battery-pass-digital-nameplate/addon';
+import { batteryPassCarbonFootprintAddon } from '../submodel-addons/battery-pass-carbon-footprint/addon';
+import { batteryPassCircularityAddon } from '../submodel-addons/battery-pass-circularity/addon';
+import { batteryPassHandoverDocumentationAddon } from '../submodel-addons/battery-pass-handover-documentation/addon';
+import { batteryPassMaterialCompositionAddon } from '../submodel-addons/battery-pass-material-composition/addon';
+import { batteryPassProductConditionAddon } from '../submodel-addons/battery-pass-product-condition/addon';
+import { batteryPassTechnicalDataAddon } from '../submodel-addons/battery-pass-technical-data/addon';
 
 interface SubmodelViewerProps {
   open: boolean;
@@ -368,6 +376,27 @@ export const SubmodelViewer: React.FC<SubmodelViewerProps> = ({
     }
     if (!submodelAddonRegistry.getAddon('serial-part')) {
       submodelAddonRegistry.register(serialPartAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-digital-nameplate')) {
+      submodelAddonRegistry.register(batteryPassDigitalNameplateAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-carbon-footprint')) {
+      submodelAddonRegistry.register(batteryPassCarbonFootprintAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-circularity')) {
+      submodelAddonRegistry.register(batteryPassCircularityAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-handover-documentation')) {
+      submodelAddonRegistry.register(batteryPassHandoverDocumentationAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-material-composition')) {
+      submodelAddonRegistry.register(batteryPassMaterialCompositionAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-product-condition')) {
+      submodelAddonRegistry.register(batteryPassProductConditionAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
+    }
+    if (!submodelAddonRegistry.getAddon('battery-pass-technical-data')) {
+      submodelAddonRegistry.register(batteryPassTechnicalDataAddon as unknown as import('../submodel-addons/shared/types').VersionedSubmodelAddon);
     }
   }, []);
 

--- a/ichub-frontend/src/i18n/index.ts
+++ b/ichub-frontend/src/i18n/index.ts
@@ -40,6 +40,7 @@ import enPartDiscovery from './locales/en/partDiscovery.json';
 import enSerializedParts from './locales/en/serializedParts.json';
 import enPcf from './locales/en/pcf.json';
 import enNotifications from './locales/en/notifications.json';
+import enBatteryPass from './locales/en/batteryPass.json';
 
 // Spanish
 import esCommon from './locales/es/common.json';
@@ -52,6 +53,7 @@ import esPartDiscovery from './locales/es/partDiscovery.json';
 import esSerializedParts from './locales/es/serializedParts.json';
 import esPcf from './locales/es/pcf.json';
 import esNotifications from './locales/es/notifications.json';
+import esBatteryPass from './locales/es/batteryPass.json';
 
 // German
 import deCommon from './locales/de/common.json';
@@ -64,6 +66,7 @@ import dePartDiscovery from './locales/de/partDiscovery.json';
 import deSerializedParts from './locales/de/serializedParts.json';
 import dePcf from './locales/de/pcf.json';
 import deNotifications from './locales/de/notifications.json';
+import deBatteryPass from './locales/de/batteryPass.json';
 
 // French
 import frCommon from './locales/fr/common.json';
@@ -76,6 +79,7 @@ import frPartDiscovery from './locales/fr/partDiscovery.json';
 import frSerializedParts from './locales/fr/serializedParts.json';
 import frPcf from './locales/fr/pcf.json';
 import frNotifications from './locales/fr/notifications.json';
+import frBatteryPass from './locales/fr/batteryPass.json';
 
 // Chinese (Simplified)
 import zhCommon from './locales/zh/common.json';
@@ -88,6 +92,7 @@ import zhPartDiscovery from './locales/zh/partDiscovery.json';
 import zhSerializedParts from './locales/zh/serializedParts.json';
 import zhPcf from './locales/zh/pcf.json';
 import zhNotifications from './locales/zh/notifications.json';
+import zhBatteryPass from './locales/zh/batteryPass.json';
 
 // Japanese
 import jaCommon from './locales/ja/common.json';
@@ -100,6 +105,7 @@ import jaPartDiscovery from './locales/ja/partDiscovery.json';
 import jaSerializedParts from './locales/ja/serializedParts.json';
 import jaPcf from './locales/ja/pcf.json';
 import jaNotifications from './locales/ja/notifications.json';
+import jaBatteryPass from './locales/ja/batteryPass.json';
 
 // Portuguese
 import ptCommon from './locales/pt/common.json';
@@ -112,6 +118,7 @@ import ptPartDiscovery from './locales/pt/partDiscovery.json';
 import ptSerializedParts from './locales/pt/serializedParts.json';
 import ptPcf from './locales/pt/pcf.json';
 import ptNotifications from './locales/pt/notifications.json';
+import ptBatteryPass from './locales/pt/batteryPass.json';
 
 export const defaultNS = 'common';
 export const resources = {
@@ -125,7 +132,8 @@ export const resources = {
     partDiscovery: enPartDiscovery,
     serializedParts: enSerializedParts,
     pcf: enPcf,
-    notifications: enNotifications
+    notifications: enNotifications,
+    batteryPass: enBatteryPass
   },
   es: {
     common: esCommon,
@@ -137,7 +145,8 @@ export const resources = {
     partDiscovery: esPartDiscovery,
     serializedParts: esSerializedParts,
     pcf: esPcf,
-    notifications: esNotifications
+    notifications: esNotifications,
+    batteryPass: esBatteryPass
   },
   de: {
     common: deCommon,
@@ -149,7 +158,8 @@ export const resources = {
     partDiscovery: dePartDiscovery,
     serializedParts: deSerializedParts,
     pcf: dePcf,
-    notifications: deNotifications
+    notifications: deNotifications,
+    batteryPass: deBatteryPass
   },
   fr: {
     common: frCommon,
@@ -161,7 +171,8 @@ export const resources = {
     partDiscovery: frPartDiscovery,
     serializedParts: frSerializedParts,
     pcf: frPcf,
-    notifications: frNotifications
+    notifications: frNotifications,
+    batteryPass: frBatteryPass
   },
   zh: {
     common: zhCommon,
@@ -173,7 +184,8 @@ export const resources = {
     partDiscovery: zhPartDiscovery,
     serializedParts: zhSerializedParts,
     pcf: zhPcf,
-    notifications: zhNotifications
+    notifications: zhNotifications,
+    batteryPass: zhBatteryPass
   },
   ja: {
     common: jaCommon,
@@ -185,7 +197,8 @@ export const resources = {
     partDiscovery: jaPartDiscovery,
     serializedParts: jaSerializedParts,
     pcf: jaPcf,
-    notifications: jaNotifications
+    notifications: jaNotifications,
+    batteryPass: jaBatteryPass
   },
   pt: {
     common: ptCommon,
@@ -197,7 +210,8 @@ export const resources = {
     partDiscovery: ptPartDiscovery,
     serializedParts: ptSerializedParts,
     pcf: ptPcf,
-    notifications: ptNotifications
+    notifications: ptNotifications,
+    batteryPass: ptBatteryPass
   }
 } as const;
 
@@ -215,7 +229,7 @@ i18n
     fallbackLng: 'en',
     supportedLngs: supportedLanguages,
     defaultNS,
-    ns: ['common', 'kits', 'catalogManagement', 'partnerManagement', 'passportConsumption', 'passportProvision', 'partDiscovery', 'pcf', 'notifications'],
+    ns: ['common', 'batteryPass', 'kits', 'catalogManagement', 'partnerManagement', 'passportConsumption', 'passportProvision', 'partDiscovery', 'serializedParts', 'pcf', 'notifications'],
     interpolation: {
       escapeValue: false // React already escapes values
     },

--- a/ichub-frontend/src/i18n/locales/de/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/de/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "Adresse",
+    "website": "Webseite",
+    "email": "E-Mail",
+    "company": "Unternehmen",
+    "contact": "Kontakt",
+    "country": "Land"
+  },
+  "digitalNameplate": {
+    "title": "Batteriepass — Digitales Typenschild",
+    "sections": {
+      "productIdentification": "Produktidentifikation",
+      "lifecycleStatus": "Lebenszyklusstatus",
+      "manufacturingDetails": "Fertigungsdetails",
+      "manufacturerInformation": "Herstellerinformationen",
+      "address": "Adresse",
+      "contact": "Kontakt",
+      "ipCommunicationChannels": "IP-Kommunikationskanäle",
+      "markingsAndCertifications": "Kennzeichnungen & Zertifizierungen",
+      "complianceDocuments": "Konformitätsdokumente"
+    },
+    "fields": {
+      "batteryPassportUri": "Batteriepass-URI",
+      "serialNumber": "Seriennummer",
+      "manufacturerIdentifier": "Herstellerkennung",
+      "operatorIdentifier": "Betreiberkennung",
+      "manufacturerName": "Herstellername",
+      "company": "Unternehmen",
+      "department": "Abteilung",
+      "contactRole": "Kontaktrolle",
+      "contactPerson": "Kontaktperson",
+      "street": "Straße",
+      "cityTown": "Stadt / Ort",
+      "zipCode": "Postleitzahl",
+      "stateCounty": "Bundesland / Landkreis",
+      "country": "Land",
+      "timeZone": "Zeitzone",
+      "poBox": "Postfach",
+      "website": "Webseite",
+      "email": "E-Mail",
+      "phone": "Telefon",
+      "fax": "Fax",
+      "document": "Dokument",
+      "dateOfManufacture": "Herstellungsdatum",
+      "dateOfPuttingIntoService": "Inbetriebnahmedatum",
+      "uniqueFacilityIdentifier": "Eindeutige Anlagenkennung",
+      "issueDate": "Ausstellungsdatum",
+      "expiryDate": "Ablaufdatum",
+      "additionalInfo": "Zusätzliche Informationen",
+      "euDeclarationOfConformity": "EU-Konformitätserklärung",
+      "resultsOfTestReportsProvingCompliance": "Ergebnisse von Prüfberichten zum Nachweis der Konformität"
+    },
+    "lifecycle": {
+      "original": "Batterie ist neu und wurde noch nie umgewidmet oder aufgearbeitet.",
+      "repurposed": "Batterie wurde für eine andere Anwendung umgewidmet.",
+      "re-used": "Batterie wurde in der gleichen oder ähnlichen Anwendung weiterverwendet.",
+      "remanufactured": "Batterie wurde aufgearbeitet, um ihre Leistung wiederherzustellen.",
+      "waste": "Batterie hat das Ende ihrer Lebensdauer erreicht und wird als Abfall eingestuft."
+    }
+  },
+  "technicalData": {
+    "title": "Batteriepass — Technische Daten",
+    "sections": {
+      "generalInformation": "Allgemeine Informationen",
+      "capacityEnergyVoltage": "Kapazität, Energie & Spannung",
+      "roundTripEnergyEfficiency": "Hin- und Rückfahrtenergieffizienz",
+      "internalResistance": "Innenwiderstand",
+      "powerCapability": "Leistungsfähigkeit",
+      "powerCapabilityAtSoC": "Leistungsfähigkeit bei Ladezustand",
+      "temperatureRange": "Temperaturbereich (Leerlauf)",
+      "lifetime": "Lebensdauer",
+      "referenceTestDocuments": "Referenzprüfdokumente"
+    },
+    "fields": {
+      "manufacturer": "Hersteller",
+      "productDesignation": "Produktbezeichnung",
+      "articleNumber": "Artikelnummer",
+      "orderCode": "Bestellcode",
+      "manufacturerIdentifier": "Herstellerkennung",
+      "warrantyPeriod": "Garantiezeit",
+      "batteryMass": "Batteriemasse",
+      "batteryCategory": "Batteriekategorie",
+      "nominalVoltage": "Nennspannung",
+      "minimumVoltage": "Minimalspannung",
+      "maximumVoltage": "Maximalspannung",
+      "ratedCapacity": "Nennkapazität",
+      "capacityFade": "Kapazitätsverlust",
+      "certifiedUsableBatteryEnergy": "Zertifizierte nutzbare Batterieenergie",
+      "initialEfficiency": "Anfangswirkungsgrad",
+      "efficiencyAt50PercentCycleLife": "Wirkungsgrad bei 50% der Zyklenlebensdauer",
+      "efficiencyFade": "Wirkungsgradverlust",
+      "initialSelfDischargingRate": "Anfängliche Selbstentladungsrate",
+      "cellLevelInitial": "Zellebene (Initial)",
+      "packLevelInitial": "Packebene (Initial)",
+      "moduleLevelInitial": "Modulebene (Initial)",
+      "packLevelIncrease": "Packebene (Zunahme)",
+      "cellLevelIncrease": "Zellebene (Zunahme)",
+      "moduleLevelIncrease": "Modulebene (Zunahme)",
+      "maximumPermittedPower": "Maximal zulässige Leistung",
+      "powerFade": "Leistungsverlust",
+      "powerToEnergyRatio": "Leistungs-Energie-Verhältnis",
+      "lowerBoundary": "Untergrenze",
+      "upperBoundary": "Obergrenze",
+      "expectedLifetime": "Erwartete Lebensdauer",
+      "expectedCycles": "Erwartete Zyklen",
+      "capacityThresholdForExhaustion": "Kapazitätsschwelle für Erschöpfung",
+      "cRateCycleLifeTest": "C-Rate (Zyklenlebensdauertest)"
+    },
+    "categories": {
+      "lmt": "Leichte Transportmittel (LMT)",
+      "ev": "Elektrofahrzeug (EV)",
+      "industrial": "Industriell",
+      "stationary": "Stationäre Energiespeicherung"
+    }
+  },
+  "circularity": {
+    "title": "Batteriepass — Kreislaufwirtschaft",
+    "sections": {
+      "renewableContent": "Erneuerbare Inhalte",
+      "recycledContent": "Recycelter Inhalt",
+      "dismantling": "Demontage- und Ausbauinformationen",
+      "sparePartSources": "Ersatzteilquellen",
+      "safetyMeasures": "Sicherheitsmaßnahmen",
+      "endOfLife": "Informationen zum Lebensende"
+    },
+    "fields": {
+      "preConsumerShare": "Vorverbraucheranteil",
+      "postConsumerShare": "Nachverbraucheranteil",
+      "address": "Adresse",
+      "email": "E-Mail",
+      "website": "Webseite",
+      "components": "Komponenten",
+      "safetyInstructions": "Sicherheitshinweise",
+      "extinguishingAgents": "Löschmittel",
+      "wastePrevention": "Abfallvermeidung",
+      "separateCollection": "Getrennte Sammlung",
+      "informationOnCollection": "Informationen zur Sammlung"
+    }
+  },
+  "productCondition": {
+    "title": "Batteriepass — Produktzustand",
+    "sections": {
+      "currentState": "Aktueller Zustand",
+      "energyAndCapacity": "Energie & Kapazität",
+      "efficiencyAndSelfDischarge": "Effizienz & Selbstentladung",
+      "temperatureHistory": "Temperaturverlauf",
+      "negativeEvents": "Negative Ereignisse",
+      "informationOnAccidents": "Unfallbericht"
+    },
+    "fields": {
+      "stateOfCharge": "Ladezustand",
+      "numberOfFullCycles": "Anzahl der Vollzyklen",
+      "energyThroughput": "Energiedurchsatz",
+      "capacityThroughput": "Kapazitätsdurchsatz",
+      "remainingEnergy": "Verbleibende Energie",
+      "remainingCapacity": "Verbleibende Kapazität",
+      "stateOfCertifiedEnergy": "Zertifizierter Energiezustand",
+      "remainingRoundTripEnergyEfficiency": "Verbleibende Hin- und Rückfahrtenergieffizienz",
+      "currentSelfDischargingRate": "Aktuelle Selbstentladungsrate",
+      "evolutionOfSelfDischarge": "Entwicklung der Selbstentladung",
+      "timeAtExtremeHighTemperature": "Zeit bei extremer Hochtemperatur",
+      "timeAtExtremeLowTemperature": "Zeit bei extremer Niedrigtemperatur",
+      "timeAtExtremeHighTempCharging": "Zeit bei extrem hoher Temperatur (Laden)",
+      "timeAtExtremeLowTempCharging": "Zeit bei extrem niedriger Temperatur (Laden)",
+      "updated": "Aktualisiert: {{date}}"
+    },
+    "accidentReports_one": "{{count}} Unfalldokument erfasst",
+    "accidentReports_other": "{{count}} Unfalldokumente erfasst"
+  },
+  "carbonFootprint": {
+    "title": "Batteriepass — CO₂-Fußabdruck",
+    "empty": "Keine CO₂-Fußabdruckdaten verfügbar.",
+    "entry": "CO₂-Fußabdruckeintrag {{index}}",
+    "single": "Produkt-CO₂-Fußabdruck",
+    "fields": {
+      "co2Equivalent": "CO₂-Äquivalent",
+      "performanceClass": "Leistungsklasse"
+    },
+    "sections": {
+      "calculationMethods": "Berechnungsmethoden",
+      "lifeCyclePhases": "Lebenszyklusphasen",
+      "publicStudies": "Öffentliche CO₂-Fußabdruckstudien"
+    }
+  },
+  "materialComposition": {
+    "title": "Batteriepass — Materialzusammensetzung",
+    "sections": {
+      "batteryChemistry": "Batteriechemie",
+      "batteryMaterials": "Batteriematerialien",
+      "hazardousSubstances": "Gefährliche Stoffe"
+    },
+    "table": {
+      "material": "Material",
+      "identifier": "Kennung",
+      "mass": "Masse (kg)",
+      "location": "Ort",
+      "critical": "Kritisch",
+      "criticalChip": "Kritisch",
+      "standardChip": "Standard"
+    },
+    "fields": {
+      "identifier": "Kennung",
+      "concentration": "Konzentration",
+      "location": "Ort",
+      "impact": "Auswirkung"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "Akute Toxizität",
+      "SkinCorrosionOrIrritation": "Haut-Korrosion / -Reizung",
+      "EyeDamageOrIrritation": "Augenschäden / -reizung"
+    },
+    "criticalCount_one": "{{count}} kritischer Rohstoff identifiziert",
+    "criticalCount_other": "{{count}} kritische Rohstoffe identifiziert",
+    "hazardousCount_one": "{{count}} gefährlicher Stoff in dieser Batterie deklariert",
+    "hazardousCount_other": "{{count}} gefährliche Stoffe in dieser Batterie deklariert"
+  },
+  "handover": {
+    "title": "Batteriepass — Übergabedokumentation",
+    "sections": {
+      "documentIdentifiers": "Dokumentkennungen",
+      "classifications": "Klassifizierungen",
+      "versions": "Versionen",
+      "digitalFiles": "Digitale Dateien"
+    },
+    "fields": {
+      "domain": "Domäne: {{id}}",
+      "primary": "Primär"
+    },
+    "documentIndex": "Dokument {{index}}",
+    "available_one": "{{count}} Dokument zur Übergabe verfügbar",
+    "available_other": "{{count}} Dokumente zur Übergabe verfügbar"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/en/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/en/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "Address",
+    "website": "Website",
+    "email": "Email",
+    "company": "Company",
+    "contact": "Contact",
+    "country": "Country"
+  },
+  "digitalNameplate": {
+    "title": "Battery Pass — Digital Nameplate",
+    "sections": {
+      "productIdentification": "Product Identification",
+      "lifecycleStatus": "Lifecycle Status",
+      "manufacturingDetails": "Manufacturing Details",
+      "manufacturerInformation": "Manufacturer Information",
+      "address": "Address",
+      "contact": "Contact",
+      "ipCommunicationChannels": "IP Communication Channels",
+      "markingsAndCertifications": "Markings & Certifications",
+      "complianceDocuments": "Compliance Documents"
+    },
+    "fields": {
+      "batteryPassportUri": "Battery Passport URI",
+      "serialNumber": "Serial Number",
+      "manufacturerIdentifier": "Manufacturer Identifier",
+      "operatorIdentifier": "Operator Identifier",
+      "manufacturerName": "Manufacturer Name",
+      "company": "Company",
+      "department": "Department",
+      "contactRole": "Contact Role",
+      "contactPerson": "Contact Person",
+      "street": "Street",
+      "cityTown": "City / Town",
+      "zipCode": "Zip Code",
+      "stateCounty": "State / County",
+      "country": "Country",
+      "timeZone": "Time Zone",
+      "poBox": "P.O. Box",
+      "website": "Website",
+      "email": "Email",
+      "phone": "Phone",
+      "fax": "Fax",
+      "document": "Document",
+      "dateOfManufacture": "Date of Manufacture",
+      "dateOfPuttingIntoService": "Date of Putting Into Service",
+      "uniqueFacilityIdentifier": "Unique Facility Identifier",
+      "issueDate": "Issue Date",
+      "expiryDate": "Expiry Date",
+      "additionalInfo": "Additional Info",
+      "euDeclarationOfConformity": "EU Declaration of Conformity",
+      "resultsOfTestReportsProvingCompliance": "Results of Test Reports Proving Compliance"
+    },
+    "lifecycle": {
+      "original": "Battery is new and has never been repurposed or remanufactured.",
+      "repurposed": "Battery has been repurposed for a different application.",
+      "re-used": "Battery has been reused in the same or similar application.",
+      "remanufactured": "Battery has been remanufactured to restore its performance.",
+      "waste": "Battery has reached end-of-life and is classified as waste."
+    }
+  },
+  "technicalData": {
+    "title": "Battery Pass — Technical Data",
+    "sections": {
+      "generalInformation": "General Information",
+      "capacityEnergyVoltage": "Capacity, Energy & Voltage",
+      "roundTripEnergyEfficiency": "Round Trip Energy Efficiency",
+      "internalResistance": "Internal Resistance",
+      "powerCapability": "Power Capability",
+      "powerCapabilityAtSoC": "Power Capability at State of Charge",
+      "temperatureRange": "Temperature Range (Idle)",
+      "lifetime": "Lifetime",
+      "referenceTestDocuments": "Reference Test Documents"
+    },
+    "fields": {
+      "manufacturer": "Manufacturer",
+      "productDesignation": "Product Designation",
+      "articleNumber": "Article Number",
+      "orderCode": "Order Code",
+      "manufacturerIdentifier": "Manufacturer Identifier",
+      "warrantyPeriod": "Warranty Period",
+      "batteryMass": "Battery Mass",
+      "batteryCategory": "Battery Category",
+      "nominalVoltage": "Nominal Voltage",
+      "minimumVoltage": "Minimum Voltage",
+      "maximumVoltage": "Maximum Voltage",
+      "ratedCapacity": "Rated Capacity",
+      "capacityFade": "Capacity Fade",
+      "certifiedUsableBatteryEnergy": "Certified Usable Battery Energy",
+      "initialEfficiency": "Initial Efficiency",
+      "efficiencyAt50PercentCycleLife": "Efficiency at 50% Cycle Life",
+      "efficiencyFade": "Efficiency Fade",
+      "initialSelfDischargingRate": "Initial Self-Discharging Rate",
+      "cellLevelInitial": "Cell Level (Initial)",
+      "packLevelInitial": "Pack Level (Initial)",
+      "moduleLevelInitial": "Module Level (Initial)",
+      "packLevelIncrease": "Pack Level (Increase)",
+      "cellLevelIncrease": "Cell Level (Increase)",
+      "moduleLevelIncrease": "Module Level (Increase)",
+      "maximumPermittedPower": "Maximum Permitted Power",
+      "powerFade": "Power Fade",
+      "powerToEnergyRatio": "Power-to-Energy Ratio",
+      "lowerBoundary": "Lower Boundary",
+      "upperBoundary": "Upper Boundary",
+      "expectedLifetime": "Expected Lifetime",
+      "expectedCycles": "Expected Cycles",
+      "capacityThresholdForExhaustion": "Capacity Threshold for Exhaustion",
+      "cRateCycleLifeTest": "C-Rate (Cycle Life Test)"
+    },
+    "categories": {
+      "lmt": "Light Means of Transport (LMT)",
+      "ev": "Electric Vehicle (EV)",
+      "industrial": "Industrial",
+      "stationary": "Stationary Energy Storage"
+    }
+  },
+  "circularity": {
+    "title": "Battery Pass — Circularity",
+    "sections": {
+      "renewableContent": "Renewable Content",
+      "recycledContent": "Recycled Content",
+      "dismantling": "Dismantling & Removal Information",
+      "sparePartSources": "Spare Part Sources",
+      "safetyMeasures": "Safety Measures",
+      "endOfLife": "End of Life Information"
+    },
+    "fields": {
+      "preConsumerShare": "Pre-consumer Share",
+      "postConsumerShare": "Post-consumer Share",
+      "address": "Address",
+      "email": "Email",
+      "website": "Website",
+      "components": "Components",
+      "safetyInstructions": "Safety Instructions",
+      "extinguishingAgents": "Extinguishing Agents",
+      "wastePrevention": "Waste Prevention",
+      "separateCollection": "Separate Collection",
+      "informationOnCollection": "Information on Collection"
+    }
+  },
+  "productCondition": {
+    "title": "Battery Pass — Product Condition",
+    "sections": {
+      "currentState": "Current State",
+      "energyAndCapacity": "Energy & Capacity",
+      "efficiencyAndSelfDischarge": "Efficiency & Self-Discharge",
+      "temperatureHistory": "Temperature History",
+      "negativeEvents": "Negative Events",
+      "informationOnAccidents": "Information on Accidents"
+    },
+    "fields": {
+      "stateOfCharge": "State of Charge",
+      "numberOfFullCycles": "Number of Full Cycles",
+      "energyThroughput": "Energy Throughput",
+      "capacityThroughput": "Capacity Throughput",
+      "remainingEnergy": "Remaining Energy",
+      "remainingCapacity": "Remaining Capacity",
+      "stateOfCertifiedEnergy": "State of Certified Energy",
+      "remainingRoundTripEnergyEfficiency": "Remaining Round Trip Energy Efficiency",
+      "currentSelfDischargingRate": "Current Self-Discharging Rate",
+      "evolutionOfSelfDischarge": "Evolution of Self-Discharge",
+      "timeAtExtremeHighTemperature": "Time at Extreme High Temperature",
+      "timeAtExtremeLowTemperature": "Time at Extreme Low Temperature",
+      "timeAtExtremeHighTempCharging": "Time at Extreme High Temp (Charging)",
+      "timeAtExtremeLowTempCharging": "Time at Extreme Low Temp (Charging)",
+      "updated": "Updated: {{date}}"
+    },
+    "accidentReports_one": "{{count}} accident report document on record",
+    "accidentReports_other": "{{count}} accident report documents on record"
+  },
+  "carbonFootprint": {
+    "title": "Battery Pass — Carbon Footprint",
+    "empty": "No carbon footprint data available.",
+    "entry": "Carbon Footprint Entry {{index}}",
+    "single": "Product Carbon Footprint",
+    "fields": {
+      "co2Equivalent": "CO₂ Equivalent",
+      "performanceClass": "Performance Class"
+    },
+    "sections": {
+      "calculationMethods": "Calculation Methods",
+      "lifeCyclePhases": "Life Cycle Phases",
+      "publicStudies": "Public Carbon Footprint Studies"
+    }
+  },
+  "materialComposition": {
+    "title": "Battery Pass — Material Composition",
+    "sections": {
+      "batteryChemistry": "Battery Chemistry",
+      "batteryMaterials": "Battery Materials",
+      "hazardousSubstances": "Hazardous Substances"
+    },
+    "table": {
+      "material": "Material",
+      "identifier": "Identifier",
+      "mass": "Mass (kg)",
+      "location": "Location",
+      "critical": "Critical",
+      "criticalChip": "Critical",
+      "standardChip": "Standard"
+    },
+    "fields": {
+      "identifier": "Identifier",
+      "concentration": "Concentration",
+      "location": "Location",
+      "impact": "Impact"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "Acute Toxicity",
+      "SkinCorrosionOrIrritation": "Skin Corrosion / Irritation",
+      "EyeDamageOrIrritation": "Eye Damage / Irritation"
+    },
+    "criticalCount_one": "{{count}} critical raw material identified",
+    "criticalCount_other": "{{count}} critical raw materials identified",
+    "hazardousCount_one": "{{count}} hazardous substance declared in this battery",
+    "hazardousCount_other": "{{count}} hazardous substances declared in this battery"
+  },
+  "handover": {
+    "title": "Battery Pass — Handover Documentation",
+    "sections": {
+      "documentIdentifiers": "Document Identifiers",
+      "classifications": "Classifications",
+      "versions": "Versions",
+      "digitalFiles": "Digital Files"
+    },
+    "fields": {
+      "domain": "Domain: {{id}}",
+      "primary": "Primary"
+    },
+    "documentIndex": "Document {{index}}",
+    "available_one": "{{count}} document available for handover",
+    "available_other": "{{count}} documents available for handover"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/es/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/es/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "Dirección",
+    "website": "Sitio web",
+    "email": "Correo electrónico",
+    "company": "Empresa",
+    "contact": "Contacto",
+    "country": "País"
+  },
+  "digitalNameplate": {
+    "title": "Pasaporte de batería — Placa digital",
+    "sections": {
+      "productIdentification": "Identificación del producto",
+      "lifecycleStatus": "Estado del ciclo de vida",
+      "manufacturingDetails": "Detalles de fabricación",
+      "manufacturerInformation": "Información del fabricante",
+      "address": "Dirección",
+      "contact": "Contacto",
+      "ipCommunicationChannels": "Canales de comunicación IP",
+      "markingsAndCertifications": "Marcas y certificaciones",
+      "complianceDocuments": "Documentos de conformidad"
+    },
+    "fields": {
+      "batteryPassportUri": "URI del pasaporte de batería",
+      "serialNumber": "Número de serie",
+      "manufacturerIdentifier": "Identificador del fabricante",
+      "operatorIdentifier": "Identificador del operador",
+      "manufacturerName": "Nombre del fabricante",
+      "company": "Empresa",
+      "department": "Departamento",
+      "contactRole": "Rol de contacto",
+      "contactPerson": "Persona de contacto",
+      "street": "Calle",
+      "cityTown": "Ciudad / Municipio",
+      "zipCode": "Código postal",
+      "stateCounty": "Estado / Condado",
+      "country": "País",
+      "timeZone": "Zona horaria",
+      "poBox": "Apartado postal",
+      "website": "Sitio web",
+      "email": "Correo electrónico",
+      "phone": "Teléfono",
+      "fax": "Fax",
+      "document": "Documento",
+      "dateOfManufacture": "Fecha de fabricación",
+      "dateOfPuttingIntoService": "Fecha de puesta en servicio",
+      "uniqueFacilityIdentifier": "Identificador único de instalación",
+      "issueDate": "Fecha de emisión",
+      "expiryDate": "Fecha de vencimiento",
+      "additionalInfo": "Información adicional",
+      "euDeclarationOfConformity": "Declaración UE de conformidad",
+      "resultsOfTestReportsProvingCompliance": "Resultados de informes de prueba que prueban la conformidad"
+    },
+    "lifecycle": {
+      "original": "La batería es nueva y nunca ha sido reacondicionada ni remanufacturada.",
+      "repurposed": "La batería ha sido reacondicionada para una aplicación diferente.",
+      "re-used": "La batería ha sido reutilizada en la misma o similar aplicación.",
+      "remanufactured": "La batería ha sido remanufacturada para restaurar su rendimiento.",
+      "waste": "La batería ha alcanzado el final de su vida útil y se clasifica como residuo."
+    }
+  },
+  "technicalData": {
+    "title": "Pasaporte de batería — Datos técnicos",
+    "sections": {
+      "generalInformation": "Información general",
+      "capacityEnergyVoltage": "Capacidad, energía y voltaje",
+      "roundTripEnergyEfficiency": "Eficiencia de energía de ida y vuelta",
+      "internalResistance": "Resistencia interna",
+      "powerCapability": "Capacidad de potencia",
+      "powerCapabilityAtSoC": "Capacidad de potencia en estado de carga",
+      "temperatureRange": "Rango de temperatura (reposo)",
+      "lifetime": "Vida útil",
+      "referenceTestDocuments": "Documentos de prueba de referencia"
+    },
+    "fields": {
+      "manufacturer": "Fabricante",
+      "productDesignation": "Designación del producto",
+      "articleNumber": "Número de artículo",
+      "orderCode": "Código de pedido",
+      "manufacturerIdentifier": "Identificador del fabricante",
+      "warrantyPeriod": "Período de garantía",
+      "batteryMass": "Masa de la batería",
+      "batteryCategory": "Categoría de batería",
+      "nominalVoltage": "Tensión nominal",
+      "minimumVoltage": "Tensión mínima",
+      "maximumVoltage": "Tensión máxima",
+      "ratedCapacity": "Capacidad nominal",
+      "capacityFade": "Degradación de capacidad",
+      "certifiedUsableBatteryEnergy": "Energía de batería utilizable certificada",
+      "initialEfficiency": "Eficiencia inicial",
+      "efficiencyAt50PercentCycleLife": "Eficiencia al 50% de vida de ciclo",
+      "efficiencyFade": "Degradación de eficiencia",
+      "initialSelfDischargingRate": "Tasa de autodescarga inicial",
+      "cellLevelInitial": "Nivel de celda (inicial)",
+      "packLevelInitial": "Nivel de paquete (inicial)",
+      "moduleLevelInitial": "Nivel de módulo (inicial)",
+      "packLevelIncrease": "Nivel de paquete (aumento)",
+      "cellLevelIncrease": "Nivel de celda (aumento)",
+      "moduleLevelIncrease": "Nivel de módulo (aumento)",
+      "maximumPermittedPower": "Potencia máxima permitida",
+      "powerFade": "Degradación de potencia",
+      "powerToEnergyRatio": "Relación potencia-energía",
+      "lowerBoundary": "Límite inferior",
+      "upperBoundary": "Límite superior",
+      "expectedLifetime": "Vida útil esperada",
+      "expectedCycles": "Ciclos esperados",
+      "capacityThresholdForExhaustion": "Umbral de capacidad para agotamiento",
+      "cRateCycleLifeTest": "Tasa C (prueba de vida de ciclo)"
+    },
+    "categories": {
+      "lmt": "Medios de transporte ligero (LMT)",
+      "ev": "Vehículo eléctrico (EV)",
+      "industrial": "Industrial",
+      "stationary": "Almacenamiento de energía estacionario"
+    }
+  },
+  "circularity": {
+    "title": "Pasaporte de batería — Circularidad",
+    "sections": {
+      "renewableContent": "Contenido renovable",
+      "recycledContent": "Contenido reciclado",
+      "dismantling": "Información de desmontaje y extracción",
+      "sparePartSources": "Fuentes de repuestos",
+      "safetyMeasures": "Medidas de seguridad",
+      "endOfLife": "Información de fin de vida"
+    },
+    "fields": {
+      "preConsumerShare": "Proporción pre-consumidor",
+      "postConsumerShare": "Proporción post-consumidor",
+      "address": "Dirección",
+      "email": "Correo electrónico",
+      "website": "Sitio web",
+      "components": "Componentes",
+      "safetyInstructions": "Instrucciones de seguridad",
+      "extinguishingAgents": "Agentes extintores",
+      "wastePrevention": "Prevención de residuos",
+      "separateCollection": "Recogida selectiva",
+      "informationOnCollection": "Información sobre la recogida"
+    }
+  },
+  "productCondition": {
+    "title": "Pasaporte de batería — Condición del producto",
+    "sections": {
+      "currentState": "Estado actual",
+      "energyAndCapacity": "Energía y capacidad",
+      "efficiencyAndSelfDischarge": "Eficiencia y autodescarga",
+      "temperatureHistory": "Historial de temperatura",
+      "negativeEvents": "Eventos negativos",
+      "informationOnAccidents": "Información sobre accidentes"
+    },
+    "fields": {
+      "stateOfCharge": "Estado de carga",
+      "numberOfFullCycles": "Número de ciclos completos",
+      "energyThroughput": "Rendimiento energético",
+      "capacityThroughput": "Rendimiento de capacidad",
+      "remainingEnergy": "Energía restante",
+      "remainingCapacity": "Capacidad restante",
+      "stateOfCertifiedEnergy": "Estado de energía certificada",
+      "remainingRoundTripEnergyEfficiency": "Eficiencia de energía de ida y vuelta restante",
+      "currentSelfDischargingRate": "Tasa de autodescarga actual",
+      "evolutionOfSelfDischarge": "Evolución de la autodescarga",
+      "timeAtExtremeHighTemperature": "Tiempo a temperatura extrema alta",
+      "timeAtExtremeLowTemperature": "Tiempo a temperatura extrema baja",
+      "timeAtExtremeHighTempCharging": "Tiempo a temperatura extrema alta (carga)",
+      "timeAtExtremeLowTempCharging": "Tiempo a temperatura extrema baja (carga)",
+      "updated": "Actualizado: {{date}}"
+    },
+    "accidentReports_one": "{{count}} documento de informe de accidente registrado",
+    "accidentReports_other": "{{count}} documentos de informe de accidente registrados"
+  },
+  "carbonFootprint": {
+    "title": "Pasaporte de batería — Huella de carbono",
+    "empty": "No hay datos de huella de carbono disponibles.",
+    "entry": "Entrada de huella de carbono {{index}}",
+    "single": "Huella de carbono del producto",
+    "fields": {
+      "co2Equivalent": "Equivalente de CO₂",
+      "performanceClass": "Clase de rendimiento"
+    },
+    "sections": {
+      "calculationMethods": "Métodos de cálculo",
+      "lifeCyclePhases": "Fases del ciclo de vida",
+      "publicStudies": "Estudios públicos de huella de carbono"
+    }
+  },
+  "materialComposition": {
+    "title": "Pasaporte de batería — Composición de materiales",
+    "sections": {
+      "batteryChemistry": "Química de la batería",
+      "batteryMaterials": "Materiales de la batería",
+      "hazardousSubstances": "Sustancias peligrosas"
+    },
+    "table": {
+      "material": "Material",
+      "identifier": "Identificador",
+      "mass": "Masa (kg)",
+      "location": "Ubicación",
+      "critical": "Crítico",
+      "criticalChip": "Crítico",
+      "standardChip": "Estándar"
+    },
+    "fields": {
+      "identifier": "Identificador",
+      "concentration": "Concentración",
+      "location": "Ubicación",
+      "impact": "Impacto"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "Toxicidad aguda",
+      "SkinCorrosionOrIrritation": "Corrosión / irritación de la piel",
+      "EyeDamageOrIrritation": "Daño / irritación ocular"
+    },
+    "criticalCount_one": "{{count}} materia prima crítica identificada",
+    "criticalCount_other": "{{count}} materias primas críticas identificadas",
+    "hazardousCount_one": "{{count}} sustancia peligrosa declarada en esta batería",
+    "hazardousCount_other": "{{count}} sustancias peligrosas declaradas en esta batería"
+  },
+  "handover": {
+    "title": "Pasaporte de batería — Documentación de entrega",
+    "sections": {
+      "documentIdentifiers": "Identificadores de documentos",
+      "classifications": "Clasificaciones",
+      "versions": "Versiones",
+      "digitalFiles": "Archivos digitales"
+    },
+    "fields": {
+      "domain": "Dominio: {{id}}",
+      "primary": "Primario"
+    },
+    "documentIndex": "Documento {{index}}",
+    "available_one": "{{count}} documento disponible para entrega",
+    "available_other": "{{count}} documentos disponibles para entrega"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/fr/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/fr/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "Adresse",
+    "website": "Site web",
+    "email": "E-mail",
+    "company": "Entreprise",
+    "contact": "Contact",
+    "country": "Pays"
+  },
+  "digitalNameplate": {
+    "title": "Passeport batterie — Plaque signalétique numérique",
+    "sections": {
+      "productIdentification": "Identification du produit",
+      "lifecycleStatus": "État du cycle de vie",
+      "manufacturingDetails": "Détails de fabrication",
+      "manufacturerInformation": "Informations fabricant",
+      "address": "Adresse",
+      "contact": "Contact",
+      "ipCommunicationChannels": "Canaux de communication IP",
+      "markingsAndCertifications": "Marquages et certifications",
+      "complianceDocuments": "Documents de conformité"
+    },
+    "fields": {
+      "batteryPassportUri": "URI du passeport batterie",
+      "serialNumber": "Numéro de série",
+      "manufacturerIdentifier": "Identifiant fabricant",
+      "operatorIdentifier": "Identifiant opérateur",
+      "manufacturerName": "Nom du fabricant",
+      "company": "Entreprise",
+      "department": "Département",
+      "contactRole": "Rôle du contact",
+      "contactPerson": "Personne de contact",
+      "street": "Rue",
+      "cityTown": "Ville",
+      "zipCode": "Code postal",
+      "stateCounty": "État / Département",
+      "country": "Pays",
+      "timeZone": "Fuseau horaire",
+      "poBox": "Boîte postale",
+      "website": "Site web",
+      "email": "E-mail",
+      "phone": "Téléphone",
+      "fax": "Fax",
+      "document": "Document",
+      "dateOfManufacture": "Date de fabrication",
+      "dateOfPuttingIntoService": "Date de mise en service",
+      "uniqueFacilityIdentifier": "Identifiant unique de l'installation",
+      "issueDate": "Date d'émission",
+      "expiryDate": "Date d'expiration",
+      "additionalInfo": "Informations supplémentaires",
+      "euDeclarationOfConformity": "Déclaration UE de conformité",
+      "resultsOfTestReportsProvingCompliance": "Résultats des rapports d'essai prouvant la conformité"
+    },
+    "lifecycle": {
+      "original": "La batterie est neuve et n'a jamais été reconditionnée ni remanufacturée.",
+      "repurposed": "La batterie a été reconditionnée pour une autre application.",
+      "re-used": "La batterie a été réutilisée dans la même application ou une application similaire.",
+      "remanufactured": "La batterie a été remanufacturée pour restaurer ses performances.",
+      "waste": "La batterie a atteint la fin de sa vie et est classée comme déchet."
+    }
+  },
+  "technicalData": {
+    "title": "Passeport batterie — Données techniques",
+    "sections": {
+      "generalInformation": "Informations générales",
+      "capacityEnergyVoltage": "Capacité, énergie et tension",
+      "roundTripEnergyEfficiency": "Efficacité énergétique aller-retour",
+      "internalResistance": "Résistance interne",
+      "powerCapability": "Capacité de puissance",
+      "powerCapabilityAtSoC": "Capacité de puissance à l'état de charge",
+      "temperatureRange": "Plage de température (repos)",
+      "lifetime": "Durée de vie",
+      "referenceTestDocuments": "Documents de test de référence"
+    },
+    "fields": {
+      "manufacturer": "Fabricant",
+      "productDesignation": "Désignation du produit",
+      "articleNumber": "Numéro d'article",
+      "orderCode": "Code de commande",
+      "manufacturerIdentifier": "Identifiant fabricant",
+      "warrantyPeriod": "Période de garantie",
+      "batteryMass": "Masse de la batterie",
+      "batteryCategory": "Catégorie de batterie",
+      "nominalVoltage": "Tension nominale",
+      "minimumVoltage": "Tension minimale",
+      "maximumVoltage": "Tension maximale",
+      "ratedCapacity": "Capacité nominale",
+      "capacityFade": "Dégradation de capacité",
+      "certifiedUsableBatteryEnergy": "Énergie utilisable certifiée de la batterie",
+      "initialEfficiency": "Efficacité initiale",
+      "efficiencyAt50PercentCycleLife": "Efficacité à 50% de la durée de vie en cycles",
+      "efficiencyFade": "Dégradation de l'efficacité",
+      "initialSelfDischargingRate": "Taux d'autodécharge initial",
+      "cellLevelInitial": "Niveau cellule (initial)",
+      "packLevelInitial": "Niveau pack (initial)",
+      "moduleLevelInitial": "Niveau module (initial)",
+      "packLevelIncrease": "Niveau pack (augmentation)",
+      "cellLevelIncrease": "Niveau cellule (augmentation)",
+      "moduleLevelIncrease": "Niveau module (augmentation)",
+      "maximumPermittedPower": "Puissance maximale autorisée",
+      "powerFade": "Dégradation de la puissance",
+      "powerToEnergyRatio": "Rapport puissance/énergie",
+      "lowerBoundary": "Limite inférieure",
+      "upperBoundary": "Limite supérieure",
+      "expectedLifetime": "Durée de vie attendue",
+      "expectedCycles": "Cycles attendus",
+      "capacityThresholdForExhaustion": "Seuil de capacité pour l'épuisement",
+      "cRateCycleLifeTest": "Taux C (test de durée de vie en cycles)"
+    },
+    "categories": {
+      "lmt": "Moyens de transport léger (LMT)",
+      "ev": "Véhicule électrique (VE)",
+      "industrial": "Industriel",
+      "stationary": "Stockage d'énergie stationnaire"
+    }
+  },
+  "circularity": {
+    "title": "Passeport batterie — Circularité",
+    "sections": {
+      "renewableContent": "Contenu renouvelable",
+      "recycledContent": "Contenu recyclé",
+      "dismantling": "Informations de démontage et retrait",
+      "sparePartSources": "Sources de pièces de rechange",
+      "safetyMeasures": "Mesures de sécurité",
+      "endOfLife": "Informations de fin de vie"
+    },
+    "fields": {
+      "preConsumerShare": "Part pré-consommateur",
+      "postConsumerShare": "Part post-consommateur",
+      "address": "Adresse",
+      "email": "E-mail",
+      "website": "Site web",
+      "components": "Composants",
+      "safetyInstructions": "Instructions de sécurité",
+      "extinguishingAgents": "Agents extincteurs",
+      "wastePrevention": "Prévention des déchets",
+      "separateCollection": "Collecte séparée",
+      "informationOnCollection": "Informations sur la collecte"
+    }
+  },
+  "productCondition": {
+    "title": "Passeport batterie — Condition du produit",
+    "sections": {
+      "currentState": "État actuel",
+      "energyAndCapacity": "Énergie et capacité",
+      "efficiencyAndSelfDischarge": "Efficacité et autodécharge",
+      "temperatureHistory": "Historique des températures",
+      "negativeEvents": "Événements négatifs",
+      "informationOnAccidents": "Informations sur les accidents"
+    },
+    "fields": {
+      "stateOfCharge": "État de charge",
+      "numberOfFullCycles": "Nombre de cycles complets",
+      "energyThroughput": "Débit énergétique",
+      "capacityThroughput": "Débit de capacité",
+      "remainingEnergy": "Énergie restante",
+      "remainingCapacity": "Capacité restante",
+      "stateOfCertifiedEnergy": "État de l'énergie certifiée",
+      "remainingRoundTripEnergyEfficiency": "Efficacité énergétique aller-retour restante",
+      "currentSelfDischargingRate": "Taux d'autodécharge actuel",
+      "evolutionOfSelfDischarge": "Évolution de l'autodécharge",
+      "timeAtExtremeHighTemperature": "Temps à température extrêmement élevée",
+      "timeAtExtremeLowTemperature": "Temps à température extrêmement basse",
+      "timeAtExtremeHighTempCharging": "Temps à température extrêmement élevée (chargement)",
+      "timeAtExtremeLowTempCharging": "Temps à température extrêmement basse (chargement)",
+      "updated": "Mis à jour : {{date}}"
+    },
+    "accidentReports_one": "{{count}} document de rapport d'accident enregistré",
+    "accidentReports_other": "{{count}} documents de rapport d'accident enregistrés"
+  },
+  "carbonFootprint": {
+    "title": "Passeport batterie — Empreinte carbone",
+    "empty": "Aucune donnée d'empreinte carbone disponible.",
+    "entry": "Entrée d'empreinte carbone {{index}}",
+    "single": "Empreinte carbone du produit",
+    "fields": {
+      "co2Equivalent": "Équivalent CO₂",
+      "performanceClass": "Classe de performance"
+    },
+    "sections": {
+      "calculationMethods": "Méthodes de calcul",
+      "lifeCyclePhases": "Phases du cycle de vie",
+      "publicStudies": "Études publiques sur l'empreinte carbone"
+    }
+  },
+  "materialComposition": {
+    "title": "Passeport batterie — Composition des matériaux",
+    "sections": {
+      "batteryChemistry": "Chimie de la batterie",
+      "batteryMaterials": "Matériaux de la batterie",
+      "hazardousSubstances": "Substances dangereuses"
+    },
+    "table": {
+      "material": "Matériau",
+      "identifier": "Identifiant",
+      "mass": "Masse (kg)",
+      "location": "Emplacement",
+      "critical": "Critique",
+      "criticalChip": "Critique",
+      "standardChip": "Standard"
+    },
+    "fields": {
+      "identifier": "Identifiant",
+      "concentration": "Concentration",
+      "location": "Emplacement",
+      "impact": "Impact"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "Toxicité aiguë",
+      "SkinCorrosionOrIrritation": "Corrosion / irritation cutanée",
+      "EyeDamageOrIrritation": "Lésions / irritations oculaires"
+    },
+    "criticalCount_one": "{{count}} matière première critique identifiée",
+    "criticalCount_other": "{{count}} matières premières critiques identifiées",
+    "hazardousCount_one": "{{count}} substance dangereuse déclarée dans cette batterie",
+    "hazardousCount_other": "{{count}} substances dangereuses déclarées dans cette batterie"
+  },
+  "handover": {
+    "title": "Passeport batterie — Documentation de transfert",
+    "sections": {
+      "documentIdentifiers": "Identifiants de documents",
+      "classifications": "Classifications",
+      "versions": "Versions",
+      "digitalFiles": "Fichiers numériques"
+    },
+    "fields": {
+      "domain": "Domaine : {{id}}",
+      "primary": "Principal"
+    },
+    "documentIndex": "Document {{index}}",
+    "available_one": "{{count}} document disponible pour le transfert",
+    "available_other": "{{count}} documents disponibles pour le transfert"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/ja/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/ja/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "住所",
+    "website": "ウェブサイト",
+    "email": "メール",
+    "company": "会社",
+    "contact": "連絡先",
+    "country": "国"
+  },
+  "digitalNameplate": {
+    "title": "バッテリーパスポート — デジタル銘板",
+    "sections": {
+      "productIdentification": "製品識別",
+      "lifecycleStatus": "ライフサイクルステータス",
+      "manufacturingDetails": "製造詳細",
+      "manufacturerInformation": "メーカー情報",
+      "address": "住所",
+      "contact": "連絡先",
+      "ipCommunicationChannels": "IP通信チャネル",
+      "markingsAndCertifications": "マーキングと認証",
+      "complianceDocuments": "コンプライアンス文書"
+    },
+    "fields": {
+      "batteryPassportUri": "バッテリーパスポートURI",
+      "serialNumber": "シリアル番号",
+      "manufacturerIdentifier": "メーカー識別子",
+      "operatorIdentifier": "オペレーター識別子",
+      "manufacturerName": "メーカー名",
+      "company": "会社",
+      "department": "部門",
+      "contactRole": "連絡役割",
+      "contactPerson": "担当者",
+      "street": "通り",
+      "cityTown": "市区町村",
+      "zipCode": "郵便番号",
+      "stateCounty": "都道府県",
+      "country": "国",
+      "timeZone": "タイムゾーン",
+      "poBox": "私書箱",
+      "website": "ウェブサイト",
+      "email": "メール",
+      "phone": "電話",
+      "fax": "ファックス",
+      "document": "文書",
+      "dateOfManufacture": "製造日",
+      "dateOfPuttingIntoService": "サービス開始日",
+      "uniqueFacilityIdentifier": "施設固有識別子",
+      "issueDate": "発行日",
+      "expiryDate": "有効期限",
+      "additionalInfo": "追加情報",
+      "euDeclarationOfConformity": "EU適合宣言",
+      "resultsOfTestReportsProvingCompliance": "適合を証明するテストレポートの結果"
+    },
+    "lifecycle": {
+      "original": "バッテリーは新品であり、転用や再製造されたことはありません。",
+      "repurposed": "バッテリーは別のアプリケーション向けに転用されました。",
+      "re-used": "バッテリーは同じまたは類似のアプリケーションで再使用されました。",
+      "remanufactured": "バッテリーはパフォーマンスを回復するために再製造されました。",
+      "waste": "バッテリーは寿命に達し、廃棄物として分類されています。"
+    }
+  },
+  "technicalData": {
+    "title": "バッテリーパスポート — 技術データ",
+    "sections": {
+      "generalInformation": "一般情報",
+      "capacityEnergyVoltage": "容量・エネルギー・電圧",
+      "roundTripEnergyEfficiency": "往復エネルギー効率",
+      "internalResistance": "内部抵抗",
+      "powerCapability": "出力能力",
+      "powerCapabilityAtSoC": "充電状態での出力能力",
+      "temperatureRange": "温度範囲（アイドル）",
+      "lifetime": "寿命",
+      "referenceTestDocuments": "参照テスト文書"
+    },
+    "fields": {
+      "manufacturer": "メーカー",
+      "productDesignation": "製品名称",
+      "articleNumber": "品番",
+      "orderCode": "注文コード",
+      "manufacturerIdentifier": "メーカー識別子",
+      "warrantyPeriod": "保証期間",
+      "batteryMass": "バッテリー質量",
+      "batteryCategory": "バッテリーカテゴリ",
+      "nominalVoltage": "定格電圧",
+      "minimumVoltage": "最低電圧",
+      "maximumVoltage": "最高電圧",
+      "ratedCapacity": "定格容量",
+      "capacityFade": "容量低下",
+      "certifiedUsableBatteryEnergy": "認定使用可能バッテリーエネルギー",
+      "initialEfficiency": "初期効率",
+      "efficiencyAt50PercentCycleLife": "サイクル寿命50%時の効率",
+      "efficiencyFade": "効率低下",
+      "initialSelfDischargingRate": "初期自己放電率",
+      "cellLevelInitial": "セルレベル（初期）",
+      "packLevelInitial": "パックレベル（初期）",
+      "moduleLevelInitial": "モジュールレベル（初期）",
+      "packLevelIncrease": "パックレベル（増加）",
+      "cellLevelIncrease": "セルレベル（増加）",
+      "moduleLevelIncrease": "モジュールレベル（増加）",
+      "maximumPermittedPower": "最大許容電力",
+      "powerFade": "出力低下",
+      "powerToEnergyRatio": "出力対エネルギー比",
+      "lowerBoundary": "下限値",
+      "upperBoundary": "上限値",
+      "expectedLifetime": "予想寿命",
+      "expectedCycles": "予想サイクル数",
+      "capacityThresholdForExhaustion": "枯渇の容量閾値",
+      "cRateCycleLifeTest": "Cレート（サイクル寿命テスト）"
+    },
+    "categories": {
+      "lmt": "軽量輸送手段（LMT）",
+      "ev": "電気自動車（EV）",
+      "industrial": "産業用",
+      "stationary": "定置型エネルギー貯蔵"
+    }
+  },
+  "circularity": {
+    "title": "バッテリーパスポート — サーキュラリティ",
+    "sections": {
+      "renewableContent": "再生可能コンテンツ",
+      "recycledContent": "再生コンテンツ",
+      "dismantling": "分解・取り外し情報",
+      "sparePartSources": "スペアパーツ供給元",
+      "safetyMeasures": "安全措置",
+      "endOfLife": "使用終了情報"
+    },
+    "fields": {
+      "preConsumerShare": "消費前割合",
+      "postConsumerShare": "消費後割合",
+      "address": "住所",
+      "email": "メール",
+      "website": "ウェブサイト",
+      "components": "コンポーネント",
+      "safetyInstructions": "安全指示",
+      "extinguishingAgents": "消火剤",
+      "wastePrevention": "廃棄物防止",
+      "separateCollection": "分別収集",
+      "informationOnCollection": "収集に関する情報"
+    }
+  },
+  "productCondition": {
+    "title": "バッテリーパスポート — 製品状態",
+    "sections": {
+      "currentState": "現在の状態",
+      "energyAndCapacity": "エネルギーと容量",
+      "efficiencyAndSelfDischarge": "効率と自己放電",
+      "temperatureHistory": "温度履歴",
+      "negativeEvents": "負のイベント",
+      "informationOnAccidents": "事故に関する情報"
+    },
+    "fields": {
+      "stateOfCharge": "充電状態",
+      "numberOfFullCycles": "完全充放電サイクル数",
+      "energyThroughput": "エネルギースループット",
+      "capacityThroughput": "容量スループット",
+      "remainingEnergy": "残存エネルギー",
+      "remainingCapacity": "残存容量",
+      "stateOfCertifiedEnergy": "認定エネルギー状態",
+      "remainingRoundTripEnergyEfficiency": "残存往復エネルギー効率",
+      "currentSelfDischargingRate": "現在の自己放電率",
+      "evolutionOfSelfDischarge": "自己放電の変化",
+      "timeAtExtremeHighTemperature": "極高温での時間",
+      "timeAtExtremeLowTemperature": "極低温での時間",
+      "timeAtExtremeHighTempCharging": "充電中の極高温での時間",
+      "timeAtExtremeLowTempCharging": "充電中の極低温での時間",
+      "updated": "更新日：{{date}}"
+    },
+    "accidentReports_one": "{{count}}件の事故報告書が記録されています",
+    "accidentReports_other": "{{count}}件の事故報告書が記録されています"
+  },
+  "carbonFootprint": {
+    "title": "バッテリーパスポート — カーボンフットプリント",
+    "empty": "カーボンフットプリントデータはありません。",
+    "entry": "カーボンフットプリントエントリー {{index}}",
+    "single": "製品カーボンフットプリント",
+    "fields": {
+      "co2Equivalent": "CO₂換算量",
+      "performanceClass": "パフォーマンスクラス"
+    },
+    "sections": {
+      "calculationMethods": "計算方法",
+      "lifeCyclePhases": "ライフサイクルフェーズ",
+      "publicStudies": "公開カーボンフットプリント研究"
+    }
+  },
+  "materialComposition": {
+    "title": "バッテリーパスポート — 材料組成",
+    "sections": {
+      "batteryChemistry": "電池化学",
+      "batteryMaterials": "電池材料",
+      "hazardousSubstances": "危険物質"
+    },
+    "table": {
+      "material": "材料",
+      "identifier": "識別子",
+      "mass": "質量（kg）",
+      "location": "場所",
+      "critical": "重要",
+      "criticalChip": "重要",
+      "standardChip": "標準"
+    },
+    "fields": {
+      "identifier": "識別子",
+      "concentration": "濃度",
+      "location": "場所",
+      "impact": "影響"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "急性毒性",
+      "SkinCorrosionOrIrritation": "皮膚腐食性/刺激性",
+      "EyeDamageOrIrritation": "眼損傷/眼刺激性"
+    },
+    "criticalCount_one": "{{count}}種の重要原材料が特定されました",
+    "criticalCount_other": "{{count}}種の重要原材料が特定されました",
+    "hazardousCount_one": "この電池で{{count}}種の危険物質が申告されています",
+    "hazardousCount_other": "この電池で{{count}}種の危険物質が申告されています"
+  },
+  "handover": {
+    "title": "バッテリーパスポート — 引き渡し文書",
+    "sections": {
+      "documentIdentifiers": "文書識別子",
+      "classifications": "分類",
+      "versions": "バージョン",
+      "digitalFiles": "デジタルファイル"
+    },
+    "fields": {
+      "domain": "ドメイン：{{id}}",
+      "primary": "プライマリ"
+    },
+    "documentIndex": "文書 {{index}}",
+    "available_one": "{{count}}件の引き渡し可能な文書",
+    "available_other": "{{count}}件の引き渡し可能な文書"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/pt/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/pt/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "Endereço",
+    "website": "Site",
+    "email": "E-mail",
+    "company": "Empresa",
+    "contact": "Contato",
+    "country": "País"
+  },
+  "digitalNameplate": {
+    "title": "Passaporte de bateria — Placa de identificação digital",
+    "sections": {
+      "productIdentification": "Identificação do produto",
+      "lifecycleStatus": "Status do ciclo de vida",
+      "manufacturingDetails": "Detalhes de fabricação",
+      "manufacturerInformation": "Informações do fabricante",
+      "address": "Endereço",
+      "contact": "Contato",
+      "ipCommunicationChannels": "Canais de comunicação IP",
+      "markingsAndCertifications": "Marcações e certificações",
+      "complianceDocuments": "Documentos de conformidade"
+    },
+    "fields": {
+      "batteryPassportUri": "URI do passaporte de bateria",
+      "serialNumber": "Número de série",
+      "manufacturerIdentifier": "Identificador do fabricante",
+      "operatorIdentifier": "Identificador do operador",
+      "manufacturerName": "Nome do fabricante",
+      "company": "Empresa",
+      "department": "Departamento",
+      "contactRole": "Função de contato",
+      "contactPerson": "Pessoa de contato",
+      "street": "Rua",
+      "cityTown": "Cidade / Município",
+      "zipCode": "Código postal",
+      "stateCounty": "Estado / Condado",
+      "country": "País",
+      "timeZone": "Fuso horário",
+      "poBox": "Caixa postal",
+      "website": "Site",
+      "email": "E-mail",
+      "phone": "Telefone",
+      "fax": "Fax",
+      "document": "Documento",
+      "dateOfManufacture": "Data de fabricação",
+      "dateOfPuttingIntoService": "Data de entrada em serviço",
+      "uniqueFacilityIdentifier": "Identificador único de instalação",
+      "issueDate": "Data de emissão",
+      "expiryDate": "Data de validade",
+      "additionalInfo": "Informações adicionais",
+      "euDeclarationOfConformity": "Declaração UE de conformidade",
+      "resultsOfTestReportsProvingCompliance": "Resultados de relatórios de teste que comprovam a conformidade"
+    },
+    "lifecycle": {
+      "original": "A bateria é nova e nunca foi redirecionada ou remanufaturada.",
+      "repurposed": "A bateria foi redirecionada para uma aplicação diferente.",
+      "re-used": "A bateria foi reutilizada na mesma ou em uma aplicação similar.",
+      "remanufactured": "A bateria foi remanufaturada para restaurar seu desempenho.",
+      "waste": "A bateria atingiu o fim de sua vida útil e é classificada como resíduo."
+    }
+  },
+  "technicalData": {
+    "title": "Passaporte de bateria — Dados técnicos",
+    "sections": {
+      "generalInformation": "Informações gerais",
+      "capacityEnergyVoltage": "Capacidade, energia e tensão",
+      "roundTripEnergyEfficiency": "Eficiência de energia de ida e volta",
+      "internalResistance": "Resistência interna",
+      "powerCapability": "Capacidade de potência",
+      "powerCapabilityAtSoC": "Capacidade de potência no estado de carga",
+      "temperatureRange": "Faixa de temperatura (repouso)",
+      "lifetime": "Vida útil",
+      "referenceTestDocuments": "Documentos de teste de referência"
+    },
+    "fields": {
+      "manufacturer": "Fabricante",
+      "productDesignation": "Designação do produto",
+      "articleNumber": "Número do artigo",
+      "orderCode": "Código de pedido",
+      "manufacturerIdentifier": "Identificador do fabricante",
+      "warrantyPeriod": "Período de garantia",
+      "batteryMass": "Massa da bateria",
+      "batteryCategory": "Categoria de bateria",
+      "nominalVoltage": "Tensão nominal",
+      "minimumVoltage": "Tensão mínima",
+      "maximumVoltage": "Tensão máxima",
+      "ratedCapacity": "Capacidade nominal",
+      "capacityFade": "Degradação de capacidade",
+      "certifiedUsableBatteryEnergy": "Energia de bateria utilizável certificada",
+      "initialEfficiency": "Eficiência inicial",
+      "efficiencyAt50PercentCycleLife": "Eficiência a 50% da vida de ciclo",
+      "efficiencyFade": "Degradação de eficiência",
+      "initialSelfDischargingRate": "Taxa de autodescarga inicial",
+      "cellLevelInitial": "Nível de célula (inicial)",
+      "packLevelInitial": "Nível de pacote (inicial)",
+      "moduleLevelInitial": "Nível de módulo (inicial)",
+      "packLevelIncrease": "Nível de pacote (aumento)",
+      "cellLevelIncrease": "Nível de célula (aumento)",
+      "moduleLevelIncrease": "Nível de módulo (aumento)",
+      "maximumPermittedPower": "Potência máxima permitida",
+      "powerFade": "Degradação de potência",
+      "powerToEnergyRatio": "Relação potência-energia",
+      "lowerBoundary": "Limite inferior",
+      "upperBoundary": "Limite superior",
+      "expectedLifetime": "Vida útil esperada",
+      "expectedCycles": "Ciclos esperados",
+      "capacityThresholdForExhaustion": "Limiar de capacidade para esgotamento",
+      "cRateCycleLifeTest": "Taxa C (teste de vida de ciclo)"
+    },
+    "categories": {
+      "lmt": "Meios de transporte leve (LMT)",
+      "ev": "Veículo elétrico (VE)",
+      "industrial": "Industrial",
+      "stationary": "Armazenamento de energia estacionário"
+    }
+  },
+  "circularity": {
+    "title": "Passaporte de bateria — Circularidade",
+    "sections": {
+      "renewableContent": "Conteúdo renovável",
+      "recycledContent": "Conteúdo reciclado",
+      "dismantling": "Informações de desmontagem e remoção",
+      "sparePartSources": "Fontes de peças de reposição",
+      "safetyMeasures": "Medidas de segurança",
+      "endOfLife": "Informações de fim de vida"
+    },
+    "fields": {
+      "preConsumerShare": "Parcela pré-consumidor",
+      "postConsumerShare": "Parcela pós-consumidor",
+      "address": "Endereço",
+      "email": "E-mail",
+      "website": "Site",
+      "components": "Componentes",
+      "safetyInstructions": "Instruções de segurança",
+      "extinguishingAgents": "Agentes extintores",
+      "wastePrevention": "Prevenção de resíduos",
+      "separateCollection": "Coleta seletiva",
+      "informationOnCollection": "Informações sobre coleta"
+    }
+  },
+  "productCondition": {
+    "title": "Passaporte de bateria — Condição do produto",
+    "sections": {
+      "currentState": "Estado atual",
+      "energyAndCapacity": "Energia e capacidade",
+      "efficiencyAndSelfDischarge": "Eficiência e autodescarga",
+      "temperatureHistory": "Histórico de temperatura",
+      "negativeEvents": "Eventos negativos",
+      "informationOnAccidents": "Informações sobre acidentes"
+    },
+    "fields": {
+      "stateOfCharge": "Estado de carga",
+      "numberOfFullCycles": "Número de ciclos completos",
+      "energyThroughput": "Rendimento de energia",
+      "capacityThroughput": "Rendimento de capacidade",
+      "remainingEnergy": "Energia restante",
+      "remainingCapacity": "Capacidade restante",
+      "stateOfCertifiedEnergy": "Estado de energia certificada",
+      "remainingRoundTripEnergyEfficiency": "Eficiência de energia de ida e volta restante",
+      "currentSelfDischargingRate": "Taxa de autodescarga atual",
+      "evolutionOfSelfDischarge": "Evolução da autodescarga",
+      "timeAtExtremeHighTemperature": "Tempo em temperatura extremamente alta",
+      "timeAtExtremeLowTemperature": "Tempo em temperatura extremamente baixa",
+      "timeAtExtremeHighTempCharging": "Tempo em temperatura extremamente alta (carregando)",
+      "timeAtExtremeLowTempCharging": "Tempo em temperatura extremamente baixa (carregando)",
+      "updated": "Atualizado: {{date}}"
+    },
+    "accidentReports_one": "{{count}} documento de relatório de acidente registrado",
+    "accidentReports_other": "{{count}} documentos de relatório de acidente registrados"
+  },
+  "carbonFootprint": {
+    "title": "Passaporte de bateria — Pegada de carbono",
+    "empty": "Nenhum dado de pegada de carbono disponível.",
+    "entry": "Entrada de pegada de carbono {{index}}",
+    "single": "Pegada de carbono do produto",
+    "fields": {
+      "co2Equivalent": "Equivalente de CO₂",
+      "performanceClass": "Classe de desempenho"
+    },
+    "sections": {
+      "calculationMethods": "Métodos de cálculo",
+      "lifeCyclePhases": "Fases do ciclo de vida",
+      "publicStudies": "Estudos públicos de pegada de carbono"
+    }
+  },
+  "materialComposition": {
+    "title": "Passaporte de bateria — Composição de materiais",
+    "sections": {
+      "batteryChemistry": "Química da bateria",
+      "batteryMaterials": "Materiais da bateria",
+      "hazardousSubstances": "Substâncias perigosas"
+    },
+    "table": {
+      "material": "Material",
+      "identifier": "Identificador",
+      "mass": "Massa (kg)",
+      "location": "Localização",
+      "critical": "Crítico",
+      "criticalChip": "Crítico",
+      "standardChip": "Padrão"
+    },
+    "fields": {
+      "identifier": "Identificador",
+      "concentration": "Concentração",
+      "location": "Localização",
+      "impact": "Impacto"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "Toxicidade aguda",
+      "SkinCorrosionOrIrritation": "Corrosão / irritação da pele",
+      "EyeDamageOrIrritation": "Danos / irritação ocular"
+    },
+    "criticalCount_one": "{{count}} matéria-prima crítica identificada",
+    "criticalCount_other": "{{count}} matérias-primas críticas identificadas",
+    "hazardousCount_one": "{{count}} substância perigosa declarada nesta bateria",
+    "hazardousCount_other": "{{count}} substâncias perigosas declaradas nesta bateria"
+  },
+  "handover": {
+    "title": "Passaporte de bateria — Documentação de entrega",
+    "sections": {
+      "documentIdentifiers": "Identificadores de documentos",
+      "classifications": "Classificações",
+      "versions": "Versões",
+      "digitalFiles": "Arquivos digitais"
+    },
+    "fields": {
+      "domain": "Domínio: {{id}}",
+      "primary": "Primário"
+    },
+    "documentIndex": "Documento {{index}}",
+    "available_one": "{{count}} documento disponível para entrega",
+    "available_other": "{{count}} documentos disponíveis para entrega"
+  }
+}

--- a/ichub-frontend/src/i18n/locales/zh/batteryPass.json
+++ b/ichub-frontend/src/i18n/locales/zh/batteryPass.json
@@ -1,0 +1,234 @@
+{
+  "common": {
+    "address": "地址",
+    "website": "网站",
+    "email": "电子邮件",
+    "company": "公司",
+    "contact": "联系方式",
+    "country": "国家"
+  },
+  "digitalNameplate": {
+    "title": "电池护照 — 数字铭牌",
+    "sections": {
+      "productIdentification": "产品标识",
+      "lifecycleStatus": "生命周期状态",
+      "manufacturingDetails": "制造详情",
+      "manufacturerInformation": "制造商信息",
+      "address": "地址",
+      "contact": "联系方式",
+      "ipCommunicationChannels": "IP通信渠道",
+      "markingsAndCertifications": "标志与认证",
+      "complianceDocuments": "合规文件"
+    },
+    "fields": {
+      "batteryPassportUri": "电池护照URI",
+      "serialNumber": "序列号",
+      "manufacturerIdentifier": "制造商标识符",
+      "operatorIdentifier": "运营商标识符",
+      "manufacturerName": "制造商名称",
+      "company": "公司",
+      "department": "部门",
+      "contactRole": "联系角色",
+      "contactPerson": "联系人",
+      "street": "街道",
+      "cityTown": "城市/城镇",
+      "zipCode": "邮政编码",
+      "stateCounty": "州/县",
+      "country": "国家",
+      "timeZone": "时区",
+      "poBox": "邮政信箱",
+      "website": "网站",
+      "email": "电子邮件",
+      "phone": "电话",
+      "fax": "传真",
+      "document": "文件",
+      "dateOfManufacture": "制造日期",
+      "dateOfPuttingIntoService": "投入使用日期",
+      "uniqueFacilityIdentifier": "唯一设施标识符",
+      "issueDate": "签发日期",
+      "expiryDate": "到期日期",
+      "additionalInfo": "附加信息",
+      "euDeclarationOfConformity": "欧盟符合性声明",
+      "resultsOfTestReportsProvingCompliance": "证明合规性的测试报告结果"
+    },
+    "lifecycle": {
+      "original": "电池是全新的，从未被重新用途或再制造。",
+      "repurposed": "电池已被重新用途于不同应用。",
+      "re-used": "电池已在相同或类似应用中被重新使用。",
+      "remanufactured": "电池已被再制造以恢复其性能。",
+      "waste": "电池已达到使用寿命终点，被归类为废物。"
+    }
+  },
+  "technicalData": {
+    "title": "电池护照 — 技术数据",
+    "sections": {
+      "generalInformation": "一般信息",
+      "capacityEnergyVoltage": "容量、能量和电压",
+      "roundTripEnergyEfficiency": "往返能量效率",
+      "internalResistance": "内阻",
+      "powerCapability": "功率能力",
+      "powerCapabilityAtSoC": "充电状态下的功率能力",
+      "temperatureRange": "温度范围（空闲）",
+      "lifetime": "使用寿命",
+      "referenceTestDocuments": "参考测试文件"
+    },
+    "fields": {
+      "manufacturer": "制造商",
+      "productDesignation": "产品名称",
+      "articleNumber": "文章编号",
+      "orderCode": "订单代码",
+      "manufacturerIdentifier": "制造商标识符",
+      "warrantyPeriod": "保修期",
+      "batteryMass": "电池质量",
+      "batteryCategory": "电池类别",
+      "nominalVoltage": "额定电压",
+      "minimumVoltage": "最低电压",
+      "maximumVoltage": "最高电压",
+      "ratedCapacity": "额定容量",
+      "capacityFade": "容量衰减",
+      "certifiedUsableBatteryEnergy": "经认证的可用电池能量",
+      "initialEfficiency": "初始效率",
+      "efficiencyAt50PercentCycleLife": "50%循环寿命时的效率",
+      "efficiencyFade": "效率衰减",
+      "initialSelfDischargingRate": "初始自放电率",
+      "cellLevelInitial": "单体级别（初始）",
+      "packLevelInitial": "电池包级别（初始）",
+      "moduleLevelInitial": "模块级别（初始）",
+      "packLevelIncrease": "电池包级别（增加）",
+      "cellLevelIncrease": "单体级别（增加）",
+      "moduleLevelIncrease": "模块级别（增加）",
+      "maximumPermittedPower": "最大允许功率",
+      "powerFade": "功率衰减",
+      "powerToEnergyRatio": "功率能量比",
+      "lowerBoundary": "下限",
+      "upperBoundary": "上限",
+      "expectedLifetime": "预期使用寿命",
+      "expectedCycles": "预期循环次数",
+      "capacityThresholdForExhaustion": "耗尽容量阈值",
+      "cRateCycleLifeTest": "C率（循环寿命测试）"
+    },
+    "categories": {
+      "lmt": "轻型交通工具（LMT）",
+      "ev": "电动车（EV）",
+      "industrial": "工业",
+      "stationary": "固定储能"
+    }
+  },
+  "circularity": {
+    "title": "电池护照 — 循环性",
+    "sections": {
+      "renewableContent": "可再生成分",
+      "recycledContent": "再生成分",
+      "dismantling": "拆卸和拆除信息",
+      "sparePartSources": "备件来源",
+      "safetyMeasures": "安全措施",
+      "endOfLife": "寿命终止信息"
+    },
+    "fields": {
+      "preConsumerShare": "消费前比例",
+      "postConsumerShare": "消费后比例",
+      "address": "地址",
+      "email": "电子邮件",
+      "website": "网站",
+      "components": "组件",
+      "safetyInstructions": "安全说明",
+      "extinguishingAgents": "灭火剂",
+      "wastePrevention": "废物预防",
+      "separateCollection": "分类收集",
+      "informationOnCollection": "收集信息"
+    }
+  },
+  "productCondition": {
+    "title": "电池护照 — 产品状况",
+    "sections": {
+      "currentState": "当前状态",
+      "energyAndCapacity": "能量和容量",
+      "efficiencyAndSelfDischarge": "效率和自放电",
+      "temperatureHistory": "温度历史",
+      "negativeEvents": "负面事件",
+      "informationOnAccidents": "事故信息"
+    },
+    "fields": {
+      "stateOfCharge": "充电状态",
+      "numberOfFullCycles": "完整循环次数",
+      "energyThroughput": "能量吞吐量",
+      "capacityThroughput": "容量吞吐量",
+      "remainingEnergy": "剩余能量",
+      "remainingCapacity": "剩余容量",
+      "stateOfCertifiedEnergy": "认证能量状态",
+      "remainingRoundTripEnergyEfficiency": "剩余往返能量效率",
+      "currentSelfDischargingRate": "当前自放电率",
+      "evolutionOfSelfDischarge": "自放电演变",
+      "timeAtExtremeHighTemperature": "极高温度时间",
+      "timeAtExtremeLowTemperature": "极低温度时间",
+      "timeAtExtremeHighTempCharging": "充电时极高温度时间",
+      "timeAtExtremeLowTempCharging": "充电时极低温度时间",
+      "updated": "更新于：{{date}}"
+    },
+    "accidentReports_one": "记录了{{count}}份事故报告文件",
+    "accidentReports_other": "记录了{{count}}份事故报告文件"
+  },
+  "carbonFootprint": {
+    "title": "电池护照 — 碳足迹",
+    "empty": "没有可用的碳足迹数据。",
+    "entry": "碳足迹条目 {{index}}",
+    "single": "产品碳足迹",
+    "fields": {
+      "co2Equivalent": "CO₂当量",
+      "performanceClass": "性能等级"
+    },
+    "sections": {
+      "calculationMethods": "计算方法",
+      "lifeCyclePhases": "生命周期阶段",
+      "publicStudies": "公开碳足迹研究"
+    }
+  },
+  "materialComposition": {
+    "title": "电池护照 — 材料组成",
+    "sections": {
+      "batteryChemistry": "电池化学",
+      "batteryMaterials": "电池材料",
+      "hazardousSubstances": "危险物质"
+    },
+    "table": {
+      "material": "材料",
+      "identifier": "标识符",
+      "mass": "质量（千克）",
+      "location": "位置",
+      "critical": "关键",
+      "criticalChip": "关键",
+      "standardChip": "标准"
+    },
+    "fields": {
+      "identifier": "标识符",
+      "concentration": "浓度",
+      "location": "位置",
+      "impact": "影响"
+    },
+    "hazardousClass": {
+      "AcuteToxicity": "急性毒性",
+      "SkinCorrosionOrIrritation": "皮肤腐蚀/刺激",
+      "EyeDamageOrIrritation": "眼睛损伤/刺激"
+    },
+    "criticalCount_one": "已识别{{count}}种关键原材料",
+    "criticalCount_other": "已识别{{count}}种关键原材料",
+    "hazardousCount_one": "本电池中申报了{{count}}种危险物质",
+    "hazardousCount_other": "本电池中申报了{{count}}种危险物质"
+  },
+  "handover": {
+    "title": "电池护照 — 移交文档",
+    "sections": {
+      "documentIdentifiers": "文档标识符",
+      "classifications": "分类",
+      "versions": "版本",
+      "digitalFiles": "数字文件"
+    },
+    "fields": {
+      "domain": "域：{{id}}",
+      "primary": "主要"
+    },
+    "documentIndex": "文档 {{index}}",
+    "available_one": "{{count}}份文档可供移交",
+    "available_other": "{{count}}份文档可供移交"
+  }
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-CarbonFootprintBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-CarbonFootprintBattery-example.json
@@ -1,0 +1,11 @@
+{
+  "ProductCarbonFootprints" : [ {
+    "PcfCalculationMethods" : ["ISO 14067"],
+    "PcfCo2eq" : 17.2,
+    "ReferenceImpactUnitForCalculation" : "piece",
+    "QuantityOfMeasureForCalculation" : 5.0,
+    "LifeCyclePhases" : ["C4 - landfill"],
+    "PerformanceClass" : "B+",
+    "WebLinkToPublicCarbonFootprintStudy" : [ "l" ]
+  } ]
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-CircularityBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-CircularityBattery-example.json
@@ -1,0 +1,75 @@
+{
+  "DismantlingAndRemovalInformation": [
+    "d0Dds"
+  ],
+  "SparePartSources": [
+    {
+      "NameOfSupplier": [
+        {
+          "en": "ABC Company"
+        }
+      ],
+      "AddressOfSupplier": {
+        "NationalCode": [
+          {
+            "en": "DE"
+          }
+        ],
+        "PostalCode": [
+          {
+            "de": "DE-10719"
+          }
+        ],
+        "Street": [
+          {
+            "de": "Musterstrasse 1"
+          }
+        ]
+      },
+      "EmailAddressOfSupplier": {
+        "EmailAddress": "email@muster-ag.de",
+        "PublicKey": {
+          "en": "0x07"
+        },
+        "TypeOfEmailAddress": "office",
+        "TypeOfPublicKey": {
+          "en": "RSA"
+        }
+      },
+      "SupplierWebAddress": "https://example.com/information/product/1224/contact",
+      "Components": [
+        {
+          "PartName": "Cell",
+          "PartNumber": "PnYAVw"
+        }
+      ]
+    }
+  ],
+  "RecycledContentInformation": [
+    {
+      "PreConsumerShare": 77.21,
+      "RecycledMaterial": "Cobalt",
+      "PostConsumerShare": 67.28
+    }
+  ],
+  "SafetyMeasures": {
+    "SafetyInstructions": [
+      "2WoCFW"
+    ],
+    "ExtinguishingAgents": [
+      "0ds2fkjV"
+    ]
+  },
+  "EndOfLifeInformation": {
+    "WastePrevention": [
+      "ojb"
+    ],
+    "SeparateCollection": [
+      "Z9"
+    ],
+    "InformationOnCollection": [
+      "caavIHWpl"
+    ]
+  },
+  "RenewableContent": -12143.4
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-DigitalNameplate-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-DigitalNameplate-example.json
@@ -1,0 +1,153 @@
+{
+  "URIOfTheProduct": "https://dc-qr.com/?m=R123456789",
+  "ManufacturerName": [
+    {
+      "de": "Muster AG"
+    }
+  ],
+  "AddressInformation": {
+    "RoleOfContactPerson": "technical contact",
+    "NationalCode": [
+      {
+        "en": "DE"
+      }
+    ],
+    "Languages": [
+      "en"
+    ],
+    "TimeZone": "-12:00",
+    "CityTown": [
+      {
+        "de": "Musterstadt"
+      }
+    ],
+    "Company": [
+      {
+        "en": "ABC Company"
+      }
+    ],
+    "Department": [
+      {
+        "de": "Vertrieb"
+      }
+    ],
+    "Phone": {
+      "TelephoneNumber": {
+        "de": "+491234567890"
+      },
+      "TypeOfTelephone": "office",
+      "AvailableTime": {
+        "de": "Montag – Freitag 08:00 bis 16:00"
+      }
+    },
+    "Fax": {
+      "FaxNumber": {
+        "de": "+491234567890"
+      },
+      "TypeOfFaxNumber": "office"
+    },
+    "Email": {
+      "EmailAddress": "email@muster-ag.de",
+      "PublicKey": {
+        "en": "0x07"
+      },
+      "TypeOfEmailAddress": "office",
+      "TypeOfPublicKey": {
+        "en": "RSA"
+      }
+    },
+    "IPCommunicationChannels": [
+      {
+        "AddressOfAdditionalLink": "QxXK0wMaoq",
+        "TypeOfCommunication": "Chat",
+        "availableTime": [
+          {
+            "de": "Montag – Freitag 08:00 bis 16:00"
+          }
+        ]
+      }
+    ],
+    "Street": [
+      {
+        "de": "Musterstrasse 1"
+      }
+    ],
+    "ZipCode": [
+      {
+        "de": "12345"
+      }
+    ],
+    "POBox": [
+      {
+        "de": "PF 1234"
+      }
+    ],
+    "ZipCodeOfPOBox": [
+      {
+        "de": "12345"
+      }
+    ],
+    "StateCounty": [
+      {
+        "de": "Muster-Bundesland"
+      }
+    ],
+    "NameOfContact": [
+      {
+        "en": "Doe"
+      }
+    ],
+    "FirstName": [
+      {
+        "en": "Jane"
+      }
+    ],
+    "MiddleNames": [
+      {
+        "en": "M."
+      }
+    ],
+    "Title": [
+      {
+        "en": "Mrs."
+      }
+    ],
+    "AcademicTitle": [
+      {
+        "en": "PhD"
+      }
+    ],
+    "FurtherDetailsOfContact": [
+      {
+        "de": "-"
+      }
+    ],
+    "AddressOfAdditionalLink": "https://example.com/information/product/1224/contact"
+  },
+  "SerialNumber": "A12345-X75EN",
+  "DateOfManufacture": "2022-01-01",
+  "DateOfPuttingIntoService": "2022-06-01",
+  "UniqueFacilityIdentifier": "987654321",
+  "LifeCycleStage": "original",
+  "OperatorIdentifier": "QizvSaagg",
+  "ManufacturerIdentifier": "f8",
+  "Markings": [
+    {
+      "MarkingName": "0173-1%2307-DAA603%23004",
+      "DesignationOfCertificateOrApproval": "KEMA99IECE X1105/128",
+      "IssueDate": "2022-01-01",
+      "ExpiryDate": "2022-01-01",
+      "MarkingFile": {
+        "value": "https://example.com/SafetyInstructions.pdf",
+        "contentType": "application/pdf"
+      },
+      "MarkingAdditionalText": "0044"
+    }
+  ],
+  "EUDeclarationOfConformity": [
+    "uwO"
+  ],
+  "ResultsOfTestReportsProvingCompliance": [
+    "Q"
+  ]
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-HandoverDocumentationBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-HandoverDocumentationBattery-example.json
@@ -1,0 +1,33 @@
+{
+  "Documents" : [ {
+    "DocumentIds" : [ {
+      "DocumentDomainId" : "1213455566",
+      "DocumentIdentifier" : "XF90-884",
+      "DocumentIsPrimary" : true
+    } ],
+    "DocumentClassifications" : [ {
+      "ClassId" : "03-02",
+      "ClassName" : [ {
+        "de" : "VLy"
+      } ],
+      "ClassificationSystem" : "VDI2770 Blatt 1:2020"
+    } ],
+    "DocumentVersions" : [ {
+      "Language" : ["en"],
+      "Version" : "V1.2",
+      "Title" : [ {
+        "de" : "mDTy"
+      } ],
+      "Subtitle" : [ {
+        "en" : "jqqQ6Qxi"
+      } ],
+      "Description" : [ {
+        "de" : "bOblvfNSj4"
+      } ],
+      "DigitalFiles" : [ {
+        "value" : "https://example.com/SafetyInstructions.pdf",
+        "contentType" : "application/pdf"
+      } ]
+    } ]
+  } ]
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-MaterialCompositionBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-MaterialCompositionBattery-example.json
@@ -1,0 +1,27 @@
+{
+  "BatteryChemistry" : {
+    "ShortName" : "NMC",
+    "ClearName" : "Lithium nickel manganese cobalt oxides"
+  },
+  "BatteryMaterials" : [ {
+    "BatteryMaterialLocation" : {
+      "ComponentName" : "Anode",
+      "ComponentId" : "PBL2dRYxE"
+    },
+    "BatteryMaterialIdentifier" : "7439-93-2",
+    "BatteryMaterialName" : "Lithium",
+    "BatteryMaterialMass" : -7283.6,
+    "IsCriticalRawMaterial" : true
+  } ],
+  "HazardousSubstances" : [ {
+    "HazardousSubstanceClass" : "AcuteToxicity",
+    "HazardousSubstanceName" : "9wEngW0",
+    "HazardousSubstanceConcentration" : -60720.2,
+    "HazardousSubstanceImpact" : [ "cP" ],
+    "HazardousSubstanceLocation": {
+      "ComponentName": "Anode",
+      "ComponentId": "anode-123"
+    },
+    "HazardousSubstanceIdentifier" : "4138218-54-3"
+  } ]
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-ProductConditionBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-ProductConditionBattery-example.json
@@ -1,0 +1,62 @@
+{
+  "EnergyThroughput" : {
+    "EnergyThroughputValue" : 100000.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "CapacityThroughput" : {
+    "CapacityThroughputValue" : 214.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "NumberOfFullCycles" : {
+    "NumberOfFullCyclesValue" : 600,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "StateOfCertifiedEnergy" : {
+    "StateOfCertifiedEnergyValue" : 70.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "RemainingEnergy" : {
+    "RemainingEnergyValue" : 30.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "RemainingCapacity" : {
+    "RemainingCapacityValue" : 56.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "NegativeEvents" : [ {
+    "NegativeEventValue" : "overcharged",
+    "LastUpdate" : "2000-01-01T14:23:00"
+  } ],
+  "InformationOnAccidents" : [ "zBq4mhmrUB" ],
+  "TemperatureInformation" : {
+    "TimeExtremeHighTemp" : 0.0,
+    "TimeExtremeLowTemp" : 0.0,
+    "TimeExtremeHighTempCharging" : 0.0,
+    "TimeExtremeLowTempCharging" : 0.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "RemainingPowerCapability" : {
+    "RemainingPowerCapabilityValue" : {
+      "RPCLastUpdated" : "2000-01-01T14:23:00",
+      "AtSoC" : 80.0,
+      "PowerCapabilityAt" : 95.0
+    },
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "EvolutionOfSelfDischarge" : {
+    "EvolutionOfSelfDischargeValue" : 1.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "CurrentSelfDischargingRate" : {
+    "CurrentSelfDischargingRateValue" : 2.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "RemainingRoundTripEnergyEfficiency" : {
+    "RemainingRoundTripEnergyEfficiencyValue" : 80.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  },
+  "StateOfCharge" : {
+    "StateOfChargeValue" : 70.0,
+    "LastUpdate" : "2000-01-01T14:23:00"
+  }
+}

--- a/ichub-frontend/src/schemas/examples/idta-BatteryPass-TechnicalDataBattery-example.json
+++ b/ichub-frontend/src/schemas/examples/idta-BatteryPass-TechnicalDataBattery-example.json
@@ -1,0 +1,68 @@
+{
+  "GeneralInformation" : {
+    "ManufacturerName" : "arBGENr",
+    "CompanyLogo" : "https://example.com/2VkEi",
+    "ManufacturerProductDesignation" : [ {
+      "de" : "iB"
+    } ],
+    "ManufacturerArticleNumber" : "PMq",
+    "ManufacturerOrderCode" : "61",
+    "ManufacturerIdentifier" : "G2aqpMuE7",
+    "WarrantyPeriod" : "2031-10",
+    "BatteryCategory" : "ev",
+    "BatteryMass" : 1007.0,
+    "ProductImages" : [ {
+      "ImageFile" : {
+        "value" : "https://example.com/SafetyInstructions.pdf",
+        "contentType" : "application/pdf"
+      },
+      "ImageNote" : [ {
+        "en" : "KU70"
+      } ]
+    } ]
+  },
+  "TechnicalPropertyAreas" : {
+    "CapacityEnergyVoltage" : {
+      "NominalVoltage" : 4.3,
+      "MinVoltage" : 2.04,
+      "MaxVoltage" : 6.0,
+      "RatedCapacity" : 210.0,
+      "CapacityFade" : 10.0,
+      "CertifiedUsableBatteryEnergy" : 100.0
+    },
+    "RoundTripEnergyEfficiency" : {
+      "InitialRoundTripEnergyEfficiency" : 100,
+      "RoundTripEnergyEfficiencyAt50PercentOfCycleLife" : 100,
+      "EnergyRoundTripEfficiencyFade" : 10.0,
+      "InitialSelfDischargingRate" : 2
+    },
+    "Resistance" : {
+      "InitialInternalResistanceAtBatteryCellLevel" : 67.0,
+      "InitialInternalResistanceAtBatteryPackLevel" : 23.0,
+      "InitialInternalResistanceAtBatteryModuleLevel" : 10.0,
+      "InternalResistanceIncreaseAtBatteryCellLevel" : 10,
+      "InternalResistanceIncreaseAtBatteryPackLevel" : 10,
+      "InternalResistanceIncreaseAtBatteryModuleLevel" : 10
+    },
+    "PowerCapability" : {
+      "MaximumPermittedBatteryPower" : 1.797693E38,
+      "PowerFade" : 23.0,
+      "RatioNominalBatteryPowerAndBatteryEnergy" : 0.611,
+      "OriginalPowerCapability" : [ {
+        "atSoC" : 80.0,
+        "powerCapabilityAt" : 500.0
+      } ]
+    },
+    "Temperature" : {
+      "TemperatureRangeIdleState_LowerBoundary" : 49.0,
+      "TemperatureRangeIdleState_UpperBoundary" : -19.0
+    },
+    "Lifetime" : {
+      "ExpectedLifetimeInCalendarYears" : 15,
+      "ExpectedNumberOfCycles" : 1000,
+      "CapacityThresholdExhaustion" : 23.0,
+      "CycleLifeReferenceTest" : [ "pUiDyF9" ],
+      "CrateOfRelevantCycleLifeTest" : -10758.2
+    }
+  }
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassCarbonFootprint-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassCarbonFootprint-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.carbon_footprint:1.0.0#CarbonFootprintBattery",
+  "description" : "Provides the means to access the Carbon Footprint of the asset in the context of a Battery Passport.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "PcfCalculationMethodSet" : {
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#PcfCalculationMethodSet",
+        "type" : "array",
+        "items" : {
+          "type" : "string",
+          "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#PcfCalculationMethodCharacteristic",
+          "description" : "Standard, method for determining the greenhouse gas emissions of a product."
+        },
+        "uniqueItems" : true
+      },
+      "PcfCo2eqCharacteristic" : {
+        "type" : "number",
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#PcfCo2eqCharacteristic"
+      },
+      "ReferenceImpactUnitForCalculationEnum" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#ReferenceImpactUnitForCalculationEnum",
+        "enum" : [ "g", "kg", "t", "ml", "l", "cbm", "qm", "piece", "kwH" ]
+      },
+      "QuantityOfMeasureForCalculationCharacteristic" : {
+        "type" : "number",
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#QuantityOfMeasureForCalculationCharacteristic"
+      },
+      "LifeCyclePhaseSet" : {
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#LifeCyclePhaseSet",
+        "type" : "array",
+        "items" : {
+          "type" : "string",
+          "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.carbon_footprint:1.0.0#LifeCyclePhaseEnum",
+          "enum" : [ "A1 - raw material supply (and upstream production)", "A1-A3", "A3 - production", "A4 - transport to final destination", "A4-A5", "A5 - Installation", "B1 - usage phase", "B1-B7", "B2 - maintenance", "B3 - repair", "B4 - Replacement", "B5 - update/upgrade, refurbishing", "B6 - usage energy consumption", "B7 - usage water consumption", "C1 - reassembly", "C1-C4", "C2 - transport to recycler", "C2-C4", "C3 - recycling, waste treatment", "C4 - landfill", "D - reuse" ]
+        },
+        "uniqueItems" : true
+      },
+      "PerformanceClassCharacteristic" : {
+        "type" : "string"
+      },
+      "DocumentIdentifierSet" : {
+        "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.shared:3.1.0#DocumentIdentifierSet",
+        "type" : "array",
+        "items" : {
+          "type" : "string",
+          "minLength" : 1
+        },
+        "uniqueItems" : true
+      },
+      "ProductCarbonFootprint" : {
+        "type" : "object",
+        "properties" : {
+          "PcfCalculationMethods" : { "$ref" : "#/components/schemas/PcfCalculationMethodSet" },
+          "PcfCo2eq" : { "$ref" : "#/components/schemas/PcfCo2eqCharacteristic" },
+          "ReferenceImpactUnitForCalculation" : { "$ref" : "#/components/schemas/ReferenceImpactUnitForCalculationEnum" },
+          "QuantityOfMeasureForCalculation" : { "$ref" : "#/components/schemas/QuantityOfMeasureForCalculationCharacteristic" },
+          "LifeCyclePhases" : { "$ref" : "#/components/schemas/LifeCyclePhaseSet" },
+          "PerformanceClass" : { "$ref" : "#/components/schemas/PerformanceClassCharacteristic" },
+          "WebLinkToPublicCarbonFootprintStudy" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" }
+        },
+        "required" : [ "PcfCalculationMethods", "PcfCo2eq", "ReferenceImpactUnitForCalculation", "QuantityOfMeasureForCalculation", "LifeCyclePhases", "PerformanceClass", "WebLinkToPublicCarbonFootprintStudy" ]
+      },
+      "ProductCarbonFootprintSet" : {
+        "type" : "array",
+        "items" : { "$ref" : "#/components/schemas/ProductCarbonFootprint" },
+        "uniqueItems" : true
+      }
+    }
+  },
+  "properties" : {
+    "ProductCarbonFootprints" : {
+      "description" : "Balance of greenhouse gas emissions along the entire life cycle of a product.",
+      "$ref" : "#/components/schemas/ProductCarbonFootprintSet"
+    }
+  },
+  "required" : [ "ProductCarbonFootprints" ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassCircularity-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassCircularity-schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.circularity:1.0.0#Circularity",
+  "description" : "Dismantling information, spare part sources, recycled content, safety measures, end-of-life information and renewable content.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "DocumentIdentifierSet" : {
+        "type" : "array",
+        "items" : { "type" : "string", "minLength" : 1 },
+        "uniqueItems" : true
+      },
+      "MultiLanguageTexts" : {
+        "type" : "array",
+        "items" : { "type" : "object" },
+        "uniqueItems" : true
+      },
+      "PostalAddress" : {
+        "type" : "object",
+        "properties" : {
+          "NationalCode" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "PostalCode" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "Street" : { "$ref" : "#/components/schemas/MultiLanguageTexts" }
+        },
+        "required" : [ "NationalCode", "PostalCode", "Street" ]
+      },
+      "EmailEntity" : {
+        "type" : "object",
+        "properties" : {
+          "EmailAddress" : { "type" : "string" },
+          "TypeOfEmailAddress" : { "type" : "string" }
+        },
+        "required" : [ "EmailAddress" ]
+      },
+      "Component" : {
+        "type" : "object",
+        "properties" : {
+          "PartName" : { "type" : "string" },
+          "PartNumber" : { "type" : "string" }
+        },
+        "required" : [ "PartName", "PartNumber" ]
+      },
+      "SparePartSupplier" : {
+        "type" : "object",
+        "properties" : {
+          "NameOfSupplier" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "AddressOfSupplier" : { "$ref" : "#/components/schemas/PostalAddress" },
+          "EmailAddressOfSupplier" : { "$ref" : "#/components/schemas/EmailEntity" },
+          "SupplierWebAddress" : { "type" : "string" },
+          "Components" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/Component" } }
+        },
+        "required" : [ "NameOfSupplier", "AddressOfSupplier", "EmailAddressOfSupplier", "SupplierWebAddress", "Components" ]
+      },
+      "RecycledContent" : {
+        "type" : "object",
+        "properties" : {
+          "PreConsumerShare" : { "type" : "number" },
+          "RecycledMaterial" : { "type" : "string" },
+          "PostConsumerShare" : { "type" : "number" }
+        },
+        "required" : [ "PreConsumerShare", "RecycledMaterial", "PostConsumerShare" ]
+      },
+      "SafetyMeasuresEntity" : {
+        "type" : "object",
+        "properties" : {
+          "SafetyInstructions" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+          "ExtinguishingAgents" : { "type" : "array", "items" : { "type" : "string" } }
+        },
+        "required" : [ "SafetyInstructions", "ExtinguishingAgents" ]
+      },
+      "EndOfLifeInformationEntity" : {
+        "type" : "object",
+        "properties" : {
+          "WastePrevention" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+          "SeparateCollection" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+          "InformationOnCollection" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" }
+        },
+        "required" : [ "WastePrevention", "SeparateCollection", "InformationOnCollection" ]
+      }
+    }
+  },
+  "properties" : {
+    "DismantlingAndRemovalInformation" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+    "SparePartSources" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/SparePartSupplier" } },
+    "RecycledContentInformation" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/RecycledContent" } },
+    "SafetyMeasures" : { "$ref" : "#/components/schemas/SafetyMeasuresEntity" },
+    "EndOfLifeInformation" : { "$ref" : "#/components/schemas/EndOfLifeInformationEntity" },
+    "RenewableContent" : { "type" : "number" }
+  },
+  "required" : [ "DismantlingAndRemovalInformation", "SparePartSources", "RecycledContentInformation", "SafetyMeasures", "EndOfLifeInformation", "RenewableContent" ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassDigitalNameplate-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassDigitalNameplate-schema.json
@@ -1,0 +1,514 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryNameplate",
+  "description": "Contains the nameplate information attached to the product within the Battery Product Passport.",
+  "type": "object",
+  "components": {
+    "schemas": {
+      "Uri": {
+        "type": "string",
+        "format": "uri",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#Uri"
+      },
+      "MultiLanguageTexts": {
+        "description": "A set of language-text items.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#MultiLanguageTexts",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "x-samm-aspect-model-urn": "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#MultiLanguageText",
+          "description": "Describes a Property which contains plain text in multiple languages. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."
+        },
+        "uniqueItems": true
+      },
+      "RoleOfContactPersonCharacteristic": {
+        "type": "string"
+      },
+      "LanguageSetTrait": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#LanguageSetTrait",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "x-samm-aspect-model-urn": "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#Locale",
+          "description": "Describes a Property containing a locale according to IETF BCP 47, for example \"de-DE\"."
+        },
+        "uniqueItems": true,
+        "minItems": 1
+      },
+      "Text": {
+        "type": "string",
+        "x-samm-aspect-model-urn": "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#Text",
+        "description": "Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."
+      },
+      "PhoneEntity": {
+        "description": "Phone number including type.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#PhoneEntity",
+        "type": "object",
+        "properties": {
+          "TelephoneNumber": {
+            "description": "Complete telephone number to be called to reach a business partner.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#telephoneNumber",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "TypeOfTelephone": {
+            "description": "Characterization of a telephone according to its location or usage.\nenumeration: 0173-1#07-AAS754#001 (office), 0173-1#07-AAS755#001 (office mobile), 0173-1#07-AAS756#001 (secretary), 0173-1#07-AAS757#001 (substitute), 0173-1#07-AAS758#001 (home), 0173-1#07-AAS759#001 (private mobile).",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#typeOfTelephone",
+            "$ref": "#/components/schemas/Text"
+          },
+          "AvailableTime": {
+            "description": "Specification of the available time window.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#availableTime",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          }
+        },
+        "required": [
+          "TelephoneNumber"
+        ]
+      },
+      "PhoneCharacteristic": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#PhoneCharacteristic",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PhoneEntity"
+          }
+        ]
+      },
+      "FaxEntity": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#FaxEntity",
+        "type": "object",
+        "properties": {
+          "FaxNumber": {
+            "description": "Complete telephone number to be called to reach a business partner's fax machine.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#faxNumber",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "TypeOfFaxNumber": {
+            "description": "Characterization of the fax according its location or usage\nenumeration: 0173-1#07-AAS754#001 (office), 0173-1#07-AAS756#001 (secretary), 0173-1#07-AAS758#001 (home).",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#typeOfFaxNumber",
+            "$ref": "#/components/schemas/Text"
+          }
+        },
+        "required": [
+          "FaxNumber"
+        ]
+      },
+      "FaxCharacteristic": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#FaxCharacteristic",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FaxEntity"
+          }
+        ]
+      },
+      "EmailEntity": {
+        "description": "E-mail address and encryption method.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#EmailEntity",
+        "type": "object",
+        "properties": {
+          "EmailAddress": {
+            "description": "Electronic mail address of a business partner.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#emailAddress",
+            "$ref": "#/components/schemas/Text"
+          },
+          "PublicKey": {
+            "description": "Public part of an unsymmetrical key pair to sign or encrypt text or messages.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#publicKey",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "TypeOfEmailAddress": {
+            "description": "Characterization of an e-mail address according to its location or usage\nenumeration: 0173-1#07-AAS754#001 (office), 0173-1#07-AAS756#001 (secretary), 0173-1#07-AAS757#001 (substitute), 0173-1#07-AAS758#001 (home).",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#typeOfEmailAddress",
+            "$ref": "#/components/schemas/Text"
+          },
+          "TypeOfPublicKey": {
+            "description": "Characterization of a public key according to its encryption process.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#typeOfPublicKey",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          }
+        },
+        "required": [
+          "EmailAddress"
+        ]
+      },
+      "EmailCharacteristic": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#EmailCharacteristic",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmailEntity"
+          }
+        ]
+      },
+      "IpCommunicationChannelEntity": {
+        "description": "IP-based communication channels, e.g. chat or video call.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#IpCommunicationChannelEntity",
+        "type": "object",
+        "properties": {
+          "AddressOfAdditionalLink": {
+            "description": "Web site address where information about the product or contact is given.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#addressOfAdditionalLinkOfIpCommunicationChannel",
+            "$ref": "#/components/schemas/Text"
+          },
+          "TypeOfCommunication": {
+            "description": "Characterization of an IP-based communication channel.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#typeOfCommunication",
+            "$ref": "#/components/schemas/Text"
+          },
+          "availableTime": {
+            "description": "Specification of the available time windows.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#availableTimeIpCommunicationChannel",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          }
+        },
+        "required": [
+          "AddressOfAdditionalLink"
+        ]
+      },
+      "IpCommunicationChannelSet": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#IpCommunicationChannelSet",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/IpCommunicationChannelEntity"
+        },
+        "uniqueItems": true
+      },
+      "AddressInformation": {
+        "description": "Contains information on how to contact the manufacturer or an authorised service provider, e.g. when a maintenance service is required.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#addressInformation",
+        "type": "object",
+        "properties": {
+          "RoleOfContactPerson": {
+            "description": "Function of a contact person in a process\nenumeration: 0173-1#07-AAS927#001 (administrativ contact), 0173-1#07-AAS928#001 (commercial contact), 0173-1#07-AAS929#001 (other contact), 0173-1#07-AAS930#001 (hazardous goods contact), 0173-1#07-AAS931#001 (technical contact)\nNote: the above mentioned ECLASS enumeration should be declared as 'open' for further addition.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#roleOfContactPerson",
+            "$ref": "#/components/schemas/RoleOfContactPersonCharacteristic"
+          },
+          "NationalCode": {
+            "description": "Code of a country (Country codes defined accord. to DIN EN ISO 3166-1).",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#nationalCode",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "Languages": {
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#languages",
+            "$ref": "#/components/schemas/LanguageSetTrait"
+          },
+          "TimeZone": {
+            "description": "Offsets from Coordinated Universal Time (UTC)\nNote: notation accord. to ISO 8601\nNote: for time in UTC the zone designator 'Z' is to be used.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#timeZone",
+            "$ref": "#/components/schemas/Text"
+          },
+          "CityTown": {
+            "description": "Town or city.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#cityTown",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "Company": {
+            "description": "Name of the company.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#company",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "Department": {
+            "description": "Administrative section within an organisation where a business partner is located.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#department",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "Phone": {
+            "description": "Phone number including type.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#phone",
+            "$ref": "#/components/schemas/PhoneCharacteristic"
+          },
+          "Fax": {
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#fax",
+            "$ref": "#/components/schemas/FaxCharacteristic"
+          },
+          "Email": {
+            "description": "E-mail address and encryption method.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#email",
+            "$ref": "#/components/schemas/EmailCharacteristic"
+          },
+          "IPCommunicationChannels": {
+            "description": "IP-based communication channels, e.g. chat or video call.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#ipCommunicationChannels",
+            "$ref": "#/components/schemas/IpCommunicationChannelSet"
+          },
+          "Street": {
+            "description": "Street name and house number.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#street",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "ZipCode": {
+            "description": "ZIP code of address.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#zipCode",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "POBox": {
+            "description": "P.O. box number.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#poBox",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "ZipCodeOfPOBox": {
+            "description": "ZIP code of address.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#zipCodeOfPoBox",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "StateCounty": {
+            "description": "Federal state, a part of a state.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#stateCounty",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "NameOfContact": {
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#nameOfContact",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "FirstName": {
+            "description": "First name of a contact person.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#firstName",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "MiddleNames": {
+            "description": "Middle names of contact person.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#middleNames",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "Title": {
+            "description": "Common, formal, religious, or other title preceding a contact person's name.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#title",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "AcademicTitle": {
+            "description": "Academic title preceding a contact person's name.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#academicTitle",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "FurtherDetailsOfContact": {
+            "description": "Additional information of the contact person.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#furtherDetailsOfContact",
+            "$ref": "#/components/schemas/MultiLanguageTexts"
+          },
+          "AddressOfAdditionalLink": {
+            "description": "Web site address where information about the product or contact is given.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.contact_information:1.0.0#addressOfAdditionalLink",
+            "$ref": "#/components/schemas/Text"
+          }
+        },
+        "required": [
+          "NationalCode",
+          "CityTown",
+          "Street",
+          "ZipCode"
+        ]
+      },
+      "AddressInformationCharacteristic": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#AddressInformationCharacteristic",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AddressInformation"
+          }
+        ]
+      },
+      "Date": {
+        "type": "string",
+        "format": "date",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.digital_nameplate:3.0.0#Date"
+      },
+      "PuttingIntoServiceDate": {
+        "type": "string",
+        "format": "date",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#PuttingIntoServiceDate"
+      },
+      "BatteryStatusEnumeration": {
+        "type": "string",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#BatteryStatusEnumeration",
+        "description": "Lifecycle status of the battery. Status defined from a list, with the options suggested as follows: 'original', 'repurposed', 'reused', 'remanufactured', 'waste'\n\nEUBR: Annex XIII (4c)",
+        "enum": [
+          "original",
+          "repurposed",
+          "re-used",
+          "remanufactured",
+          "waste"
+        ]
+      },
+      "Date0": {
+        "type": "string",
+        "format": "date",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#Date",
+        "description": "Date in format CCYY-MM-DD."
+      },
+      "ResourcePath": {
+        "type": "string",
+        "format": "uri",
+        "x-samm-aspect-model-urn": "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#ResourcePath",
+        "description": "The path of a resource."
+      },
+      "MimeType": {
+        "type": "string",
+        "x-samm-aspect-model-urn": "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#MimeType",
+        "description": "A MIME type as defined in RFC 2046, for example \"application/pdf\"."
+      },
+      "FileWithContentType": {
+        "description": "A file is a data element that represents an address to a file (a locator). The value is a URI that can represent an absolute or relative path.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#FileWithContentType",
+        "type": "object",
+        "properties": {
+          "value": {
+            "description": "Path and name of the file (with file extension).\n\nThe path can be absolute or relative.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#resourceValue",
+            "$ref": "#/components/schemas/ResourcePath"
+          },
+          "contentType": {
+            "description": "Content type of the content of the file or blob.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#contentType",
+            "$ref": "#/components/schemas/MimeType"
+          }
+        },
+        "required": [
+          "value",
+          "contentType"
+        ]
+      },
+      "Marking": {
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#Marking",
+        "type": "object",
+        "properties": {
+          "MarkingName": {
+            "description": "Common name of the marking.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#markingName",
+            "$ref": "#/components/schemas/Text"
+          },
+          "DesignationOfCertificateOrApproval": {
+            "description": "Alphanumeric character sequence identifying a certificate or approval.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#designationOfCertificateOrApproval",
+            "$ref": "#/components/schemas/Text"
+          },
+          "IssueDate": {
+            "description": "Date, at which the specified certificate is issued. Note: format by lexical representation: CCYY-MM-DD. Note: to be specified to the day.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#issueDate",
+            "$ref": "#/components/schemas/Date0"
+          },
+          "ExpiryDate": {
+            "description": "Date, at which the specified certificate expires. Note: format by lexical representation: CCYY-MM-DD. Note: to be specified to the day.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#expiryDate",
+            "$ref": "#/components/schemas/Date0"
+          },
+          "MarkingFile": {
+            "description": "Conformity symbol of the marking.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#markingFile",
+            "$ref": "#/components/schemas/FileWithContentType"
+          },
+          "MarkingAdditionalText": {
+            "description": "Where applicable, additional information on the marking in plain text, e.g. the ID-number of the notified body involved in the conformity process.",
+            "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#markingAdditionalText",
+            "$ref": "#/components/schemas/Text"
+          }
+        },
+        "required": [
+          "MarkingName",
+          "MarkingFile"
+        ]
+      },
+      "Markings": {
+        "description": "Note: CE marking is declared as mandatory according to EU Blue Guide.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#Markings",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Marking"
+        },
+        "uniqueItems": true
+      },
+      "DocumentIdentifierSet": {
+        "description": "Each document is uniquely discoverable via its identifier. If more information is needed, please refer to the 'Handover Documentation'.",
+        "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#DocumentIdentifierSet",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.shared:3.1.0#DocumentIdentifierSetTrait",
+          "description": "Alphanumeric character sequence uniquely identifying a document.",
+          "minLength": 1
+        },
+        "uniqueItems": true
+      }
+    }
+  },
+  "properties": {
+    "URIOfTheProduct": {
+      "description": "Unique global identification of the product instance using an universal resource identifier (URI).\n The battery passport identifier is the unique identifier of a battery passport.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.1",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#uriOfTheProduct",
+      "$ref": "#/components/schemas/Uri"
+    },
+    "ManufacturerName": {
+      "description": "Legally valid designation of the natural or judicial person which is directly responsible for the design, production, packaging and labeling of a product in respect to its being brought into circulation.\n\n Information identifying the manufacturer with a name.Information identifying the manufacturer with a name.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.1",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#manufacturerName",
+      "$ref": "#/components/schemas/MultiLanguageTexts"
+    },
+    "AddressInformation": {
+      "description": "The manufacturer information postal address, indicating a single contact point. Web address, if available; and web address, if available.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#addressInformation",
+      "$ref": "#/components/schemas/AddressInformation"
+    },
+    "SerialNumber": {
+      "description": "Unique combination of numbers and letters used to identify the device once it has been manufactured.\n\n The battery identifier should be serialised, i.e., identifying each battery via a serial number.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.2",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#serialNumber",
+      "$ref": "#/components/schemas/Text"
+    },
+    "DateOfManufacture": {
+      "description": "Date when an item was manufactured.\n\n The manufacturing date should not only relate to the battery model, but to the battery item. The date code should comply with DINISO8601-1:2020-12 and ISO8601-2:2019.\n\n DIN DKE Spec 99100 chapter reference: 6.1.3.2",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#dateOfManufacture",
+      "$ref": "#/components/schemas/Date"
+    },
+    "DateOfPuttingIntoService": {
+      "description": "Where appropriate, the battery passport must include information on the date of putting the battery into service. BR Annex VI Part A (1); Art. 3(33); Art. 38(7); ESPR Art. 2(32)\n\nDIN DKE Spec chapter reference: 6.1.3.3",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#dateOfPuttingIntoService",
+      "$ref": "#/components/schemas/PuttingIntoServiceDate"
+    },
+    "UniqueFacilityIdentifier": {
+      "description": "Unique string of characters for the identification of locations or buildings involved in a product’s value chain or used by actors involved in a product’s value chain.\n\n The manufacturing place should be uniquely identifiable.\n\n DIN DKE Spec 99100 chapter reference: 6.1.3.1",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#uniqueFacilityIdentifier",
+      "$ref": "#/components/schemas/Text"
+    },
+    "LifeCycleStage": {
+      "description": "A battery passport must include information on the life cycle status of the battery.\r\n   \r\n   The status of the battery must be defined as 'original' (0173-1#07-ACC020#001), 'repurposed'(0173-1#07-ACC021#001), 're-used'(0173-1#07-ACC022#001), 'remanufactured' (0173-1#07-ACC023#001) or 'waste' (0173-1#07-ACC024#001).\r\n   \r\n   A new battery passport must be issued when a battery was subject to remanufacturing, repurpose or one of the treatment operations preparing for re-use and preparing for repurpose and is placed on the market again.\r\n   \r\n   DIN DKE Spec 99100 chapter reference: 6.1.3.7",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#batteryStatus",
+      "$ref": "#/components/schemas/BatteryStatusEnumeration"
+    },
+    "OperatorIdentifier": {
+      "description": "The unique operator identifier should comply with ISO/IEC 15459 1:2014, ISO/IEC 15459 2:2015, ISO/IEC 15459 3:2014, ISO/IEC 15459 4:2014, ISO/IEC 15459 5:2014, ISO/IEC 15459 6:2014, or their equivalent until referenced harmonised standards are listed in the OJEU.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.3",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#operatorIdentifier",
+      "$ref": "#/components/schemas/Text"
+    },
+    "ManufacturerIdentifier": {
+      "description": "A battery passport must include information identifying the manufacturer.\n\n DIN DKE Spec 99100 chapter reference: 6.1.2.4",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#manufacturerIdentifier",
+      "$ref": "#/components/schemas/Text"
+    },
+    "Markings": {
+      "description": "Should be used to provide all relevant marking information of the battery passport based on DIN DKE SPEC 99100 such as:\r\n\r\n* Separate collection symbol (6.2.2)\r\n* Symbols for cadmium and lead (6.2.3)\r\n* Carbon footprint label (6.2.4)\r\n* Extinguishing agent (6.2.5)\r\n* Meaning of labels and symbols (6.2.6)\r\n* EU declaration of conformity (6.2.7)\r\n* Results of test reports proving compliance (6.2.8)\r\n\r\nNote: CE marking is declared as mandatory according to EU Blue Guide \r\n   ",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#markings",
+      "$ref": "#/components/schemas/Markings"
+    },
+    "EUDeclarationOfConformity": {
+      "description": "A battery passport must include the EU declaration of conformity.\n\n  DIN DKE Spec 99100 chapter reference: 6.2.7 \n\n Document identifiers (e.g., depending of different languages) of a document (e.g., PDF) that can be found in the Handover Documentation model.",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#euDeclarationOfConformity",
+      "$ref": "#/components/schemas/DocumentIdentifierSet"
+    },
+    "ResultsOfTestReportsProvingCompliance": {
+      "description": "A battery passport must include the test report results that can prove the compliance with the requirements stated in the battery regulation.\n\n  DIN DKE Spec 99100 chapter reference: 6.2.8\n\n Document identifiers (e.g., depending of different languages) of a document (e.g., PDF) that can be found in the Handover Documentation model.\n\n ",
+      "x-samm-aspect-model-urn": "urn:samm:io.admin-shell.idta.batterypass.digital_nameplate:1.0.0#resultsOfTestReportsProvingCompliance",
+      "$ref": "#/components/schemas/DocumentIdentifierSet"
+    }
+  },
+  "required": [
+    "URIOfTheProduct",
+    "ManufacturerName",
+    "AddressInformation",
+    "SerialNumber",
+    "DateOfManufacture",
+    "UniqueFacilityIdentifier",
+    "LifeCycleStage",
+    "ManufacturerIdentifier",
+    "Markings",
+    "EUDeclarationOfConformity",
+    "ResultsOfTestReportsProvingCompliance"
+  ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassHandoverDocumentation-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassHandoverDocumentation-schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation",
+  "description" : "Handover Documentation defines a set of meta data for the handover of documentation from the operator to the users of the Battery Passport.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "DocumentId" : {
+        "type" : "object",
+        "properties" : {
+          "DocumentDomainId" : { "type" : "string" },
+          "DocumentIdentifier" : { "type" : "string" },
+          "DocumentIsPrimary" : { "type" : "boolean" }
+        },
+        "required" : [ "DocumentDomainId", "DocumentIdentifier" ]
+      },
+      "MultiLanguageTexts" : {
+        "type" : "array",
+        "items" : { "type" : "object" },
+        "uniqueItems" : true
+      },
+      "DocumentClassification" : {
+        "type" : "object",
+        "properties" : {
+          "ClassId" : { "type" : "string" },
+          "ClassName" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "ClassificationSystem" : { "type" : "string" }
+        },
+        "required" : [ "ClassId", "ClassName", "ClassificationSystem" ]
+      },
+      "FileWithContentType" : {
+        "type" : "object",
+        "properties" : {
+          "value" : { "type" : "string", "format" : "uri" },
+          "contentType" : { "type" : "string" }
+        },
+        "required" : [ "value", "contentType" ]
+      },
+      "DocumentVersion" : {
+        "type" : "object",
+        "properties" : {
+          "Language" : { "type" : "array", "items" : { "type" : "string" } },
+          "Version" : { "type" : "string" },
+          "Title" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "Subtitle" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "Description" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "DigitalFiles" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/FileWithContentType" } }
+        },
+        "required" : [ "Language", "Title", "DigitalFiles" ]
+      },
+      "Document" : {
+        "type" : "object",
+        "properties" : {
+          "DocumentIds" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/DocumentId" } },
+          "DocumentClassifications" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/DocumentClassification" } },
+          "DocumentVersions" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/DocumentVersion" } }
+        },
+        "required" : [ "DocumentIds", "DocumentClassifications", "DocumentVersions" ]
+      }
+    }
+  },
+  "properties" : {
+    "Documents" : {
+      "description" : "A set of relevant documents to hand over to customers for documentation purposes.",
+      "type" : "array",
+      "items" : { "$ref" : "#/components/schemas/Document" },
+      "uniqueItems" : true
+    }
+  },
+  "required" : [ "Documents" ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassMaterialComposition-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassMaterialComposition-schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.material_composition:1.0.0#MaterialComposition",
+  "description" : "Mandatory data: Battery chemistry; critical raw materials; materials used in the cathode, anode, and electrolyte; hazardous substances.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "BatteryChemistry" : {
+        "type" : "object",
+        "properties" : {
+          "ShortName" : { "type" : "string" },
+          "ClearName" : { "type" : "string" }
+        },
+        "required" : [ "ShortName", "ClearName" ]
+      },
+      "BatteryLocation" : {
+        "type" : "object",
+        "properties" : {
+          "ComponentName" : { "type" : "string" },
+          "ComponentId" : { "type" : "string" }
+        }
+      },
+      "BatteryMaterial" : {
+        "type" : "object",
+        "properties" : {
+          "BatteryMaterialLocation" : { "$ref" : "#/components/schemas/BatteryLocation" },
+          "BatteryMaterialIdentifier" : { "type" : "string" },
+          "BatteryMaterialName" : { "type" : "string" },
+          "BatteryMaterialMass" : { "type" : "number" },
+          "IsCriticalRawMaterial" : { "type" : "boolean" }
+        },
+        "required" : [ "BatteryMaterialLocation", "BatteryMaterialIdentifier", "BatteryMaterialName", "BatteryMaterialMass", "IsCriticalRawMaterial" ]
+      },
+      "HazardousSubstance" : {
+        "type" : "object",
+        "properties" : {
+          "HazardousSubstanceClass" : { "type" : "string", "enum" : [ "AcuteToxicity", "SkinCorrosionOrIrritation", "EyeDamageOrIrritation" ] },
+          "HazardousSubstanceName" : { "type" : "string" },
+          "HazardousSubstanceConcentration" : { "type" : "number" },
+          "HazardousSubstanceImpact" : { "type" : "array", "items" : { "type" : "string" } },
+          "HazardousSubstanceLocation" : { "$ref" : "#/components/schemas/BatteryLocation" },
+          "HazardousSubstanceIdentifier" : { "type" : "string" }
+        },
+        "required" : [ "HazardousSubstanceClass", "HazardousSubstanceName", "HazardousSubstanceConcentration", "HazardousSubstanceImpact", "HazardousSubstanceLocation", "HazardousSubstanceIdentifier" ]
+      }
+    }
+  },
+  "properties" : {
+    "BatteryChemistry" : { "$ref" : "#/components/schemas/BatteryChemistry" },
+    "BatteryMaterials" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/BatteryMaterial" } },
+    "HazardousSubstances" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/HazardousSubstance" } }
+  },
+  "required" : [ "BatteryChemistry", "BatteryMaterials", "HazardousSubstances" ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassProductCondition-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassProductCondition-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.product_condition:1.0.0#ProductCondition",
+  "description" : "Covers all battery lifetime relevant properties.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "TimestampedValue" : {
+        "type" : "object",
+        "properties" : {
+          "LastUpdate" : { "type" : "string" }
+        },
+        "required" : [ "LastUpdate" ]
+      },
+      "NegativeEvent" : {
+        "type" : "object",
+        "properties" : {
+          "NegativeEventValue" : { "type" : "string" },
+          "LastUpdate" : { "type" : "string" }
+        },
+        "required" : [ "NegativeEventValue", "LastUpdate" ]
+      },
+      "DocumentIdentifierSet" : {
+        "type" : "array",
+        "items" : { "type" : "string", "minLength" : 1 },
+        "uniqueItems" : true
+      }
+    }
+  },
+  "properties" : {
+    "EnergyThroughput" : { "type" : "object", "properties" : { "EnergyThroughputValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "EnergyThroughputValue", "LastUpdate" ] },
+    "CapacityThroughput" : { "type" : "object", "properties" : { "CapacityThroughputValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "CapacityThroughputValue", "LastUpdate" ] },
+    "NumberOfFullCycles" : { "type" : "object", "properties" : { "NumberOfFullCyclesValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "NumberOfFullCyclesValue", "LastUpdate" ] },
+    "StateOfCertifiedEnergy" : { "type" : "object", "properties" : { "StateOfCertifiedEnergyValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "StateOfCertifiedEnergyValue", "LastUpdate" ] },
+    "RemainingEnergy" : { "type" : "object", "properties" : { "RemainingEnergyValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "RemainingEnergyValue", "LastUpdate" ] },
+    "RemainingCapacity" : { "type" : "object", "properties" : { "RemainingCapacityValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "RemainingCapacityValue", "LastUpdate" ] },
+    "NegativeEvents" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/NegativeEvent" } },
+    "InformationOnAccidents" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+    "TemperatureInformation" : { "type" : "object", "properties" : { "TimeExtremeHighTemp" : { "type" : "number" }, "TimeExtremeLowTemp" : { "type" : "number" }, "TimeExtremeHighTempCharging" : { "type" : "number" }, "TimeExtremeLowTempCharging" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "LastUpdate" ] },
+    "RemainingPowerCapability" : { "type" : "object", "properties" : { "RemainingPowerCapabilityValue" : { "type" : "object" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "RemainingPowerCapabilityValue", "LastUpdate" ] },
+    "EvolutionOfSelfDischarge" : { "type" : "object", "properties" : { "EvolutionOfSelfDischargeValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "EvolutionOfSelfDischargeValue", "LastUpdate" ] },
+    "CurrentSelfDischargingRate" : { "type" : "object", "properties" : { "CurrentSelfDischargingRateValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "CurrentSelfDischargingRateValue", "LastUpdate" ] },
+    "RemainingRoundTripEnergyEfficiency" : { "type" : "object", "properties" : { "RemainingRoundTripEnergyEfficiencyValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "RemainingRoundTripEnergyEfficiencyValue", "LastUpdate" ] },
+    "StateOfCharge" : { "type" : "object", "properties" : { "StateOfChargeValue" : { "type" : "number" }, "LastUpdate" : { "type" : "string" } }, "required" : [ "StateOfChargeValue", "LastUpdate" ] }
+  },
+  "required" : [ "NumberOfFullCycles", "InformationOnAccidents", "TemperatureInformation", "StateOfCharge" ]
+}

--- a/ichub-frontend/src/schemas/idta-BatteryPassTechnicalData-schema.json
+++ b/ichub-frontend/src/schemas/idta-BatteryPassTechnicalData-schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.admin-shell.idta.batterypass.technical_data:1.0.0#TechnicalData",
+  "description" : "Technical data of the asset and associated product classifications.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "MultiLanguageTexts" : {
+        "type" : "array",
+        "items" : { "type" : "object" },
+        "uniqueItems" : true
+      },
+      "FileWithContentType" : {
+        "type" : "object",
+        "properties" : {
+          "value" : { "type" : "string", "format" : "uri" },
+          "contentType" : { "type" : "string" }
+        },
+        "required" : [ "value", "contentType" ]
+      },
+      "GeneralInformation" : {
+        "type" : "object",
+        "properties" : {
+          "ManufacturerName" : { "type" : "string" },
+          "CompanyLogo" : { "type" : "string" },
+          "ManufacturerProductDesignation" : { "$ref" : "#/components/schemas/MultiLanguageTexts" },
+          "ManufacturerArticleNumber" : { "type" : "string" },
+          "ManufacturerOrderCode" : { "type" : "string" },
+          "ManufacturerIdentifier" : { "type" : "string" },
+          "WarrantyPeriod" : { "type" : "string" },
+          "BatteryCategory" : { "type" : "string", "enum" : [ "lmt", "ev", "industrial", "stationary" ] },
+          "BatteryMass" : { "type" : "number" }
+        },
+        "required" : [ "ManufacturerName", "ManufacturerProductDesignation", "ManufacturerArticleNumber", "ManufacturerOrderCode", "ManufacturerIdentifier", "WarrantyPeriod", "BatteryCategory", "BatteryMass" ]
+      },
+      "DocumentIdentifierSet" : {
+        "type" : "array",
+        "items" : { "type" : "string", "minLength" : 1 },
+        "uniqueItems" : true
+      },
+      "PowerCapabilityAt" : {
+        "type" : "object",
+        "properties" : {
+          "atSoC" : { "type" : "number" },
+          "powerCapabilityAt" : { "type" : "number" }
+        },
+        "required" : [ "atSoC", "powerCapabilityAt" ]
+      },
+      "TechnicalAttributes" : {
+        "type" : "object",
+        "properties" : {
+          "CapacityEnergyVoltage" : {
+            "type" : "object",
+            "properties" : {
+              "NominalVoltage" : { "type" : "number" },
+              "MinVoltage" : { "type" : "number" },
+              "MaxVoltage" : { "type" : "number" },
+              "RatedCapacity" : { "type" : "number" },
+              "CapacityFade" : { "type" : "number" },
+              "CertifiedUsableBatteryEnergy" : { "type" : "number" }
+            },
+            "required" : [ "NominalVoltage", "MinVoltage", "MaxVoltage", "RatedCapacity" ]
+          },
+          "RoundTripEnergyEfficiency" : {
+            "type" : "object",
+            "properties" : {
+              "InitialRoundTripEnergyEfficiency" : { "type" : "number" },
+              "RoundTripEnergyEfficiencyAt50PercentOfCycleLife" : { "type" : "number" },
+              "EnergyRoundTripEfficiencyFade" : { "type" : "number" },
+              "InitialSelfDischargingRate" : { "type" : "number" }
+            },
+            "required" : [ "InitialRoundTripEnergyEfficiency", "RoundTripEnergyEfficiencyAt50PercentOfCycleLife" ]
+          },
+          "Resistance" : {
+            "type" : "object",
+            "properties" : {
+              "InitialInternalResistanceAtBatteryCellLevel" : { "type" : "number" },
+              "InitialInternalResistanceAtBatteryPackLevel" : { "type" : "number" },
+              "InitialInternalResistanceAtBatteryModuleLevel" : { "type" : "number" },
+              "InternalResistanceIncreaseAtBatteryCellLevel" : { "type" : "number" },
+              "InternalResistanceIncreaseAtBatteryPackLevel" : { "type" : "number" },
+              "InternalResistanceIncreaseAtBatteryModuleLevel" : { "type" : "number" }
+            },
+            "required" : [ "InitialInternalResistanceAtBatteryCellLevel", "InitialInternalResistanceAtBatteryPackLevel", "InternalResistanceIncreaseAtBatteryPackLevel" ]
+          },
+          "PowerCapability" : {
+            "type" : "object",
+            "properties" : {
+              "MaximumPermittedBatteryPower" : { "type" : "number" },
+              "PowerFade" : { "type" : "number" },
+              "RatioNominalBatteryPowerAndBatteryEnergy" : { "type" : "number" },
+              "OriginalPowerCapability" : { "type" : "array", "items" : { "$ref" : "#/components/schemas/PowerCapabilityAt" } }
+            },
+            "required" : [ "MaximumPermittedBatteryPower", "PowerFade", "RatioNominalBatteryPowerAndBatteryEnergy", "OriginalPowerCapability" ]
+          },
+          "Temperature" : {
+            "type" : "object",
+            "properties" : {
+              "TemperatureRangeIdleState_LowerBoundary" : { "type" : "number" },
+              "TemperatureRangeIdleState_UpperBoundary" : { "type" : "number" }
+            },
+            "required" : [ "TemperatureRangeIdleState_LowerBoundary", "TemperatureRangeIdleState_UpperBoundary" ]
+          },
+          "Lifetime" : {
+            "type" : "object",
+            "properties" : {
+              "ExpectedLifetimeInCalendarYears" : { "type" : "number" },
+              "ExpectedNumberOfCycles" : { "type" : "number" },
+              "CapacityThresholdExhaustion" : { "type" : "number" },
+              "CycleLifeReferenceTest" : { "$ref" : "#/components/schemas/DocumentIdentifierSet" },
+              "CrateOfRelevantCycleLifeTest" : { "type" : "number" }
+            },
+            "required" : [ "ExpectedLifetimeInCalendarYears", "ExpectedNumberOfCycles", "CapacityThresholdExhaustion", "CycleLifeReferenceTest", "CrateOfRelevantCycleLifeTest" ]
+          }
+        },
+        "required" : [ "CapacityEnergyVoltage", "RoundTripEnergyEfficiency", "Resistance", "PowerCapability", "Temperature", "Lifetime" ]
+      }
+    }
+  },
+  "properties" : {
+    "GeneralInformation" : { "$ref" : "#/components/schemas/GeneralInformation" },
+    "TechnicalPropertyAreas" : { "$ref" : "#/components/schemas/TechnicalAttributes" }
+  },
+  "required" : [ "GeneralInformation", "TechnicalPropertyAreas" ]
+}

--- a/ichub-frontend/src/schemas/index.ts
+++ b/ichub-frontend/src/schemas/index.ts
@@ -2,7 +2,8 @@
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
  * Copyright (c) 2025 LKS Next
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,6 +36,13 @@ import { loadSchemas } from './schemaLoader';
 import digitalProductPassportSchema from './DigitalProductPassport-schema.json';
 import UsTariffInformationSchema from './UsTariffInformation-schema.json';
 import PcfSchema from './Pcf-schema.json';
+import idtaBatteryPassDigitalNameplate from './idta-BatteryPassDigitalNameplate-schema.json';
+import idtaBatteryPassCarbonFootprint from './idta-BatteryPassCarbonFootprint-schema.json';
+import idtaBatteryPassCircularity from './idta-BatteryPassCircularity-schema.json';
+import idtaBatteryPassHandoverDocumentation from './idta-BatteryPassHandoverDocumentation-schema.json';
+import idtaBatteryPassMaterialComposition from './idta-BatteryPassMaterialComposition-schema.json';
+import idtaBatteryPassProductCondition from './idta-BatteryPassProductCondition-schema.json';
+import idtaBatteryPassTechnicalData from './idta-BatteryPassTechnicalData-schema.json';
 import { JSONSchema } from './json-schema-interpreter';
 
 export interface SchemaMetadata {
@@ -76,7 +84,14 @@ export interface SchemaDefinition<T = any> {
 const schemasToLoad = [
   digitalProductPassportSchema as JSONSchema,
   UsTariffInformationSchema as JSONSchema,
-  PcfSchema as JSONSchema
+  PcfSchema as JSONSchema,
+  idtaBatteryPassDigitalNameplate as JSONSchema,
+  idtaBatteryPassCarbonFootprint as JSONSchema,
+  idtaBatteryPassCircularity as JSONSchema,
+  idtaBatteryPassHandoverDocumentation as JSONSchema,
+  idtaBatteryPassMaterialComposition as JSONSchema,
+  idtaBatteryPassProductCondition as JSONSchema,
+  idtaBatteryPassTechnicalData as JSONSchema,
   // Add more schemas here:
   // serialPartSchema as JSONSchema,
   // batchSchema as JSONSchema,


### PR DESCRIPTION
## WHAT

This PR adds the IDTA BatteryPass submodels, incl. viewer addons to nicely present the submodels in the Dataspace Discovery view.
It includes a small change in ``ichub-frontend/src/features/industry-core-kit/part-discovery/components/submodel-addons/shared/semantic-id-utils.ts``, so that IC-Hub can handle non-CatenaX submodels.

## WHY

The IC-Hub currently supports solely Catena-X submodels, which are not sufficient for some users (e.g. Railway-X consortium). This addition allows the usage of IDTA BatteryPass with IC-Hub.

## FURTHER NOTES
Transparency disclaimer: most code for this PR (esp. the views) was generated by AI.

The view implementations make up most of the code for this PR, but they are optional in my opinion as they are not strictly required for exchanging the submodels. So this code could be removed.

Screenshots of the submodel views (with nonsensical example data):

### Material Composition
<img width="2036" height="1243" alt="idta_materialcomposition" src="https://github.com/user-attachments/assets/557f2c77-015e-4ab6-baf3-6bfd3852ede0" />

### Product Condition
<img width="2037" height="1996" alt="idta_productcondition" src="https://github.com/user-attachments/assets/899ba460-5e69-43f0-a359-8560df161229" />

### Circularity
<img width="2046" height="1996" alt="idta_circularity" src="https://github.com/user-attachments/assets/9e7bb489-a399-4f17-96c0-0c0d848c6dc4" />

### Battery Nameplate
<img width="2043" height="1992" alt="idta_nameplate" src="https://github.com/user-attachments/assets/e6da257e-86c9-4f1b-98d3-ae5a9de3e242" />

### Technical Data
<img width="2046" height="1992" alt="idta_technicaldata" src="https://github.com/user-attachments/assets/a295cb6f-3967-4651-b628-b1ce63e3abad" />

### Carbon Footprint Battery
<img width="2040" height="1017" alt="idta_carbonfootprint" src="https://github.com/user-attachments/assets/5a19b8d7-7e17-48c1-bd85-bf4721899f40" />

### Handover Documentation
<img width="2032" height="1055" alt="idta_handoverdocumentation" src="https://github.com/user-attachments/assets/2d5a29ff-ccef-441d-9768-eba6e4b876bd" />

Closes: none, no issue exists for this PR
