### PR TITLE
feat: configure partType creation with default bom and usage submodels

### DIFF
--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -281,6 +281,78 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
       - semanticid: "urn:samm:io.catenax.us_tariff_information:1.0.0#UsTariffInformation"
         usage:
           context:

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -310,6 +310,78 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
     # -- Consumer configuration
     consumer:
       discovery:

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -281,7 +281,7 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         usage:
           context:
             - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -317,7 +317,7 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         usage:
           context:
             - "https://w3id.org/tractusx/policy/v1.0.0"

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -300,7 +300,7 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         usage:
           context:
             - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -336,7 +336,7 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         usage:
           context:
             - "https://w3id.org/tractusx/policy/v1.0.0"

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -329,6 +329,78 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
     # -- Consumer configuration
     consumer:
       discovery:

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -300,6 +300,78 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
       - semanticid: "urn:samm:io.catenax.us_tariff_information:1.0.0#UsTariffInformation"
         usage:
           context:

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -329,6 +329,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
     # -- Consumer configuration
     consumer:
       discovery:

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -295,6 +295,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
       - semanticid: "urn:samm:io.catenax.us_tariff_information:1.0.0#UsTariffInformation"
         usage:
           context:

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -295,7 +295,7 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         usage:
           context:
             - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -329,7 +329,7 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         usage:
           context:
             - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -276,7 +276,7 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         usage:
           context:
             - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -310,7 +310,7 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         usage:
           context:
             - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -276,6 +276,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
       - semanticid: "urn:samm:io.catenax.us_tariff_information:1.0.0#UsTariffInformation"
         usage:
           context:

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -310,6 +310,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
     consumer:
       discovery:
         discovery_finder:

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -793,7 +793,7 @@ frontend:
                       "odrl:rightOperand": "cx.core.industrycore:1"
             "odrl:prohibition": []
             "odrl:obligation": []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         policies:
           - "@context":
               - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -822,7 +822,7 @@ frontend:
                       "odrl:rightOperand": "cx.core.industrycore:1"
             "odrl:prohibition": []
             "odrl:obligation": []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         policies:
           - "@context":
               - "https://w3id.org/tractusx/policy/v1.0.0"

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -203,6 +203,78 @@ backend:
                 rightOperand: "active"
           prohibitions: []
           obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "eq"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibitions: []
+          obligations: []
+        access:
+          context:
+            - "https://w3id.org/tractusx/policy/v1.0.0"
+            - "http://www.w3.org/ns/odrl.jsonld"
+            - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+              "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibitions: []
+          obligations: []
     authorization:
       enabled: true
       apiKey:

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -793,6 +793,64 @@ frontend:
                       "odrl:rightOperand": "cx.core.industrycore:1"
             "odrl:prohibition": []
             "odrl:obligation": []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        policies:
+          - "@context":
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            "odrl:permission":
+              - "odrl:action":
+                  "@id": "odrl:use"
+                "odrl:constraint":
+                  "odrl:and":
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:FrameworkAgreement"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "DataExchangeGovernance:1.0"
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:Membership"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "active"
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:UsagePurpose"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "cx.core.industrycore:1"
+            "odrl:prohibition": []
+            "odrl:obligation": []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        policies:
+          - "@context":
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            "odrl:permission":
+              - "odrl:action":
+                  "@id": "odrl:use"
+                "odrl:constraint":
+                  "odrl:and":
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:FrameworkAgreement"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "DataExchangeGovernance:1.0"
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:Membership"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "active"
+                    - "odrl:leftOperand":
+                        "@id": "cx-policy:UsagePurpose"
+                      "odrl:operator":
+                        "@id": "odrl:eq"
+                      "odrl:rightOperand": "cx.core.industrycore:1"
+            "odrl:prohibition": []
+            "odrl:obligation": []
       - semanticid: "urn:samm:io.catenax.serial_part:3.0.0#SerialPart"
         policies:
           - "@context":

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -823,7 +823,7 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         policies:
           - context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -844,7 +844,7 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         policies:
           - context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -823,6 +823,48 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
       - semanticid: "urn:samm:io.catenax.serial_part:3.0.0#SerialPart"
         policies:
           - context:

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -212,6 +212,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
     authorization:
       enabled: true
       apiKey:

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -213,6 +213,74 @@ backend:
                 rightOperand: "active"
           prohibition: []
           obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
+        usage:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "use"
+              constraint:
+                and:
+                  - leftOperand: "FrameworkAgreement"
+                    operator: "eq"
+                    rightOperand: "DataExchangeGovernance:1.0"
+                  - leftOperand: "Membership"
+                    operator: "eq"
+                    rightOperand: "active"
+                  - leftOperand: "UsagePurpose"
+                    operator: "isAnyOf"
+                    rightOperand: "cx.core.industrycore:1"
+          prohibition: []
+          obligation: []
+        access:
+          context:
+            - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+            - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+            - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          permission:
+            - action: "access"
+              constraint:
+                leftOperand: "Membership"
+                operator: "eq"
+                rightOperand: "active"
+          prohibition: []
+          obligation: []
       - semanticid: urn:samm:io.catenax.pcf:9.0.0#Pcf
         usage:
           context:

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -858,6 +858,48 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+        policies:
+          - context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
       - semanticid: "urn:samm:io.catenax.serial_part:3.0.0#SerialPart"
         policies:
           - context:

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2026 Contributors to the Eclipse Foundation
 # Copyright (c) 2026 Capgemini Deutschland GmbH
 #

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -858,7 +858,7 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelBomAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
         policies:
           - context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -879,7 +879,7 @@ frontend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
-      - semanticid: "urn:samm:io.catenax.part_type_information:3.0.0#SingleLevelUsageAsPlanned"
+      - semanticid: "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
         policies:
           - context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"

--- a/ichub-backend/managers/submodels/submodel_document_generator.py
+++ b/ichub-backend/managers/submodels/submodel_document_generator.py
@@ -1,6 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation

--- a/ichub-backend/managers/submodels/submodel_document_generator.py
+++ b/ichub-backend/managers/submodels/submodel_document_generator.py
@@ -29,6 +29,8 @@ from tools.exceptions import InvalidError
 
 SEM_ID_PART_TYPE_INFORMATION_V1 = "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation"
 SEM_ID_SERIAL_PART_V3 = "urn:samm:io.catenax.serial_part:3.0.0#SerialPart"
+SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3 = "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned"
+SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3 = "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned"
 
 
 class SubmodelDocumentGenerator:
@@ -42,6 +44,10 @@ class SubmodelDocumentGenerator:
             return self.generate_part_type_information_v1(**data)
         elif semantic_id == SEM_ID_SERIAL_PART_V3:
             return self.generate_serial_part_v3(**data)
+        elif semantic_id == SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3:
+            return self.generate_single_level_bom_as_planned_v3(**data)
+        elif semantic_id == SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3:
+            return self.generate_single_level_usage_as_planned_v3(**data)
         raise InvalidError(f"Unsupported semantic ID: {semantic_id}")
     
     def generate_part_type_information_v1(self,
@@ -67,6 +73,25 @@ class SubmodelDocumentGenerator:
                 }
             ]
         return result
