### PR TITLE
fix(#563): wire Share DPP button in PassportProvisionWizard success dialog

### DIFF
--- a/ichub-frontend/src/features/eco-pass-kit/passport-provision/components/DppShareDialog.tsx
+++ b/ichub-frontend/src/features/eco-pass-kit/passport-provision/components/DppShareDialog.tsx
@@ -1,7 +1,8 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -41,9 +42,10 @@ interface DppShareDialogProps {
   onClose: () => void;
   dppId: string;
   dppName: string;
+  onShareSuccess?: () => void;
 }
 
-const DppShareDialog = ({ open, onClose, dppId, dppName }: DppShareDialogProps) => {
+const DppShareDialog = ({ open, onClose, dppId, dppName, onShareSuccess }: DppShareDialogProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation(['passportProvision', 'common']);
 
@@ -105,8 +107,12 @@ const DppShareDialog = ({ open, onClose, dppId, dppName }: DppShareDialogProps) 
       setTimeout(() => {
         setSuccessMessage('');
         onClose();
-        // Refresh the page to update the view
-        window.location.reload();
+        if (onShareSuccess) {
+          onShareSuccess();
+        } else {
+          // Refresh the page to update the view
+          window.location.reload();
+        }
         setIsLoading(false);
       }, 2000);
 

--- a/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionWizard.tsx
+++ b/ichub-frontend/src/features/eco-pass-kit/passport-provision/pages/PassportProvisionWizard.tsx
@@ -1,7 +1,8 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Capgemini Deutschland GmbH
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -71,6 +72,7 @@ import { SerializedPart } from '@/features/industry-core-kit/serialized-parts/ty
 import { SerializedPartTwinRead } from '@/features/industry-core-kit/serialized-parts/types/twin-types';
 import { StatusVariants } from '@/features/industry-core-kit/catalog-management/types/types';
 import AddSerializedPartDialog from '@/features/industry-core-kit/serialized-parts/components/AddSerializedPartDialog';
+import DppShareDialog from '../components/DppShareDialog';
 
 const PassportProvisionWizard: React.FC = () => {
   const navigate = useNavigate();
@@ -115,6 +117,16 @@ const PassportProvisionWizard: React.FC = () => {
   const [showPreview, setShowPreview] = useState(false);
   const [publishingDialog, setPublishingDialog] = useState(false);
   const [publishingResult, setPublishingResult] = useState<{ success: boolean; submodelId?: string; error?: string } | null>(null);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+
+  const getCreatedDppId = (): string | null => {
+    const passportId = dppData?.metadata?.passportId || dppData?.passportId;
+    if (passportId) return passportId;
+    if (selectedPart?.manufacturerPartId && selectedPart?.partInstanceId) {
+      return `CX:${selectedPart.manufacturerPartId}:${selectedPart.partInstanceId}`;
+    }
+    return null;
+  };
 
   const handleNext = async () => {
     setError(null);
@@ -1588,6 +1600,8 @@ const PassportProvisionWizard: React.FC = () => {
                   fullWidth
                   variant="outlined"
                   startIcon={<LinkIcon />}
+                  disabled={!getCreatedDppId()}
+                  onClick={() => setShareDialogOpen(true)}
                   sx={{
                     borderColor: `rgba(16, 185, 129, 0.5)`,
                     color: kitThemes.ecoPass.gradientStart,
@@ -1663,6 +1677,15 @@ const PassportProvisionWizard: React.FC = () => {
           </DialogActions>
         )}
       </Dialog>
+      {shareDialogOpen && (
+        <DppShareDialog
+          open={shareDialogOpen}
+          onClose={() => setShareDialogOpen(false)}
+          dppId={getCreatedDppId() ?? ''}
+          dppName={selectedPart?.name || (getCreatedDppId() ?? '')}
+          onShareSuccess={() => navigate('/passport/provision')}
+        />
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## WHAT
- Wires the **Share DPP** action in `PassportProvisionWizard` so the success dialog button triggers the share flow instead of being non-functional.
- Ensures users can continue directly from successful DPP provisioning to sharing without leaving the wizard context.
## WHY
- The success dialog exposed a Share DPP action that was not connected to the underlying share behavior.
- This created a broken UX path at a key step in the provisioning workflow and could block expected follow-up actions.
## FURTHER NOTES
- The fix is scoped to the frontend wizard dialog behavior for DPP provisioning.
- No API contract changes are introduced.

Closes #563

## Demo screenshots
After creating the DPP (picture 1), the bugfix is visible in picture 2 as the button "Share DPP" button in picture 2 is now active and opens the share dialog (picture 3).
<img width="1061" height="1023" alt="fix_dpp_1" src="https://github.com/user-attachments/assets/58c13d66-eda4-41da-9d26-257bcbda3628" />
<img width="962" height="830" alt="fix_dpp_2" src="https://github.com/user-attachments/assets/e3db02bf-2f65-4ee3-a68d-0367cced7d02" />
<img width="890" height="773" alt="fix_dpp_3" src="https://github.com/user-attachments/assets/2ad425f2-922a-4bd1-8d62-5541a7e06a56" />
