### PR TITLE
fix: ichub admin user login issue

### DIFF
--- a/charts/industry-core-hub/files/realm-export.json
+++ b/charts/industry-core-hub/files/realm-export.json
@@ -249,31 +249,5 @@
   "updateProfileOnInitialSocialLogin": false,
   "socialProviders": {},
   "users": [
-    {
-      "username": "ichub-admin",
-      "email": "ichub-admin@example.com",
-      "firstName": "Industry",
-      "lastName": "Admin",
-      "emailVerified": true,
-      "enabled": true,
-      "credentials": [
-        {
-          "type": "password",
-          "value": "changeme",
-          "temporary": false
-        }
-      ],
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "notBefore": 0,
-      "realmRoles": [
-        "default-roles-ichub",
-        "offline_access",
-        "uma_authorization"
-      ],
-      "attributes": {
-        "BPN": ["BPNL000000000000"]
-      }
-    }
   ]
 }

--- a/charts/industry-core-hub/files/realm-export.json
+++ b/charts/industry-core-hub/files/realm-export.json
@@ -248,6 +248,5 @@
   "social": false,
   "updateProfileOnInitialSocialLogin": false,
   "socialProviders": {},
-  "users": [
-  ]
+  "users": []
 }

--- a/charts/industry-core-hub/files/realm-export.json
+++ b/charts/industry-core-hub/files/realm-export.json
@@ -248,5 +248,32 @@
   "social": false,
   "updateProfileOnInitialSocialLogin": false,
   "socialProviders": {},
-  "users": []
+  "users": [
+    {
+      "username": "ichub-admin",
+      "email": "ichub-admin@example.com",
+      "firstName": "Industry",
+      "lastName": "Admin",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "changeme",
+          "temporary": false
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "notBefore": 0,
+      "realmRoles": [
+        "default-roles-ichub",
+        "offline_access",
+        "uma_authorization"
+      ],
+      "attributes": {
+        "BPN": ["BPNL000000000000"]
+      }
+    }
+  ]
 }

--- a/deployment/local/docker-compose/docker-compose.yml
+++ b/deployment/local/docker-compose/docker-compose.yml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 Technovative Solutions
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/deployment/local/docker-compose/docker-compose.yml
+++ b/deployment/local/docker-compose/docker-compose.yml
@@ -62,8 +62,11 @@ services:
     container_name: local_keycloak_init
     environment:
       ICHUB_ADMIN_PASSWORD: ${ICHUB_ADMIN_PASSWORD:-changeme}
+      REALM_TEMPLATE_FILE: /realm-template.json
+      KEYCLOAK_VALUES_FILE: /keycloak-values.yaml
     volumes:
       - ../../../charts/industry-core-hub/files/realm-export.json:/realm-template.json:ro
+      - ../../../charts/industry-core-hub/values-keycloak.yaml:/keycloak-values.yaml:ro
       - keycloak_import:/output
       - ./prepare-realm.sh:/prepare-realm.sh:ro
     command: /bin/sh /prepare-realm.sh

--- a/deployment/local/docker-compose/prepare-realm.sh
+++ b/deployment/local/docker-compose/prepare-realm.sh
@@ -25,83 +25,82 @@ set -e
 echo "Preparing realm import with password hash..."
 
 # Check if realm template file exists
-REALM_FILE="/realm-template.json"
-
-if [ ! -f "$REALM_FILE" ]; then
-    echo "ERROR: Realm template not found at $REALM_FILE"
+if [ ! -f "$REALM_TEMPLATE_FILE" ]; then
+    echo "ERROR: Realm template not found at $REALM_TEMPLATE_FILE"
     exit 1
 fi
 
-echo "Found realm template at: $REALM_FILE"
+echo "Found realm template at: $REALM_TEMPLATE_FILE"
 
-# Install Python (no additional packages needed - using stdlib)
-apk add --no-cache python3
+# Install PyYAML for YAML parsing (python:3.11-alpine already includes Python and pip)
+pip install --quiet pyyaml
 
-# Export REALM_FILE for Python script
-export REALM_FILE
-
-# Generate password hash and update realm template
+# Inject users from values-keycloak.yaml and hash their passwords
 python3 <<'PYTHON_SCRIPT'
 import json
 import os
 import base64
+import hashlib
 import sys
+import yaml
 
 try:
-    # Get the realm file path from environment
-    realm_file = os.environ.get('REALM_FILE', '/realm-data/realm-export.json')
-    print(f"Reading realm template from: {realm_file}")
-    
-    # Read the realm template from the shared volume
-    with open(realm_file, 'r') as f:
+    realm_template_file = os.environ.get('REALM_TEMPLATE_FILE', '/realm-template.json')
+    values_file = os.environ.get('KEYCLOAK_VALUES_FILE', '/keycloak-values.yaml')
+
+    print(f"Reading realm template from: {realm_template_file}")
+    with open(realm_template_file, 'r') as f:
         realm_data = json.load(f)
 
-    # Get password from environment (default if not set)
-    password = os.environ.get('ICHUB_ADMIN_PASSWORD', 'changeme')
-    print(f"Using password from environment (length: {len(password)})")
+    print(f"Reading Keycloak values from: {values_file}")
+    with open(values_file, 'r') as f:
+        values = yaml.safe_load(f)
 