+
+    def generate_single_level_bom_as_planned_v3(self,
+        global_id: UUID) -> Dict[str, Any]:
+        """Generate SingleLevelBomAsPlanned v3.0.0 document with empty child items."""
+
+        return {
+            "catenaXId": str(global_id),
+            "childItems": []
+        }
+
+    def generate_single_level_usage_as_planned_v3(self,
+        global_id: UUID) -> Dict[str, Any]:
+        """Generate SingleLevelUsageAsPlanned v3.0.0 document with empty parent items and customers."""
+
+        return {
+            "catenaXId": str(global_id),
+            "parentItems": [],
+            "customers": []
+        }
 
     def generate_serial_part_v3(self,
         global_id: UUID,

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -1,6 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -25,7 +25,12 @@
 from .twin_management_service import TwinManagementService
 from datetime import datetime, timezone
 from uuid import UUID
-from managers.submodels.submodel_document_generator import SubmodelDocumentGenerator, SEM_ID_PART_TYPE_INFORMATION_V1
+from managers.submodels.submodel_document_generator import (
+    SubmodelDocumentGenerator,
+    SEM_ID_PART_TYPE_INFORMATION_V1,
+    SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3,
+    SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3,
+)
 from managers.metadata_database.manager import RepositoryManagerFactory, RepositoryManager
 from models.services.provider.twin_management import CatalogPartTwinCreate, TwinAspectCreate
 from models.metadata_database.provider.models import BusinessPartner, Twin, DataExchangeAgreement, CatalogPart, PartnerCatalogPart
@@ -81,6 +86,24 @@ class SharingService:
                     globalId=db_twin.global_id,
                     semanticId=SEM_ID_PART_TYPE_INFORMATION_V1,
                     payload=part_type_info_doc
+                )
+            )
+            # Step 8b: Create SingleLevelBomAsPlanned submodel (default empty)
+            bom_doc = self._create_single_level_bom_aspect_doc(global_id=db_twin.global_id)
+            self.twin_management_service.create_twin_aspect(
+                TwinAspectCreate(
+                    globalId=db_twin.global_id,
+                    semanticId=SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3,
+                    payload=bom_doc
+                )
+            )
+            # Step 8c: Create SingleLevelUsageAsPlanned submodel (default empty)
+            usage_doc = self._create_single_level_usage_aspect_doc(global_id=db_twin.global_id)
+            self.twin_management_service.create_twin_aspect(
+                TwinAspectCreate(
+                    globalId=db_twin.global_id,
+                    semanticId=SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3,
+                    payload=usage_doc
                 )
             )
             # Step 9: Return the shared part information
@@ -216,5 +239,15 @@ class SharingService:
             manufacturer_part_id=manufacturer_part_id,
             name=name,
             bpns=bpns
+        )
+
+    def _create_single_level_bom_aspect_doc(self, global_id: UUID):
+        return self.submodel_document_generator.generate_single_level_bom_as_planned_v3(
+            global_id=global_id
+        )
+
+    def _create_single_level_usage_aspect_doc(self, global_id: UUID):
+        return self.submodel_document_generator.generate_single_level_usage_as_planned_v3(
+            global_id=global_id
         )
 

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -30,7 +30,13 @@ from datetime import datetime, timezone
 from connector import connector_manager
 from dtr import dtr_provider_manager
 
-from managers.submodels.submodel_document_generator import SubmodelDocumentGenerator, SEM_ID_PART_TYPE_INFORMATION_V1, SEM_ID_SERIAL_PART_V3
+from managers.submodels.submodel_document_generator import (
+    SubmodelDocumentGenerator,
+    SEM_ID_PART_TYPE_INFORMATION_V1,
+    SEM_ID_SERIAL_PART_V3,
+    SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3,
+    SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3,
+)
 from managers.config.config_manager import ConfigManager
 from managers.metadata_database.manager import RepositoryManagerFactory, RepositoryManager
 from managers.enablement_services.submodel_service_manager import SubmodelServiceManager
@@ -198,6 +204,30 @@ class TwinManagementService:
                         semanticId= SEM_ID_PART_TYPE_INFORMATION_V1,
                         payload= part_type_info_doc
                     )                    
+                )
+
+                ## Create SingleLevelBomAsPlanned submodel (default empty)
+                bom_doc = self.submodel_document_generator.generate_single_level_bom_as_planned_v3(
+                    global_id=db_twin.global_id,
+                )
+                self.create_twin_aspect(
+                    TwinAspectCreate(
+                        globalId=db_twin.global_id,
+                        semanticId=SEM_ID_SINGLE_LEVEL_BOM_AS_PLANNED_V3,
+                        payload=bom_doc
+                    )
+                )
+
+                ## Create SingleLevelUsageAsPlanned submodel (default empty)
+                usage_doc = self.submodel_document_generator.generate_single_level_usage_as_planned_v3(
+                    global_id=db_twin.global_id,
+                )
+                self.create_twin_aspect(
+                    TwinAspectCreate(
+                        globalId=db_twin.global_id,
+                        semanticId=SEM_ID_SINGLE_LEVEL_USAGE_AS_PLANNED_V3,
+                        payload=usage_doc
+                    )
                 )
             
             return TwinRead(

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -629,11 +629,11 @@ class TwinManagementService:
                 else:
                     # Update existing twin aspect
                     self._handle_submodel_service_update(
-                        repo, db_twin_aspect.registrations[0], db_enablement_service_stack, db_twin_aspect, twin_aspect_create
+                        repo, db_twin_aspect.twin_aspect_registrations[0], db_enablement_service_stack, db_twin_aspect, twin_aspect_create
                     )
                     repo.commit()
                     repo.refresh(db_twin_aspect)
-                    return self._create_twin_aspect_read_response(db_twin_aspect, db_enablement_service_stack, db_twin_aspect.registrations[0])
+                    return self._create_twin_aspect_read_response(db_twin_aspect, db_enablement_service_stack, db_twin_aspect.twin_aspect_registrations[0])
             
 
             # Step 4: Check if there is already a registration for the given enablement service stack and create it if not

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -715,7 +715,7 @@ class TwinManagementService:
         """
         Handle the update of the twin aspect payload to the submodel service.
         """
-        if db_twin_aspect_registration.status == TwinAspectRegistrationStatus.STORED.value:
+        if db_twin_aspect_registration.status >= TwinAspectRegistrationStatus.STORED.value:
             submodel_service_manager = _create_submodel_service_manager(db_enablement_service_stack.connection_settings)
             
             # Update the payload to the submodel service

--- a/ichub-backend/tests/services/provider/test_sharing_service.py
+++ b/ichub-backend/tests/services/provider/test_sharing_service.py
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2025,2026 LKS NEXT
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/tests/services/provider/test_sharing_service.py
+++ b/ichub-backend/tests/services/provider/test_sharing_service.py
@@ -148,7 +148,11 @@ class TestSharingService:
     @patch.object(SharingService, '_create_and_get_twin')
     @patch.object(SharingService, '_ensure_twin_exchange')
     @patch.object(SharingService, '_create_part_type_information_aspect_doc')
+    @patch.object(SharingService, '_create_single_level_bom_aspect_doc')
+    @patch.object(SharingService, '_create_single_level_usage_aspect_doc')
     def test_share_catalog_part_success(self, 
+                                        mock_create_single_level_usage,
+                                        mock_create_single_level_bom,
                                         mock_create_part_type_info,
                                         mock_ensure_twin_exchange,
                                         mock_create_and_get_twin,
@@ -174,6 +178,8 @@ class TestSharingService:
         }
         mock_create_and_get_twin.return_value = sample_twin_db
         mock_create_part_type_info.return_value = {"test": "document"}
+        mock_create_single_level_bom.return_value = {"test": "bom_document"}
+        mock_create_single_level_usage.return_value = {"test": "usage_document"}
         
         # Mock twin management service methods
         self.service.twin_management_service.get_or_create_enablement_stack = Mock()
@@ -212,6 +218,8 @@ class TestSharingService:
         mock_create_and_get_twin.assert_called_once()
         mock_ensure_twin_exchange.assert_called_once()
         mock_create_part_type_info.assert_called_once()
+        mock_create_single_level_bom.assert_called_once()
+        mock_create_single_level_usage.assert_called_once()
 
     @patch('managers.metadata_database.manager.RepositoryManagerFactory.create')
     def test_get_catalog_part_success(self, mock_repo_factory, mock_repo, sample_share_catalog_part, sample_catalog_part_db):
@@ -461,6 +469,40 @@ class TestSharingService:
             bpns="BPNS123456789012"
         )
 
