### PR TITLE
chore: add license headers to YAML files and init script

### DIFF
--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Add SubPart to Our Main Part.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Add SubPart to Our Main Part.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Add SubPart to Our Main Part.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Add SubPart to Our Main Part.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Add SubPart to Our Main Part
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Consult My Part Global Assembly Progress.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Consult My Part Global Assembly Progress.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Consult My Part Global Assembly Progress.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Consult My Part Global Assembly Progress.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Consult My Part Global Assembly Progress
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Download the PCF of all the SubParts of my Part.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Download the PCF of all the SubParts of my Part.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Download the PCF of all the SubParts of my Part
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Download the PCF of all the SubParts of my Part.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Download the PCF of all the SubParts of my Part.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Retry in case of failes to Send PCF Request to the Sub Participant.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Retry in case of failes to Send PCF Request to the Sub Participant.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Retry in case of failes to Send PCF Request to the Sub Participant
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Retry in case of failes to Send PCF Request to the Sub Participant.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Retry in case of failes to Send PCF Request to the Sub Participant.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Search Own Part by ManufacturerPartId.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Search Own Part by ManufacturerPartId.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Search Own Part by ManufacturerPartId.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Search Own Part by ManufacturerPartId.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Search Own Part by ManufacturerPartId
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Send PCF Request to the Sub Participant.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Send PCF Request to the Sub Participant.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Send PCF Request to the Sub Participant
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/Send PCF Request to the Sub Participant.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/Send PCF Request to the Sub Participant.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/folder.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Consumption
   type: folder

--- a/docs/api/bruno/PCF KIT Exchange/Consumption/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Consumption/folder.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Update a PCF and retrieve al the participants that you share with.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Update a PCF and retrieve al the participants that you share with.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Update a PCF and retrieve al the participants that you share with
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Update a PCF and retrieve al the participants that you share with.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Update a PCF and retrieve al the participants that you share with.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Upload a new PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Upload a new PCF.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Upload a new PCF
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Upload a new PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/Upload a new PCF.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/View Existing PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/View Existing PCF.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/View Existing PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/View Existing PCF.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: View Existing PCF
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/folder.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: PCF Management
   type: folder

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Management/folder.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Accept Request and send the Response with the PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Accept Request and send the Response with the PCF.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Accept Request and send the Response with the PCF
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Accept Request and send the Response with the PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Accept Request and send the Response with the PCF.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/List the incoming PCF Request and the outgoing Response.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/List the incoming PCF Request and the outgoing Response.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/List the incoming PCF Request and the outgoing Response.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/List the incoming PCF Request and the outgoing Response.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: List the incoming PCF Request and the outgoing Response
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Refresh our Pending Response in case that We have the PCF but it not appear in the PCF Response card.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Refresh our Pending Response in case that We have the PCF but it not appear in the PCF Response card.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Refresh our Pending Response in case that We have the PCF but it not appear in the PCF Response card
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Refresh our Pending Response in case that We have the PCF but it not appear in the PCF Response card.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Refresh our Pending Response in case that We have the PCF but it not appear in the PCF Response card.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Retry Accept Request and send the Response with the PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Retry Accept Request and send the Response with the PCF.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Retry Accept Request and send the Response with the PCF
   type: http

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Retry Accept Request and send the Response with the PCF.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/Retry Accept Request and send the Response with the PCF.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/folder.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: PCF Request and Response Management
   type: folder

--- a/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/PCF Request and Response Management/folder.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/folder.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/docs/api/bruno/PCF KIT Exchange/Provision/folder.yml
+++ b/docs/api/bruno/PCF KIT Exchange/Provision/folder.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 info:
   name: Provision
   type: folder

--- a/docs/api/bruno/PCF KIT Exchange/opencollection.yml
+++ b/docs/api/bruno/PCF KIT Exchange/opencollection.yml
@@ -1,3 +1,26 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
 opencollection: 1.0.0
 
 info:

--- a/docs/api/bruno/PCF KIT Exchange/opencollection.yml
+++ b/docs/api/bruno/PCF KIT Exchange/opencollection.yml
@@ -15,7 +15,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/ichub-backend/tests/controllers/pcf_kit/__init__.py
+++ b/ichub-backend/tests/controllers/pcf_kit/__init__.py
@@ -1,0 +1,21 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################

--- a/ichub-backend/tests/controllers/pcf_kit/__init__.py
+++ b/ichub-backend/tests/controllers/pcf_kit/__init__.py
@@ -14,7 +14,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the
-# License for the specific language govern in permissions and limitations
+# License for the specific language governing permissions and limitations
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## WHAT

This pull request adds comprehensive copyright and licensing headers to multiple API documentation files in the `docs/api/bruno/PCF KIT Exchange` directory. These headers clarify the legal terms, contributors, and licensing (Apache 2.0) for the Eclipse Tractus-X Industry Core Hub Backend API documentation.

## WHY

These changes ensure legal clarity and compliance for all API documentation in the repository. No functional or structural changes to the API definitions themselves were introduced.