-    # Generate PBKDF2-SHA512 hash manually (Keycloak's default algorithm)
-    # Keycloak uses 210,000 iterations for PBKDF2-SHA512
-    import hashlib
-    import os as os_module
-    
-    # Generate random salt (16 bytes)
-    salt = os_module.urandom(16)
-    
-    # Generate PBKDF2-SHA512 hash
-    password_bytes = password.encode('utf-8')
-    hash_bytes = hashlib.pbkdf2_hmac('sha512', password_bytes, salt, 210000)
-    
-    # Encode to standard Base64 (with padding)
-    salt_b64 = base64.b64encode(salt).decode('utf-8')
-    hash_b64 = base64.b64encode(hash_bytes).decode('utf-8')
-    
-    # Prepare the secretData JSON structure for Keycloak
-    secret_data = {
-        "value": hash_b64,
-        "salt": salt_b64,
-        "additionalParameters": {}
-    }
+    yaml_users = values.get('keycloak', {}).get('ichubRealm', {}).get('users', [])
+    if not yaml_users:
+        print("ERROR: No users found at keycloak.ichubRealm.users in values file")
+        sys.exit(1)
 
-    # Update the user credentials
-    users_updated = 0
-    for user in realm_data.get('users', []):
-        if user.get('username') == 'ichub-admin':
-            for cred in user.get('credentials', []):
-                if cred.get('type') == 'password':
-                    cred['secretData'] = json.dumps(secret_data)
-                    users_updated += 1
+    print(f"Found {len(yaml_users)} user(s) in values file")
 
-    if users_updated == 0:
-        print("WARNING: No ichub-admin user credentials were updated")
-    else:
-        print(f"Updated {users_updated} user credential(s)")
+    def build_credential(password):
+        salt = os.urandom(16)
+        hash_bytes = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), salt, 210000)
+        salt_b64 = base64.b64encode(salt).decode('utf-8')
+        hash_b64 = base64.b64encode(hash_bytes).decode('utf-8')
+        secret_data = json.dumps({"value": hash_b64, "salt": salt_b64, "additionalParameters": {}})
+        credential_data = json.dumps({"hashIterations": 210000, "algorithm": "pbkdf2-sha512", "additionalParameters": {}})
+        return {"type": "password", "secretData": secret_data, "credentialData": credential_data}
 
-    # Write the processed realm to the output volume
+    kc_users = []
+    for user in yaml_users:
+        password = user.get('password', 'changeme')
+        kc_users.append({
+            "username": user["username"],
+            "email": user.get("email", ""),
+            "firstName": user.get("firstName", ""),
+            "lastName": user.get("lastName", ""),
+            "emailVerified": user.get("emailVerified", False),
+            "enabled": user.get("enabled", True),
+            "credentials": [build_credential(password)],
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
+            "notBefore": 0,
+            "realmRoles": user.get("realmRoles", []),
+            "attributes": user.get("attributes", {})
+        })
+        print(f"Prepared user: {user['username']}")
+
+    realm_data['users'] = kc_users
+
+    admin_found = any(u['username'] == 'ichub-admin' for u in kc_users)
+    if not admin_found:
+        print("WARNING: ichub-admin user was not found in values file")
+
     with open('/output/realm-export.json', 'w') as f:
         json.dump(realm_data, f, indent=2)
 
-    print("Password hash generated and realm template processed successfully")
+    print(f"Realm template processed successfully with {len(kc_users)} user(s)")
 except Exception as e:
     print(f"ERROR: {type(e).__name__}: {e}")
     import traceback

--- a/deployment/local/docker-compose/prepare-realm.sh
+++ b/deployment/local/docker-compose/prepare-realm.sh
@@ -2,6 +2,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 Technovative Solutions
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/index.html
+++ b/ichub-frontend/index.html
@@ -44,7 +44,7 @@
         APP_VERSION: "1.0.0",
         
         // API configuration
-        ICHUB_BACKEND_URL: "http://localhost:9000/v1",
+        ICHUB_BACKEND_URL: "http://localhost:8000/v1",
         API_TIMEOUT: "30000",
         API_RETRY_ATTEMPTS: "3",
         REQUIRE_HTTPS_URL_PATTERN: "false",

--- a/ichub-frontend/index.html
+++ b/ichub-frontend/index.html
@@ -1,6 +1,7 @@
 <!--
   Eclipse Tractus-X - Industry Core Hub Frontend
 
+  Copyright (c) 2026 Technovative Solutions
   Copyright (c) 2026 LKS Next
   Copyright (c) 2025 Contributors to the Eclipse Foundation
 


### PR DESCRIPTION
## WHAT

This PR updates the `prepare-realm.sh` file. It adds script to inject `ICHub` realm users including `ichub-admin` user into `realm-export.json` file from `values-keycloak.json` so that the users are created in `ICHub` realm of KeyCloak.

## WHY

When we run the `ichub-frontend` for the first time after setting up locally, we should be able to login using the `ichub-admin` user. But this was not happening because there was no user in KeyCloak's `ICHub` realm.

## FURTHER NOTES

I've also updated ICHUB_BACKEND_URL environment variable in index.html to point to the correct local server port according to the [documentation](https://github.com/eclipse-tractusx/industry-core-hub/blob/main/INSTALL.md#setup--run)

Closes #604 