+    def test_create_single_level_bom_aspect_doc(self):
+        """Test single level BOM as planned aspect document creation."""
+        # Arrange
+        global_id = uuid.uuid4()
+        self.service.submodel_document_generator.generate_single_level_bom_as_planned_v3 = Mock(
+            return_value={"catenaXId": str(global_id), "childItems": []}
+        )
+
+        # Act
+        result = self.service._create_single_level_bom_aspect_doc(global_id=global_id)
+
+        # Assert
+        assert result == {"catenaXId": str(global_id), "childItems": []}
+        self.service.submodel_document_generator.generate_single_level_bom_as_planned_v3.assert_called_once_with(
+            global_id=global_id
+        )
+
+    def test_create_single_level_usage_aspect_doc(self):
+        """Test single level usage as planned aspect document creation."""
+        # Arrange
+        global_id = uuid.uuid4()
+        self.service.submodel_document_generator.generate_single_level_usage_as_planned_v3 = Mock(
+            return_value={"catenaXId": str(global_id), "parentItems": [], "customers": []}
+        )
+
+        # Act
+        result = self.service._create_single_level_usage_aspect_doc(global_id=global_id)
+
+        # Assert
+        assert result == {"catenaXId": str(global_id), "parentItems": [], "customers": []}
+        self.service.submodel_document_generator.generate_single_level_usage_as_planned_v3.assert_called_once_with(
+            global_id=global_id
+        )
+
     @patch('managers.metadata_database.manager.RepositoryManagerFactory.create')
     def test_share_catalog_part_datetime_handling(self, mock_repo_factory, mock_repo):
         """Test that share_catalog_part correctly handles datetime."""
@@ -473,7 +515,9 @@ class TestSharingService:
              patch.object(self.service, '_get_or_create_partner_catalog_parts') as mock_get_partner_parts, \
              patch.object(self.service, '_create_and_get_twin') as mock_create_and_get_twin, \
              patch.object(self.service, '_ensure_twin_exchange'), \
-             patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info:
+             patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info, \
+             patch.object(self.service, '_create_single_level_bom_aspect_doc'), \
+             patch.object(self.service, '_create_single_level_usage_aspect_doc'):
             
             # Mock catalog part
             mock_catalog_part = Mock(spec=CatalogPart)
@@ -542,7 +586,9 @@ class TestSharingService:
              patch.object(self.service, '_get_or_create_partner_catalog_parts') as mock_get_partner_parts, \
              patch.object(self.service, '_create_and_get_twin') as mock_create_and_get_twin, \
              patch.object(self.service, '_ensure_twin_exchange'), \
-             patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info:
+             patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info, \
+             patch.object(self.service, '_create_single_level_bom_aspect_doc'), \
+             patch.object(self.service, '_create_single_level_usage_aspect_doc'):
 
             mock_catalog_part = Mock(spec=CatalogPart)
             mock_catalog_part.name = "Test Part"

--- a/ichub-backend/tests/services/provider/test_sharing_service.py
+++ b/ichub-backend/tests/services/provider/test_sharing_service.py
@@ -516,8 +516,8 @@ class TestSharingService:
              patch.object(self.service, '_create_and_get_twin') as mock_create_and_get_twin, \
              patch.object(self.service, '_ensure_twin_exchange'), \
              patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info, \
-             patch.object(self.service, '_create_single_level_bom_aspect_doc'), \
-             patch.object(self.service, '_create_single_level_usage_aspect_doc'):
+             patch.object(self.service, '_create_single_level_bom_aspect_doc') as mock_create_bom, \
+             patch.object(self.service, '_create_single_level_usage_aspect_doc') as mock_create_usage:
             
             # Mock catalog part
             mock_catalog_part = Mock(spec=CatalogPart)
@@ -537,6 +537,8 @@ class TestSharingService:
             
             # Mock part type info document
             mock_create_part_type_info.return_value = {"test": "document"}
+            mock_create_bom.return_value = {}
+            mock_create_usage.return_value = {}
             
             # Mock twin management service
             self.service.twin_management_service.get_or_create_enablement_stack = Mock()
@@ -587,8 +589,8 @@ class TestSharingService:
              patch.object(self.service, '_create_and_get_twin') as mock_create_and_get_twin, \
              patch.object(self.service, '_ensure_twin_exchange'), \
              patch.object(self.service, '_create_part_type_information_aspect_doc') as mock_create_part_type_info, \
-             patch.object(self.service, '_create_single_level_bom_aspect_doc'), \
-             patch.object(self.service, '_create_single_level_usage_aspect_doc'):
+             patch.object(self.service, '_create_single_level_bom_aspect_doc') as mock_create_bom, \
+             patch.object(self.service, '_create_single_level_usage_aspect_doc') as mock_create_usage:
 
             mock_catalog_part = Mock(spec=CatalogPart)
             mock_catalog_part.name = "Test Part"
@@ -608,6 +610,8 @@ class TestSharingService:
             
             # Mock part type info document
             mock_create_part_type_info.return_value = {"test": "document"}
+            mock_create_bom.return_value = {}
+            mock_create_usage.return_value = {}
 
             self.service.twin_management_service.get_or_create_enablement_stack = Mock()
             self.service.twin_management_service.create_twin_aspect = Mock()

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -785,7 +785,7 @@ class TestTwinManagementService:
         mock_registration.registration_mode = TwinsAspectRegistrationMode.DISPATCHED.value
         mock_registration.created_date = datetime.now()
         mock_registration.modified_date = datetime.now()
-        mock_existing_aspect.registrations = [mock_registration]
+        mock_existing_aspect.twin_aspect_registrations = [mock_registration]
         
         mock_repo = Mock()
         mock_repo_factory.return_value.__enter__.return_value = mock_repo

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 LKS NEXT
+# Copyright (c) 2025,2026 LKS NEXT
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/api.ts
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/api.ts
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
+ * Copyright (c) 2026 LKS Next
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/api.ts
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/api.ts
@@ -151,8 +151,12 @@ export const createTwinAspect = async (
       requestBody.submodelId = submodelId;
     }
 
+    const url = submodelId
+      ? `${backendUrl}/twin-management/twin-aspect?default=false`
+      : `${backendUrl}/twin-management/twin-aspect`;
+
     const response = await httpClient.post(
-      `${backendUrl}/twin-management/twin-aspect`,
+      url,
       requestBody
     );
     

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelCard.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelCard.tsx
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
+ * Copyright (c) 2026 LKS Next
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelCard.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelCard.tsx
@@ -33,7 +33,8 @@ import {
 } from '@mui/material';
 import {
     Visibility as VisibilityIcon,
-    DataObject as DataObjectIcon
+    DataObject as DataObjectIcon,
+    Edit as EditIcon
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 
@@ -55,12 +56,14 @@ interface SubmodelCardProps {
             }>;
         };
     }, submodelId: string, semanticId: string) => void;
+    onEdit?: (semanticId: string, submodelId: string) => void;
 }
 
 const SubmodelCard: React.FC<SubmodelCardProps> = ({
     semanticId,
     aspect,
-    onViewDetails
+    onViewDetails,
+    onEdit
 }) => {
     const { t } = useTranslation('catalogManagement');
     const { t: tCommon } = useTranslation('common');
@@ -219,7 +222,7 @@ const SubmodelCard: React.FC<SubmodelCardProps> = ({
                 </Box>
             </CardContent>
 
-            <CardActions sx={{ p: 1.5, pt: 0 }}>
+            <CardActions sx={{ p: 1.5, pt: 0, gap: 1 }}>
                 <Button
                     fullWidth
                     variant="contained"
@@ -241,6 +244,30 @@ const SubmodelCard: React.FC<SubmodelCardProps> = ({
                 >
                     {tCommon('actions.viewDetails')}
                 </Button>
+                {onEdit && (
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<EditIcon />}
+                        onClick={() => onEdit(semanticId, aspect.submodelId)}
+                        sx={{
+                            color: '#60a5fa',
+                            borderColor: 'rgba(96, 165, 250, 0.5)',
+                            fontSize: '11px',
+                            textTransform: 'none',
+                            fontWeight: 500,
+                            py: 0.5,
+                            minWidth: 'auto',
+                            '&:hover': {
+                                borderColor: 'rgba(96, 165, 250, 0.9)',
+                                backgroundColor: 'rgba(96, 165, 250, 0.1)',
+                            },
+                            borderRadius: 1
+                        }}
+                    >
+                        {tCommon('actions.edit')}
+                    </Button>
+                )}
             </CardActions>
         </Card>
     );

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelsGridDialog.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelsGridDialog.tsx
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
+ * Copyright (c) 2026 LKS Next
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelsGridDialog.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/components/product-detail/SubmodelsGridDialog.tsx
@@ -55,6 +55,7 @@ interface SubmodelsGridDialogProps {
     twinDetails: CatalogPartTwinDetailsRead | null;
     partName?: string;
     onCreateSubmodel?: () => void;
+    onEditSubmodel?: (semanticId: string, submodelId: string) => void;
 }
 
 // Dark theme for the dialog - matching application patterns
@@ -102,7 +103,8 @@ const SubmodelsGridDialog: React.FC<SubmodelsGridDialogProps> = ({
     onClose,
     twinDetails,
     partName,
-    onCreateSubmodel
+    onCreateSubmodel,
+    onEditSubmodel
 }) => {
     const { t } = useTranslation('catalogManagement');
     const { t: tCommon } = useTranslation('common');
@@ -310,6 +312,7 @@ const SubmodelsGridDialog: React.FC<SubmodelsGridDialogProps> = ({
                                             aspect={aspect}
                                             assetId={twinDetails.globalId}
                                             onViewDetails={handleViewSubmodelDetails}
+                                            onEdit={onEditSubmodel}
                                         />
                                     </Grid2>
                                 ))}

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/pages/ProductsDetails.tsx
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
+ * Copyright (c) 2026 LKS Next
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/features/industry-core-kit/catalog-management/pages/ProductsDetails.tsx
+++ b/ichub-frontend/src/features/industry-core-kit/catalog-management/pages/ProductsDetails.tsx
@@ -45,7 +45,7 @@ import ShareDialog from "@/features/industry-core-kit/catalog-management/compone
 import {ErrorNotFound} from '@/components/general/ErrorNotFound';
 import LoadingSpinner from '@/components/general/LoadingSpinner';
 import { SchemaSelector, SubmodelCreator } from '@/components/submodel-creation';
-import { SchemaDefinition } from '@/schemas';
+import { SchemaDefinition, getSchemaBySemanticId } from '@/schemas';
 
 import { PartType } from "@/features/industry-core-kit/catalog-management/types/types";
 import { PRODUCT_STATUS } from "@/features/industry-core-kit/catalog-management/types/shared";
@@ -53,7 +53,7 @@ import { CatalogPartTwinDetailsRead } from "@/features/industry-core-kit/catalog
 
 import { SharedPartner } from "@/features/industry-core-kit/catalog-management/types/types"
 
-import { fetchCatalogPart, fetchCatalogPartTwinDetails, createTwinAspect } from "@/features/industry-core-kit/catalog-management/api";
+import { fetchCatalogPart, fetchCatalogPartTwinDetails, createTwinAspect, fetchSubmodelContent } from "@/features/industry-core-kit/catalog-management/api";
 import { mapApiPartDataToPartType, mapSharePartCustomerPartIds} from "../utils/utils";
 import { useEscapeNavigation } from '@/hooks/useEscapeKey';
 
@@ -80,6 +80,8 @@ const ProductsDetails = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [sharedPartners, setSharedPartners] = useState<SharedPartner[]>([]);
   const [twinDetails, setTwinDetails] = useState<CatalogPartTwinDetailsRead | null>(null);
+  const [editingSubmodelId, setEditingSubmodelId] = useState<string | null>(null);
+  const [editInitialData, setEditInitialData] = useState<Record<string, unknown> | null>(null);
 
   useEscapeNavigation(() => navigate('/catalog'), !jsonDialogOpen && !shareDialogOpen && !addSerializedPartDialogOpen && !submodelsGridDialogOpen);
 
@@ -209,6 +211,40 @@ const ProductsDetails = () => {
     setSubmodelCreatorOpen(false);
     setSelectedSchema(null);
     setSelectedSchemaKey('');
+    setEditingSubmodelId(null);
+    setEditInitialData(null);
+  };
+
+  const handleEditSubmodel = async (semanticId: string, submodelId: string) => {
+    try {
+      // Find the matching schema for the semantic ID
+      const schema = getSchemaBySemanticId(semanticId);
+      if (!schema) {
+        setNotification({
+          open: true,
+          severity: 'error',
+          title: t('messages.noSchemaForEdit')
+        });
+        return;
+      }
+
+      // Fetch existing submodel content
+      const content = await fetchSubmodelContent(semanticId, submodelId);
+
+      // Open SubmodelCreator in edit mode with fetched data
+      setSelectedSchema(schema);
+      setSelectedSchemaKey('');
+      setEditingSubmodelId(submodelId);
+      setEditInitialData(content);
+      setSubmodelCreatorOpen(true);
+    } catch (error) {
+      console.error('Error loading submodel for editing:', error);
+      setNotification({
+        open: true,
+        severity: 'error',
+        title: t('messages.submodelLoadError')
+      });
+    }
   };
 
   const handleCreateSubmodelSubmit = async (submodelData: Record<string, unknown>) => {
@@ -221,18 +257,20 @@ const ProductsDetails = () => {
         throw new Error('Twin must be created before adding submodels. Please create a twin first.');
       }
 
-      // Call the API to create the twin aspect
+      // Call the API to create or update the twin aspect
       const result = await createTwinAspect(
         twinDetails.globalId,
         selectedSchema.metadata.semanticId,
-        submodelData
+        submodelData,
+        editingSubmodelId || undefined
       );
 
       if (result.success) {
+        const messageKey = editingSubmodelId ? 'messages.submodelUpdatedSuccess' : 'messages.submodelCreatedSuccess';
         setNotification({ 
           open: true, 
           severity: 'success', 
-          title: t('messages.submodelCreatedSuccess', { schemaName: selectedSchema.metadata.name })
+          title: t(messageKey, { schemaName: selectedSchema.metadata.name })
         });
         
         handleCloseSubmodelCreator();
@@ -336,6 +374,7 @@ const ProductsDetails = () => {
           twinDetails={twinDetails}
           partName={partType?.name}
           onCreateSubmodel={handleCreateSubmodel}
+          onEditSubmodel={handleEditSubmodel}
         />
 
         {/* Schema Selector Dialog */}
@@ -351,12 +390,14 @@ const ProductsDetails = () => {
           <SubmodelCreator
             open={submodelCreatorOpen}
             onClose={handleCloseSubmodelCreator}
-            onBack={handleBackToSchemaSelector}
+            onBack={editingSubmodelId ? handleCloseSubmodelCreator : handleBackToSchemaSelector}
             onCreateSubmodel={handleCreateSubmodelSubmit}
             selectedSchema={selectedSchema}
             schemaKey={selectedSchemaKey}
             manufacturerPartId={partType?.manufacturerPartId}
             twinId={twinDetails?.globalId}
+            initialData={editInitialData || undefined}
+            saveButtonLabel={editingSubmodelId ? t('productDetail.submodelsGrid.updateSubmodel') : undefined}
           />
         )}
       </Grid2>

--- a/ichub-frontend/src/i18n/locales/de/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/de/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "Teil-Twin erfolgreich registriert!",
     "registerError": "Fehler beim Registrieren des Teil-Twins!",
     "submodelCreatedSuccess": "Submodell erfolgreich mit {{schemaName}}-Schema erstellt!",
-    "submodelCreatedError": "Fehler beim Erstellen des Submodells"
+    "submodelCreatedError": "Fehler beim Erstellen des Submodells",
+    "submodelUpdatedSuccess": "Submodell erfolgreich mit {{schemaName}}-Schema aktualisiert!",
+    "noSchemaForEdit": "Kein passendes Schema für dieses Submodell gefunden. Es kann nicht im Formular-Editor bearbeitet werden.",
+    "submodelLoadError": "Fehler beim Laden der Submodell-Daten zur Bearbeitung"
   },
   "createDialog": {
     "title": "Neues Katalogteil erstellen",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "Neuen Submodell-Aspekt erstellen",
       "noSubmodels": "Keine Submodelle Verfügbar",
       "noSubmodelsDescription": "Dieser digitale Zwilling hat keine Submodell-Aspekte zur Ansicht verfügbar.",
-      "submodelsDisplayed": "{{count}} digitale Zwilling Submodell(e) angezeigt"
+      "submodelsDisplayed": "{{count}} digitale Zwilling Submodell(e) angezeigt",
+      "updateSubmodel": "Submodell aktualisieren"
     },
     "jsonViewer": {
       "title": "JSON-Viewer",

--- a/ichub-frontend/src/i18n/locales/en/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/en/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "Part twin registered successfully!",
     "registerError": "Failed to register part twin!",
     "submodelCreatedSuccess": "Submodel created successfully with {{schemaName}} schema!",
-    "submodelCreatedError": "Failed to create submodel"
+    "submodelCreatedError": "Failed to create submodel",
+    "submodelUpdatedSuccess": "Submodel updated successfully with {{schemaName}} schema!",
+    "noSchemaForEdit": "No matching schema found for this submodel. It cannot be edited in the form editor.",
+    "submodelLoadError": "Failed to load submodel data for editing"
   },
   "createDialog": {
     "title": "Create New Catalog Part",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "Create a new submodel aspect",
       "noSubmodels": "No Submodels Available",
       "noSubmodelsDescription": "This digital twin doesn't have any submodel aspects available for viewing.",
-      "submodelsDisplayed": "{{count}} digital twin submodel(s) displayed"
+      "submodelsDisplayed": "{{count}} digital twin submodel(s) displayed",
+      "updateSubmodel": "Update Submodel"
     },
     "jsonViewer": {
       "title": "JSON Viewer",

--- a/ichub-frontend/src/i18n/locales/es/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/es/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "¡Twin de pieza registrado correctamente!",
     "registerError": "¡Error al registrar el twin de pieza!",
     "submodelCreatedSuccess": "¡Submodelo creado correctamente con el esquema {{schemaName}}!",
-    "submodelCreatedError": "Error al crear el submodelo"
+    "submodelCreatedError": "Error al crear el submodelo",
+    "submodelUpdatedSuccess": "¡Submodelo actualizado correctamente con el esquema {{schemaName}}!",
+    "noSchemaForEdit": "No se encontró un esquema compatible para este submodelo. No se puede editar en el editor de formularios.",
+    "submodelLoadError": "Error al cargar los datos del submodelo para edición"
   },
   "createDialog": {
     "title": "Crear Nueva Pieza de Catálogo",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "Crear un nuevo aspecto de submodelo",
       "noSubmodels": "No Hay Submodelos Disponibles",
       "noSubmodelsDescription": "Este gemelo digital no tiene aspectos de submodelo disponibles para visualizar.",
-      "submodelsDisplayed": "{{count}} submodelo(s) de gemelo digital mostrado(s)"
+      "submodelsDisplayed": "{{count}} submodelo(s) de gemelo digital mostrado(s)",
+      "updateSubmodel": "Actualizar Submodelo"
     },
     "jsonViewer": {
       "title": "Visor JSON",

--- a/ichub-frontend/src/i18n/locales/fr/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/fr/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "Twin de pièce enregistré avec succès !",
     "registerError": "Échec de l'enregistrement du twin de pièce !",
     "submodelCreatedSuccess": "Submodèle créé avec succès avec le schéma {{schemaName}} !",
-    "submodelCreatedError": "Échec de la création du submodèle"
+    "submodelCreatedError": "Échec de la création du submodèle",
+    "submodelUpdatedSuccess": "Submodèle mis à jour avec succès avec le schéma {{schemaName}} !",
+    "noSchemaForEdit": "Aucun schéma correspondant trouvé pour ce submodèle. Il ne peut pas être modifié dans l'éditeur de formulaire.",
+    "submodelLoadError": "Échec du chargement des données du submodèle pour la modification"
   },
   "createDialog": {
     "title": "Créer une Nouvelle Pièce de Catalogue",
@@ -308,7 +311,8 @@
       "createNewSubmodel": "Créer un nouvel aspect de sous-modèle",
       "noSubmodels": "Aucun Sous-modèle Disponible",
       "noSubmodelsDescription": "Ce jumeau numérique n'a aucun aspect de sous-modèle disponible pour l'affichage.",
-      "submodelsDisplayed": "{{count}} sous-modèle(s) de jumeau numérique affiché(s)"
+      "submodelsDisplayed": "{{count}} sous-modèle(s) de jumeau numérique affiché(s)",
+      "updateSubmodel": "Mettre à jour le sous-modèle"
     },
     "jsonViewer": {
       "title": "Visionneuse JSON",

--- a/ichub-frontend/src/i18n/locales/ja/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/ja/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "部品ツインが正常に登録されました！",
     "registerError": "部品ツインの登録に失敗しました！",
     "submodelCreatedSuccess": "{{schemaName}}スキーマでサブモデルが正常に作成されました！",
-    "submodelCreatedError": "サブモデルの作成に失敗しました"
+    "submodelCreatedError": "サブモデルの作成に失敗しました",
+    "submodelUpdatedSuccess": "{{schemaName}}スキーマでサブモデルが正常に更新されました！",
+    "noSchemaForEdit": "このサブモデルに一致するスキーマが見つかりません。フォームエディタで編集できません。",
+    "submodelLoadError": "編集用のサブモデルデータの読み込みに失敗しました"
   },
   "createDialog": {
     "title": "新しいカタログ部品を作成",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "新しいサブモデルアスペクトを作成",
       "noSubmodels": "サブモデルがありません",
       "noSubmodelsDescription": "このデジタルツインには表示可能なサブモデルアスペクトがありません。",
-      "submodelsDisplayed": "{{count}}個のデジタルツインサブモデルを表示"
+      "submodelsDisplayed": "{{count}}個のデジタルツインサブモデルを表示",
+      "updateSubmodel": "サブモデルを更新"
     },
     "jsonViewer": {
       "title": "JSONビューア",

--- a/ichub-frontend/src/i18n/locales/pt/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/pt/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "Gémeo da peça registado com sucesso!",
     "registerError": "Falha ao registar o gémeo da peça!",
     "submodelCreatedSuccess": "Submodelo criado com sucesso com o esquema {{schemaName}}!",
-    "submodelCreatedError": "Falha ao criar submodelo"
+    "submodelCreatedError": "Falha ao criar submodelo",
+    "submodelUpdatedSuccess": "Submodelo atualizado com sucesso com o esquema {{schemaName}}!",
+    "noSchemaForEdit": "Nenhum esquema correspondente encontrado para este submodelo. Não pode ser editado no editor de formulários.",
+    "submodelLoadError": "Falha ao carregar os dados do submodelo para edição"
   },
   "createDialog": {
     "title": "Criar Nova Peça de Catálogo",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "Criar um novo aspeto de submodelo",
       "noSubmodels": "Nenhum Submodelo Disponível",
       "noSubmodelsDescription": "Este gémeo digital não tem nenhum aspeto de submodelo disponível para visualização.",
-      "submodelsDisplayed": "{{count}} submodelo(s) do gémeo digital exibido(s)"
+      "submodelsDisplayed": "{{count}} submodelo(s) do gémeo digital exibido(s)",
+      "updateSubmodel": "Atualizar Submodelo"
     },
     "jsonViewer": {
       "title": "Visualizador JSON",

--- a/ichub-frontend/src/i18n/locales/zh/catalogManagement.json
+++ b/ichub-frontend/src/i18n/locales/zh/catalogManagement.json
@@ -13,7 +13,10 @@
     "registerSuccess": "零件孪生注册成功！",
     "registerError": "注册零件孪生失败！",
     "submodelCreatedSuccess": "子模型已使用{{schemaName}}架构成功创建！",
-    "submodelCreatedError": "创建子模型失败"
+    "submodelCreatedError": "创建子模型失败",
+    "submodelUpdatedSuccess": "子模型已使用{{schemaName}}架构成功更新！",
+    "noSchemaForEdit": "未找到此子模型的匹配架构。无法在表单编辑器中编辑。",
+    "submodelLoadError": "加载子模型数据以进行编辑失败"
   },
   "createDialog": {
     "title": "创建新目录零件",
@@ -271,7 +274,8 @@
       "createNewSubmodel": "创建新的子模型方面",
       "noSubmodels": "无可用子模型",
       "noSubmodelsDescription": "此数字孪生没有任何可供查看的子模型方面。",
-      "submodelsDisplayed": "显示{{count}}个数字孪生子模型"
+      "submodelsDisplayed": "显示{{count}}个数字孪生子模型",
+      "updateSubmodel": "更新子模型"
     },
     "jsonViewer": {
       "title": "JSON查看器",

--- a/ichub-frontend/src/schemas/SingleLevelBomAsPlanned-schema.json
+++ b/ichub-frontend/src/schemas/SingleLevelBomAsPlanned-schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned",
+  "description" : "The single-level bill of material (BoM)represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "UuidV4Trait" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.uuid:2.0.0#UuidV4Trait",
+        "description" : "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI.",
+        "pattern" : "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)"
+      },
+      "DateTimeTrait" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#DateTimeTrait",
+        "description" : "Regular Expression to enable UTC and Timezone formats and the possibility to exclude time information.",
+        "pattern" : "^-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?)?$"
+      },
+      "QuantityValueCharacteristic" : {
+        "type" : "number",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:2.0.0#QuantityValueCharacteristic",
+        "description" : "The quantity value associated with the unit expressed as float."
+      },
+      "ItemUnitEnumeration" : {
+        "type" : "string",
+        "pattern" : "[a-zA-Z]*:[a-zA-Z]+",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:2.0.0#ItemUnitEnumeration",
+        "description" : "Enumeration for common item units.",
+        "enum" : [ "unit:piece", "unit:set", "unit:pair", "unit:page", "unit:cycle", "unit:kilowattHour", "unit:gram", "unit:kilogram", "unit:tonneMetricTon", "unit:tonUsOrShortTonUkorus", "unit:ounceAvoirdupois", "unit:pound", "unit:metre", "unit:centimetre", "unit:kilometre", "unit:inch", "unit:foot", "unit:yard", "unit:squareCentimetre", "unit:squareMetre", "unit:squareInch", "unit:squareFoot", "unit:squareYard", "unit:cubicCentimetre", "unit:cubicMetre", "unit:cubicInch", "unit:cubicFoot", "unit:cubicYard", "unit:litre", "unit:millilitre", "unit:hectolitre", "unit:secondUnitOfTime", "unit:minuteUnitOfTime", "unit:hourUnitOfTime", "unit:day" ]
+      },
+      "ItemQuantityCharacteristic" : {
+        "description" : "Characteristic for measurements of an item (mass, count, linear, area, volume, misc).",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:2.0.0#ItemQuantityCharacteristic",
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "description" : "The quantity value associated with the unit.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue",
+            "$ref" : "#/components/schemas/QuantityValueCharacteristic"
+          },
+          "unit" : {
+            "description" : "The unit of an item. Common units may be related to mass, count, linear, area, volume or misc.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:2.0.0#itemUnit",
+            "$ref" : "#/components/schemas/ItemUnitEnumeration"
+          }
+        },
+        "required" : [ "value", "unit" ]
+      },
+      "ValidityPeriodCharacteristic" : {
+        "description" : "Characteristic for a validity period defined by an (optional)start and an (optional)end timestamp.",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#ValidityPeriodCharacteristic",
+        "type" : "object",
+        "properties" : {
+          "validFrom" : {
+            "description" : "Start date of validity period.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#validFrom",
+            "$ref" : "#/components/schemas/DateTimeTrait"
+          },
+          "validTo" : {
+            "description" : "End date of validity period.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#validTo",
+            "$ref" : "#/components/schemas/DateTimeTrait"
+          }
+        }
+      },
+      "BpnlTrait" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.business_partner_number:2.0.0#BpnlTrait",
+        "description" : "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters.",
+        "pattern" : "^BPNL[a-zA-Z0-9]{12}$"
+      },
+      "ChildData" : {
+        "description" : "Catena-X ID and meta data of the assembled child item.",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#ChildData",
+        "type" : "object",
+        "properties" : {
+          "createdOn" : {
+            "description" : "Timestamp when the relation between the parent part and the child part was created",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#createdOn",
+            "$ref" : "#/components/schemas/DateTimeTrait"
+          },
+          "quantity" : {
+            "description" : "Quantity of which the child part will be assembled into the parent part.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#quantity",
+            "$ref" : "#/components/schemas/ItemQuantityCharacteristic"
+          },
+          "lastModifiedOn" : {
+            "description" : "Timestamp when the relationship between parent part and child part was last modified.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#lastModifiedOn",
+            "$ref" : "#/components/schemas/DateTimeTrait"
+          },
+          "validityPeriod" : {
+            "description" : "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#validityPeriod",
+            "$ref" : "#/components/schemas/ValidityPeriodCharacteristic"
+          },
+          "businessPartner" : {
+            "description" : "The supplier of the given child item.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#businessPartner",
+            "$ref" : "#/components/schemas/BpnlTrait"
+          },
+          "catenaXId" : {
+            "description" : "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#catenaXId",
+            "$ref" : "#/components/schemas/UuidV4Trait"
+          }
+        },
+        "required" : [ "createdOn", "quantity", "businessPartner", "catenaXId" ]
+      },
+      "SetOfChildItemsCharacteristic" : {
+        "description" : "Set of child items the parent object will be assembled by (one structural level down).",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SetOfChildItemsCharacteristic",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/ChildData"
+        },
+        "uniqueItems" : true
+      }
+    }
+  },
+  "properties" : {
+    "catenaXId" : {
+      "description" : "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace.",
+      "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#catenaXId",
+      "$ref" : "#/components/schemas/UuidV4Trait"
+    },
+    "childItems" : {
+      "description" : "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down).",
+      "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#childItems",
+      "$ref" : "#/components/schemas/SetOfChildItemsCharacteristic"
+    }
+  },
+  "required" : [ "catenaXId", "childItems" ]
+}

--- a/ichub-frontend/src/schemas/SingleLevelUsageAsPlanned-schema.json
+++ b/ichub-frontend/src/schemas/SingleLevelUsageAsPlanned-schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema" : "http://json-schema.org/draft-04/schema",
+  "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SingleLevelUsageAsPlanned",
+  "description" : "The aspect provides the information in which parent part(s)/product(s)the given item is to be assembled into or used. This could be a 1:1 relationship in terms of a e.g. a brake component or 1:n for e.g. coatings. The given item as well as the parent item must refer to an object from the as-planned lifecycle phase.\nIf multiple versions of parent parts exist that the child part can be assembled into or used, all versions of the parent part are included in the usage list.",
+  "type" : "object",
+  "components" : {
+    "schemas" : {
+      "QuantityValueCharacteristic" : {
+        "type" : "number",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:3.0.0#QuantityValueCharacteristic",
+        "description" : "The quantity value associated with the unit expressed as float."
+      },
+      "ItemUnitEnumeration" : {
+        "type" : "string",
+        "pattern" : "[a-zA-Z]*:[a-zA-Z]+",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:3.0.0#ItemUnitEnumeration",
+        "description" : "Enumeration for common item units.",
+        "enum" : [ "unit:piece", "unit:set", "unit:pair", "unit:page", "unit:cycle", "unit:kilowattHour", "unit:gram", "unit:kilogram", "unit:tonneMetricTon", "unit:tonUsOrShortTonUkorus", "unit:ounceAvoirdupois", "unit:pound", "unit:metre", "unit:centimetre", "unit:kilometre", "unit:inch", "unit:foot", "unit:yard", "unit:squareCentimetre", "unit:squareMetre", "unit:squareInch", "unit:squareFoot", "unit:squareYard", "unit:cubicCentimetre", "unit:cubicMetre", "unit:cubicInch", "unit:cubicFoot", "unit:cubicYard", "unit:litre", "unit:millilitre", "unit:hectolitre", "unit:secondUnitOfTime", "unit:minuteUnitOfTime", "unit:hourUnitOfTime", "unit:day" ]
+      },
+      "ItemQuantityCharacteristic" : {
+        "description" : "Characteristic for measurements of an item (mass, count, linear, area, volume, misc).",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:3.0.0#ItemQuantityCharacteristic",
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "description" : "The quantity value associated with the unit.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:3.0.0#quantityValue",
+            "$ref" : "#/components/schemas/QuantityValueCharacteristic"
+          },
+          "unit" : {
+            "description" : "The unit of an item. Common units may be related to mass, count, linear, area, volume or misc.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.quantity:3.0.0#itemUnit",
+            "$ref" : "#/components/schemas/ItemUnitEnumeration"
+          }
+        },
+        "required" : [ "value", "unit" ]
+      },
+      "Timestamp" : {
+        "type" : "string",
+        "pattern" : "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?",
+        "x-samm-aspect-model-urn" : "urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#Timestamp",
+        "description" : "Describes a Property which contains the date and time with an optional timezone."
+      },
+      "BpnlTrait" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.business_partner_number:2.0.0#BpnlTrait",
+        "description" : "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters.",
+        "pattern" : "^BPNL[a-zA-Z0-9]{12}$"
+      },
+      "UuidV4Trait" : {
+        "type" : "string",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.uuid:2.0.0#UuidV4Trait",
+        "description" : "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI.",
+        "pattern" : "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)"
+      },
+      "ValidityPeriodCharacteristic" : {
+        "description" : "Characteristic  for a validity period defined by an (optional)start and an (optional)end timestamp.",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#ValidityPeriodCharacteristic",
+        "type" : "object",
+        "properties" : {
+          "validTo" : {
+            "description" : "End date of validity period.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#validTo",
+            "$ref" : "#/components/schemas/Timestamp"
+          },
+          "validFrom" : {
+            "description" : "Start date and time of validity period.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#validFrom",
+            "$ref" : "#/components/schemas/Timestamp"
+          }
+        }
+      },
+      "ParentData" : {
+        "description" : "globalAssetId and meta data of the parent part.",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#ParentData",
+        "type" : "object",
+        "properties" : {
+          "quantity" : {
+            "description" : "Quantity of which the child part will be assembled into or used in the parent part.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#quantity",
+            "$ref" : "#/components/schemas/ItemQuantityCharacteristic"
+          },
+          "createdOn" : {
+            "description" : "Timestamp when the relation between the parent part and the child part was created",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#createdOn",
+            "$ref" : "#/components/schemas/Timestamp"
+          },
+          "businessPartner" : {
+            "description" : "The supplier of the given child item.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#businessPartner",
+            "$ref" : "#/components/schemas/BpnlTrait"
+          },
+          "globalAssetId" : {
+            "description" : "The fully anonymous ID in the dataspace of the part.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#globalAssetId",
+            "$ref" : "#/components/schemas/UuidV4Trait"
+          },
+          "lastModifiedOn" : {
+            "description" : "Timestamp when the assembly or usage relationship between parent part and child part was last modified.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#lastModifiedOn",
+            "$ref" : "#/components/schemas/Timestamp"
+          },
+          "validityPeriod" : {
+            "description" : "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into or used in the production of the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time.",
+            "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#validityPeriod",
+            "$ref" : "#/components/schemas/ValidityPeriodCharacteristic"
+          }
+        },
+        "required" : [ "quantity", "createdOn", "businessPartner", "globalAssetId" ]
+      },
+      "SetOfParentItemsCharacteristic" : {
+        "description" : "Set of parent items the given child object will be assembled into or used (one structural level up).",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#SetOfParentItemsCharacteristic",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/ParentData"
+        },
+        "uniqueItems" : true
+      },
+      "ListOfCustomers" : {
+        "description" : "A list of customers and their related parent items.",
+        "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#ListOfCustomers",
+        "type" : "array",
+        "items" : {
+          "type" : "string",
+          "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.business_partner_number:2.0.0#BpnlTrait",
+          "description" : "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters.",
+          "pattern" : "^BPNL[a-zA-Z0-9]{12}$"
+        }
+      }
+    }
+  },
+  "properties" : {
+    "parentItems" : {
+      "description" : "Set of parent parts, in which the given child object will be assembled into or used (one structural level up).",
+      "x-samm-aspect-model-urn" : "urn:samm:io.catenax.single_level_usage_as_planned:3.0.0#parentItems",
+      "$ref" : "#/components/schemas/SetOfParentItemsCharacteristic"
+    },
+    "customers" : {
+      "description" : "A list of all customers of this item. If the parent items in which this item is assembled into are known, they should be listed as well.\n\nFor serialized items the list should contain only one customer with one parent item.\nAs different subsets of a batch might be sold to different customers this is a list.",
+      "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#customers",
+      "$ref" : "#/components/schemas/ListOfCustomers"
+    },
+    "globalAssetId" : {
+      "description" : "The fully anonymous ID in the dataspace of the part.",
+      "x-samm-aspect-model-urn" : "urn:samm:io.catenax.shared.industry_core.common:1.0.0#globalAssetId",
+      "$ref" : "#/components/schemas/UuidV4Trait"
+    }
+  },
+  "required" : [ "parentItems", "customers", "globalAssetId" ]
+}

--- a/ichub-frontend/src/schemas/index.ts
+++ b/ichub-frontend/src/schemas/index.ts
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 LKS Next
+ * Copyright (c) 2025,2026 LKS Next
  * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2026 Capgemini Deutschland GmbH
  *

--- a/ichub-frontend/src/schemas/index.ts
+++ b/ichub-frontend/src/schemas/index.ts
@@ -35,6 +35,8 @@ import { loadSchemas } from './schemaLoader';
 import digitalProductPassportSchema from './DigitalProductPassport-schema.json';
 import UsTariffInformationSchema from './UsTariffInformation-schema.json';
 import PcfSchema from './Pcf-schema.json';
+import SingleLevelBomAsPlannedSchema from './SingleLevelBomAsPlanned-schema.json';
+import SingleLevelUsageAsPlannedSchema from './SingleLevelUsageAsPlanned-schema.json';
 import { JSONSchema } from './json-schema-interpreter';
 
 export interface SchemaMetadata {
@@ -76,7 +78,9 @@ export interface SchemaDefinition<T = any> {
 const schemasToLoad = [
   digitalProductPassportSchema as JSONSchema,
   UsTariffInformationSchema as JSONSchema,
-  PcfSchema as JSONSchema
+  PcfSchema as JSONSchema,
+  SingleLevelBomAsPlannedSchema as JSONSchema,
+  SingleLevelUsageAsPlannedSchema as JSONSchema
   // Add more schemas here:
   // serialPartSchema as JSONSchema,
   // batchSchema as JSONSchema,

--- a/ichub-frontend/src/schemas/schemaLoader.ts
+++ b/ichub-frontend/src/schemas/schemaLoader.ts
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Eclipse Tractus-X - Industry Core Hub Frontend
  *
- * Copyright (c) 2025 LKS Next
+ * Copyright (c) 2025,2026 LKS Next
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/ichub-frontend/src/schemas/schemaLoader.ts
+++ b/ichub-frontend/src/schemas/schemaLoader.ts
@@ -147,7 +147,9 @@ export function createSchemaKey(semanticId: string): string {
             'digital-product-passport': 'dpp',
             'serial-part': 'sp',
             'batch': 'batch',
-            'part-type-information': 'pti'
+            'part-type-information': 'pti',
+            'single-level-bom-as-planned': 'slbap',
+            'single-level-usage-as-planned': 'sluap'
         };
         
         const key = abbreviations[kebabName] || kebabName;


### PR DESCRIPTION
## WHAT

This pull request adds new policy configurations for two semantic data assets—SingleLevelBomAsPlanned and SingleLevelUsageAsPlanned—across multiple environment-specific YAML files in the `charts/industry-core-hub` directory. These changes define how these assets can be accessed and used, specifying permissions, constraints, and context for both usage and access scenarios.

## WHY

To be able to fullfill the industry core standard.

Closes #616 
