### PR TITLE
feat: update notification endpoint and asset for latest unique id push version

### DIFF
--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -426,6 +426,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibitions: []
             obligations: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
           access:
             context:
               - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -455,6 +471,22 @@ backend:
               - "http://www.w3.org/ns/odrl.jsonld"
               - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
                 "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          consumption:
             permission:
               - action: "use"
                 constraint:

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -444,6 +444,7 @@ backend:
       uniqueIdPush:
         hostname: "https://backend-ichub.int.catena-x.net"
         apiPath: /v1/uniqueidpush
+        sendOnShare: true
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-jupiter.yaml
@@ -440,6 +440,49 @@ backend:
                   rightOperand: "active"
             prohibitions: []
             obligations: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://backend-ichub.int.catena-x.net"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          access:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  leftOperand: "Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibitions: []
+            obligations: []
     submodel_dispatcher:
       path: "/industry-core-hub/data/submodels"
       apiPath: "/submodel-dispatcher"

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -463,6 +463,7 @@ backend:
       uniqueIdPush:
         hostname: "https://backend-ichub-manufacturer.int.catena-x.net"
         apiPath: /v1/uniqueidpush
+        sendOnShare: true
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -445,6 +445,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibitions: []
             obligations: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
           access:
             context:
               - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -474,6 +490,22 @@ backend:
               - "http://www.w3.org/ns/odrl.jsonld"
               - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
                 "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          consumption:
             permission:
               - action: "use"
                 constraint:

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -459,6 +459,49 @@ backend:
                   rightOperand: "active"
             prohibitions: []
             obligations: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://backend-ichub-manufacturer.int.catena-x.net"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          access:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  leftOperand: "Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibitions: []
+            obligations: []
     submodel_dispatcher:
       path: "/industry-core-hub/data/submodels"
       apiPath: "/submodel-dispatcher"

--- a/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer-jupiter.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -459,6 +459,7 @@ backend:
       uniqueIdPush:
         hostname: "https://backend-ichub-manufacturer.int.catena-x.net"
         apiPath: /v1/uniqueidpush
+        sendOnShare: true
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -455,6 +455,47 @@ backend:
                   rightOperand: "active"
             prohibition: []
             obligation: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://backend-ichub-manufacturer.int.catena-x.net"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          access:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "access"
+                constraint:
+                  leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibition: []
+            obligation: []
       pcfExchange:
         # -- Enable or disable PCF Exchange
         enabled: false

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -442,6 +442,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
           access:
             context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -450,7 +466,7 @@ backend:
             permission:
               - action: "access"
                 constraint:
-                  leftOperand: "Membership"
+                  leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
                   operator: "eq"
                   rightOperand: "active"
             prohibition: []
@@ -480,6 +496,22 @@ backend:
                       operator: "eq"
                       rightOperand: "active"
                     - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
                       operator: "isAnyOf"
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -440,6 +440,7 @@ backend:
       uniqueIdPush:
         hostname: "https://backend-ichub.int.catena-x.net"
         apiPath: /v1/uniqueidpush
+        sendOnShare: true
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -1,6 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -423,6 +423,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
           access:
             context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -461,6 +477,22 @@ backend:
                       operator: "eq"
                       rightOperand: "active"
                     - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
                       operator: "isAnyOf"
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -436,6 +436,47 @@ backend:
                   rightOperand: "active"
             prohibition: []
             obligation: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://backend-ichub.int.catena-x.net"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          access:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "access"
+                constraint:
+                  leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibition: []
+            obligation: []
       pcfExchange:
         # -- Enable or disable PCF Exchange
         enabled: false

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -349,6 +349,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibitions: []
             obligations: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
           access:
             context:
               - "https://w3id.org/tractusx/policy/v1.0.0"
@@ -379,6 +395,22 @@ backend:
               - "http://www.w3.org/ns/odrl.jsonld"
               - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
                 "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          consumption:
             permission:
               - action: "use"
                 constraint:

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -367,6 +367,7 @@ backend:
       uniqueIdPush:
         hostname: "https://<backend-hostname>"
         apiPath: /v1/uniqueidpush
+        sendOnShare: false
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-jupiter.yaml
+++ b/charts/industry-core-hub/values-jupiter.yaml
@@ -363,6 +363,50 @@ backend:
                   rightOperand: "active"
             prohibitions: []
             obligations: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://<backend-hostname>"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+          # existing_asset_id: <unique-id-push-asset> # -- In case an existing Unique ID Push asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "eq"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibitions: []
+            obligations: []
+          access:
+            context:
+              - "https://w3id.org/tractusx/policy/v1.0.0"
+              - "http://www.w3.org/ns/odrl.jsonld"
+              - tx: "https://w3id.org/tractusx/v0.0.1/ns/"
+                "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  leftOperand: "Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibitions: []
+            obligations: []
       # -- Submodel Dispatcher configuration
       submodel_dispatcher:
         # -- Storage mode: "filesystem" (local storage) or "http" (external service)

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -372,6 +372,7 @@ backend:
       uniqueIdPush:
         hostname: "https://<backend-hostname>"
         apiPath: /v1/uniqueidpush
+        sendOnShare: false
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -368,6 +368,48 @@ backend:
                   rightOperand: "active"
             prohibition: []
             obligation: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      uniqueIdPush:
+        hostname: "https://<backend-hostname>"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+          # existing_asset_id: <unique-id-push-asset> # -- In case an existing Unique ID Push asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          access:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "access"
+                constraint:
+                  leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibition: []
+            obligation: []
       pcfExchange:
         # -- Enable or disable PCF Exchange
         enabled: false

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -355,6 +355,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
           access:
             context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -394,6 +410,22 @@ backend:
                       operator: "eq"
                       rightOperand: "active"
                     - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
                       operator: "isAnyOf"
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -649,6 +649,7 @@ backend:
       uniqueIdPush:
         hostname: "https://<backend-hostname>"
         apiPath: /v1/uniqueidpush
+        sendOnShare: false
         uri: ""
         asset_config:
           dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -630,6 +630,22 @@ backend:
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []
             obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
           access:
             context:
               - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
@@ -671,6 +687,22 @@ backend:
                       operator: "eq"
                       rightOperand: "active"
                     - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          consumption:
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "UsagePurpose"
                       operator: "isAnyOf"
                       rightOperand: "cx.core.industrycore:1"
             prohibition: []

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -1,7 +1,7 @@
 ###############################################################
 # Eclipse Tractus-X - Industry Core Hub
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2026 Contributors to the Eclipse Foundation
 # Copyright (c) 2026 Capgemini Deutschland GmbH
 #

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -643,6 +643,50 @@ backend:
                   rightOperand: "active"
             prohibition: []
             obligation: []
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      # -- Unique ID Push notification endpoint configuration (CX-0126)
+      # -- hostname points to the ichub-backend itself, which serves this endpoint
+      uniqueIdPush:
+        hostname: "https://<backend-hostname>"
+        apiPath: /v1/uniqueidpush
+        uri: ""
+        asset_config:
+          dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+          # existing_asset_id: <unique-id-push-asset> # -- In case an existing Unique ID Push asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+        policy:
+          usage:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "use"
+                constraint:
+                  and:
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/FrameworkAgreement"
+                      operator: "eq"
+                      rightOperand: "DataExchangeGovernance:1.0"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                      operator: "eq"
+                      rightOperand: "active"
+                    - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                      operator: "isAnyOf"
+                      rightOperand: "cx.core.industrycore:1"
+            prohibition: []
+            obligation: []
+          access:
+            context:
+              - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+              - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+              - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            permission:
+              - action: "access"
+                constraint:
+                  leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+            prohibition: []
+            obligation: []
       # -- PCF Exchange configuration
       pcfExchange:
         # -- Enable or disable PCF Exchange. Keep this disabled until a real hostname is configured.

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -605,6 +605,7 @@ provider:
   uniqueIdPush:
     hostname: "http://localhost:9000"
     apiPath: /v1/uniqueidpush
+    sendOnShare: false
     uri: ""
     asset_config:
       dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -602,6 +602,47 @@ provider:
               rightOperand: "active"
         prohibitions: []
         obligations: []
+  uniqueIdPush:
+    hostname: "http://<provider-unique-id-push-api>"
+    apiPath: /api/v1
+    uri: ""
+    asset_config:
+      dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
+      # existing_asset_id: <unique-id-push-asset> # -- In case an existing Unique ID Push asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+    policy:
+      usage:
+        context:
+          - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+          - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+          - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+        permissions:
+          - action: "use"
+            constraint:
+              and:
+                - leftOperand: "https://w3id.org/catenax/2025/9/policy/FrameworkAgreement"
+                  operator: "eq"
+                  rightOperand: "DataExchangeGovernance:1.0"
+                - leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+                  operator: "eq"
+                  rightOperand: "active"
+                - leftOperand: "https://w3id.org/catenax/2025/9/policy/UsagePurpose"
+                  operator: "isAnyOf"
+                  rightOperand: "cx.core.industrycore:1"
+        prohibitions: []
+        obligations: []
+      access:
+        context:
+          - "https://w3id.org/catenax/2025/9/policy/odrl.jsonld"
+          - "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+          - "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+        permissions:
+          - action: "access"
+            constraint:
+              leftOperand: "https://w3id.org/catenax/2025/9/policy/Membership"
+              operator: "eq"
+              rightOperand: "active"
+        prohibitions: []
+        obligations: []
   pcfExchange:
     enabled: false
     hostname: "https://<provider-pcf-exchange-api>"

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -603,8 +603,8 @@ provider:
         prohibitions: []
         obligations: []
   uniqueIdPush:
-    hostname: "http://<provider-unique-id-push-api>"
-    apiPath: /api/v1
+    hostname: "http://localhost:9000"
+    apiPath: /v1/uniqueidpush
     uri: ""
     asset_config:
       dct_type: "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -1,6 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation

--- a/ichub-backend/controllers/fastapi/app.py
+++ b/ichub-backend/controllers/fastapi/app.py
@@ -29,60 +29,14 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 import os
-import logging
-
-from tools.exceptions import BaseError, ValidationError
+from tools.exceptions import BaseError
 from tools.constants import API_V1
 from managers.config.config_manager import ConfigManager
 
-startup_logger = logging.getLogger("app.startup")
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Run startup tasks before serving requests."""
-    _sync_digital_twin_event_asset_on_startup()
+    """Application lifespan handler. Asset registration is handled by the Kubernetes asset-sync Job."""
     yield
-
-
-def _sync_digital_twin_event_asset_on_startup() -> None:
-    """
-    Register the Digital Twin Event asset in the EDC on every backend startup.
-    This ensures the notification endpoint is always advertised in the connector
-    catalog, even if the Kubernetes sync Job has not run yet.
-    Failures are logged but do not prevent the backend from starting.
-    """
-    try:
-        # Import here to avoid circular imports at module load time.
-        from connector import connector_provider_manager, connector_start_up_error
-
-        if connector_start_up_error or connector_provider_manager is None:
-            startup_logger.warning(
-                "[Startup] Connector is not available. Skipping Digital Twin Event asset sync."
-            )
-            return
-
-        dte_config = ConfigManager.get_config("provider.digitalTwinEventAPI")
-        if not dte_config:
-            startup_logger.warning(
-                "[Startup] No 'provider.digitalTwinEventAPI' config found. "
-                "Skipping Digital Twin Event asset sync."
-            )
-            return
-
-        asset_config = dte_config.get("asset_config", {})
-        dte_asset_id, _, _, _ = connector_provider_manager.register_digital_twin_event_offer(
-            digital_twin_event_url=dte_config.get("hostname"),
-            digital_twin_event_policy_config=dte_config.get("policy"),
-            existing_asset_id=asset_config.get("existing_asset_id"),
-        )
-        startup_logger.info(
-            f"[Startup] Digital Twin Event asset synced successfully: {dte_asset_id}"
-        )
-    except Exception as e:
-        startup_logger.error(
-            f"[Startup] Failed to sync Digital Twin Event asset: {e}", exc_info=True
-        )
 
 from tractusx_sdk.dataspace.tools import op
 
@@ -99,7 +53,8 @@ from .routers.consumer.v1 import (
 )
 from .routers.notifications.v1 import (
     digital_twin_event_api,
-    notifications_management
+    notifications_management,
+    unique_id_push_api
 )
 from .routers.addons import addons
 
@@ -139,6 +94,10 @@ tags_metadata = [
     {
         "name": "Notifications Management",
         "description": "Endpoints for managing notifications, such as retrieving, deleting or marking notifications related to digital twins and part sharing"
+    },
+    {
+        "name": "Unique ID Push Notifications",
+        "description": "Endpoints for receiving Unique ID Push notifications (CX-0126) to link child digital twins to their parents"
     },
     {
         "name": "Add-Ons Microservices",
@@ -227,6 +186,7 @@ v1_router.include_router(connection_management.router)
 v1_router.include_router(discovery_management.router)
 v1_router.include_router(digital_twin_event_api.router)
 v1_router.include_router(notifications_management.router)
+v1_router.include_router(unique_id_push_api.router)
 v1_router.include_router(addons.router)
 
 # Include the API version 1 router into the main app
@@ -260,7 +220,8 @@ def custom_openapi():
                 "Open Connection Management",
                 "Part Discovery Management",
                 "Digital Twin Event Management",
-                "Notifications Management"
+                "Notifications Management",
+                "Unique ID Push Notifications"
             ],
         },
         {

--- a/ichub-backend/controllers/fastapi/routers/notifications/v1/unique_id_push_api.py
+++ b/ichub-backend/controllers/fastapi/routers/notifications/v1/unique_id_push_api.py
@@ -1,0 +1,70 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import Response, JSONResponse
+
+from controllers.fastapi.routers.authentication.auth_api import get_authentication_dependency
+from managers.config.log_manager import LoggingManager
+from models.metadata_database.notification.models import NotificationDirection
+from models.services.notification.unique_id_push import UniqueIdPushConnectToParentRequest
+from services.notifications.notifications_management_service import NotificationsManagementService
+from services.notifications.unique_id_push_service import UniqueIdPushService
+from tools.constants import INTERNAL_SERVER_ERROR
+from tools.exceptions import NotificationCreationError
+
+logger = LoggingManager.get_logger(__name__)
+
+notification_management_service = NotificationsManagementService()
+unique_id_push_service = UniqueIdPushService(notification_management_service)
+
+router = APIRouter(
+    prefix="/uniqueidpush",
+    tags=["Unique ID Push Notifications"],
+    dependencies=[Depends(get_authentication_dependency())],
+)
+
+
+@router.post("/connect-to-parent")
+async def connect_to_parent(request: UniqueIdPushConnectToParentRequest) -> Response:
+    """
+    Receive a Unique ID Push Connect-to-Parent notification.
+
+    This endpoint is called by data providers to notify the parent
+    manufacturer about newly created digital twins that should be
+    linked in the parent's bill-of-material.
+    """
+    try:
+        unique_id_push_service.receive_connect_to_parent(
+            request, direction=NotificationDirection.INCOMING
+        )
+        return Response(status_code=201)
+    except NotificationCreationError as e:
+        return JSONResponse(
+            status_code=e.status_code, content={"detail": e.detail.model_dump()}
+        )
+    except Exception as e:
+        logger.exception("Unhandled error in uniqueidpush/connect-to-parent endpoint")
+        return JSONResponse(
+            status_code=500, content={"detail": INTERNAL_SERVER_ERROR}
+        )

--- a/ichub-backend/controllers/fastapi/routers/notifications/v1/unique_id_push_api.py
+++ b/ichub-backend/controllers/fastapi/routers/notifications/v1/unique_id_push_api.py
@@ -30,7 +30,6 @@ from models.metadata_database.notification.models import NotificationDirection
 from models.services.notification.unique_id_push import UniqueIdPushConnectToParentRequest
 from services.notifications.notifications_management_service import NotificationsManagementService
 from services.notifications.unique_id_push_service import UniqueIdPushService
-from tools.constants import INTERNAL_SERVER_ERROR
 from tools.exceptions import NotificationCreationError
 
 logger = LoggingManager.get_logger(__name__)
@@ -45,7 +44,19 @@ router = APIRouter(
 )
 
 
-@router.post("/connect-to-parent")
+@router.post(
+    "/connect-to-parent",
+    status_code=201,
+    responses={
+        201: {"description": "Notification was received successfully"},
+        400: {"description": "Request body was malformed"},
+        401: {"description": "Not authorized"},
+        403: {"description": "Forbidden"},
+        405: {"description": "Method not allowed"},
+        409: {"description": "Could not accept the send notification, because a notification with that messageId already exists"},
+        422: {"description": "Could not accept the send notification even though it is syntactically correct. The notification is not accepted, because of semantic reasons (e.g., an item is not known by the receiver)."},
+    },
+)
 async def connect_to_parent(request: UniqueIdPushConnectToParentRequest) -> Response:
     """
     Receive a Unique ID Push Connect-to-Parent notification.
@@ -55,6 +66,15 @@ async def connect_to_parent(request: UniqueIdPushConnectToParentRequest) -> Resp
     linked in the parent's bill-of-material.
     """
     try:
+        # Duplicate check
+        if notification_management_service.notification_exists(request.header.message_id):
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "description": "Could not accept the send notification, because a notification with that messageId already exists"
+                },
+            )
+
         unique_id_push_service.receive_connect_to_parent(
             request, direction=NotificationDirection.INCOMING
         )
@@ -66,5 +86,5 @@ async def connect_to_parent(request: UniqueIdPushConnectToParentRequest) -> Resp
     except Exception as e:
         logger.exception("Unhandled error in uniqueidpush/connect-to-parent endpoint")
         return JSONResponse(
-            status_code=500, content={"detail": INTERNAL_SERVER_ERROR}
+            status_code=500, content={"description": "Internal server error"}
         )

--- a/ichub-backend/jobs/asset_sync_job.py
+++ b/ichub-backend/jobs/asset_sync_job.py
@@ -1,7 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
-# Copyright (c) 2025 LKS Next
+# Copyright (c) 2025,2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/jobs/asset_sync_job.py
+++ b/ichub-backend/jobs/asset_sync_job.py
@@ -162,7 +162,8 @@ class AssetSyncJob:
             asset_config = uid_config.get("asset_config", {})
 
             uid_asset_id, _, _, _ = self.connector_provider_manager.register_unique_id_push_offer(
-                unique_id_push_url=uid_config.get("hostname"),
+                hostname=uid_config.get("hostname"),
+                api_path=uid_config.get("apiPath", "/v1/uniqueidpush"),
                 unique_id_push_policy_config=uid_config.get("policy"),
                 existing_asset_id=asset_config.get("existing_asset_id", None),
                 dct_type=asset_config.get(

--- a/ichub-backend/jobs/asset_sync_job.py
+++ b/ichub-backend/jobs/asset_sync_job.py
@@ -71,7 +71,10 @@ class AssetSyncJob:
             # Step 3: Sync Digital Twin Event asset
             self._sync_digital_twin_event_asset()
 
-            # Step 4: Sync PCF Exchange asset if enabled
+            # Step 4: Sync Unique ID Push asset
+            self._sync_unique_id_push_asset()
+
+            # Step 5: Sync PCF Exchange asset if enabled
             if self._pcf_kit_enablement_check():
                 self._sync_pcf_exchange_asset()
             
@@ -143,6 +146,38 @@ class AssetSyncJob:
                 
         except Exception as e:
             logger.error(f"[AssetSyncJob] Error synchronizing DTE asset: {e}", exc_info=True)
+
+    def _sync_unique_id_push_asset(self) -> None:
+        """
+        Synchronize the Unique ID Push notification asset with the connector.
+        """
+        try:
+            logger.info("[AssetSyncJob] Synchronizing Unique ID Push asset...")
+
+            uid_config = ConfigManager.get_config("provider.uniqueIdPush")
+            if not uid_config:
+                logger.warning("[AssetSyncJob] No Unique ID Push configuration found. Skipping sync.")
+                return
+
+            asset_config = uid_config.get("asset_config", {})
+
+            uid_asset_id, _, _, _ = self.connector_provider_manager.register_unique_id_push_offer(
+                unique_id_push_url=uid_config.get("hostname"),
+                unique_id_push_policy_config=uid_config.get("policy"),
+                existing_asset_id=asset_config.get("existing_asset_id", None),
+                dct_type=asset_config.get(
+                    "dct_type",
+                    "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification",
+                ),
+            )
+
+            if uid_asset_id:
+                logger.info(f"[AssetSyncJob] Unique ID Push asset synchronized: {uid_asset_id}")
+            else:
+                logger.error("[AssetSyncJob] Failed to synchronize Unique ID Push asset.")
+
+        except Exception as e:
+            logger.error(f"[AssetSyncJob] Error synchronizing Unique ID Push asset: {e}", exc_info=True)
     
     def _sync_semantic_assets(self) -> None:
         """

--- a/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
@@ -491,6 +491,113 @@ class ConnectorProviderManager:
             headers=headers
         )
 
+    def register_unique_id_push_offer(
+        self,
+        unique_id_push_url: str,
+        unique_id_push_policy_config: dict = None,
+        existing_asset_id: str = None,
+        dct_type: str = "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification",
+        version: str = "2.0",
+        headers: dict = None,
+    ) -> tuple[str, str, str, str]:
+        """
+        Register a Unique ID Push notification asset, create policies and contract for it.
+
+        Returns a tuple: (asset_id, usage_policy_id, access_policy_id, contract_id)
+        """
+        if self.authorization:
+            headers = {
+                self.backend_api_key: self.backend_api_key_value
+            }
+
+        # Step 1: Create or get the Unique ID Push asset
+        asset_id = self.get_or_create_unique_id_push_asset(
+            unique_id_push_url=unique_id_push_url,
+            existing_asset_id=existing_asset_id,
+            dct_type=dct_type,
+            version=version,
+            headers=headers,
+        )
+
+        # Step 2: Create or get policies and contract
+        policy_config = unique_id_push_policy_config or self.empty_policy
+        usage_policy_id, access_policy_id, contract_id = self.get_or_create_contract_with_policies(
+            asset_id=asset_id,
+            policy_config=policy_config,
+        )
+
+        return asset_id, usage_policy_id, access_policy_id, contract_id
+
+    def get_or_create_unique_id_push_asset(
+        self,
+        unique_id_push_url: str,
+        existing_asset_id: str = None,
+        dct_type: str = "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification",
+        version: str = "2.0",
+        headers: dict = None,
+    ) -> str:
+        """Get or create the Unique ID Push notification asset in the connector."""
+        if not existing_asset_id:
+            existing_asset_id = self.generate_unique_id_push_asset_id(unique_id_push_url)
+
+        # Check if the asset already exists
+        existing_asset = self.connector_service.assets.get_by_id(oid=existing_asset_id)
+        if existing_asset.status_code == 200:
+            logger.debug(f"[UniqueIdPush] Asset with ID {existing_asset_id} already exists.")
+            return existing_asset_id
+
+        # Create the asset
+        logger.info(f"[UniqueIdPush] Creating new asset with ID {existing_asset_id}.")
+        try:
+            asset = self.create_unique_id_push_asset(
+                asset_id=existing_asset_id,
+                notification_endpoint_url=unique_id_push_url,
+                dct_type=dct_type,
+                version=version,
+                headers=headers,
+            )
+        except ValueError as e:
+            logger.error(
+                f"[UniqueIdPush] Failed to register asset with ID {existing_asset_id} "
+                f"for URL '{unique_id_push_url}'. Error: {e}"
+            )
+            raise
+        logger.info(f"[UniqueIdPush] Successfully registered asset with ID {existing_asset_id}.")
+        return asset.get("@id", existing_asset_id)
+
+    def generate_unique_id_push_asset_id(self, unique_id_push_url: str) -> str:
+        """Generate a unique asset ID for the Unique ID Push asset."""
+        return "ichub:asset:uniqueidpush:" + blake2b_128bit(unique_id_push_url)
+
+    def create_unique_id_push_asset(
+        self,
+        asset_id: str,
+        notification_endpoint_url: str,
+        dct_type: str = "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification",
+        version: str = "2.0",
+        headers: dict = None,
+    ):
+        """
+        Create the Unique ID Push asset directly via the connector provider service.
+
+        Uses the generic create_asset method with the appropriate dct:type for
+        UniqueIdPushConnectToParentNotification.
+        """
+        proxy_params = {
+            "proxyQueryParams": "false",
+            "proxyPath": "true",
+            "proxyMethod": "true",
+            "proxyBody": "true",
+        }
+        return self.connector_service.create_asset(
+            asset_id=asset_id,
+            base_url=notification_endpoint_url,
+            dct_type=dct_type,
+            version=version,
+            proxy_params=proxy_params,
+            headers=headers,
+        )
+
     def register_pcf_exchange_offer(self,
                            base_url:str=None,
                            api_path:str = "/v1/addons/pcf-kit/footprintExchange", 

--- a/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
@@ -21,7 +21,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 from tractusx_sdk.dataspace.services.connector import BaseConnectorProviderService
 from tractusx_sdk.industry.services.notifications import NotificationService
 from managers.config.log_manager import LoggingManager
@@ -493,7 +493,8 @@ class ConnectorProviderManager:
 
     def register_unique_id_push_offer(
         self,
-        unique_id_push_url: str,
+        hostname: str,
+        api_path: str = "/v1/uniqueidpush",
         unique_id_push_policy_config: dict = None,
         existing_asset_id: str = None,
         dct_type: str = "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification",
@@ -505,6 +506,10 @@ class ConnectorProviderManager:
 
         Returns a tuple: (asset_id, usage_policy_id, access_policy_id, contract_id)
         """
+        unique_id_push_url = urljoin(
+            hostname.rstrip("/") + "/", api_path.lstrip("/")
+        )
+
         if self.authorization:
             headers = {
                 self.backend_api_key: self.backend_api_key_value

--- a/ichub-backend/models/services/notification/unique_id_push.py
+++ b/ichub-backend/models/services/notification/unique_id_push.py
@@ -158,9 +158,6 @@ class UniqueIdPushConnectToParentRequest(BaseModel):
         # Build a NotificationContent with extra fields allowed
         notification_content = NotificationContent(
             information=self.content.information,
-            listOfAffectedItems=[
-                item.catena_x_id for item in self.content.list_of_items
-            ],
             # Store the full typed payload as extra fields
             digitalTwinType=self.content.digital_twin_type.value,
             listOfItems=[

--- a/ichub-backend/models/services/notification/unique_id_push.py
+++ b/ichub-backend/models/services/notification/unique_id_push.py
@@ -1,0 +1,175 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from enum import Enum
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from tractusx_sdk.industry.models.notifications import Notification, NotificationHeader, NotificationContent
+
+
+class DigitalTwinType(str, Enum):
+    """Type of digital twin being referenced in the notification."""
+    PART_TYPE = "PartType"
+    PART_INSTANCE = "PartInstance"
+
+
+class PartItem(BaseModel):
+    """
+    Base item identifying a part by manufacturer and partner IDs.
+    All item types in the Unique ID Push payload share these fields.
+    """
+    manufacturer_id: str = Field(
+        ...,
+        alias="manufacturerId",
+        description="BPN of the manufacturer (BPNL)",
+    )
+    manufacturer_part_id: str = Field(
+        ...,
+        alias="manufacturerPartId",
+        description="Part ID assigned by the manufacturer",
+    )
+    customer_part_id: Optional[str] = Field(
+        default=None,
+        alias="customerPartId",
+        description="Part ID assigned by the customer (optional)",
+    )
+    catena_x_id: str = Field(
+        ...,
+        alias="catenaXId",
+        description="Catena-X identifier (UUID, optionally prefixed with urn:uuid:)",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class SerializedPartItem(PartItem):
+    """Item for a specific serialized part instance."""
+    part_instance_id: str = Field(
+        ...,
+        alias="partInstanceId",
+        description="Unique identifier of the serialized part instance",
+    )
+
+
+class BatchItem(PartItem):
+    """Item for a batch of parts."""
+    batch_id: str = Field(
+        ...,
+        alias="batchId",
+        description="Identifier of the batch",
+    )
+
+
+class JISItem(PartItem):
+    """Item for a Just-In-Sequence (JIS) delivery."""
+    jis_number: str = Field(
+        ...,
+        alias="jisNumber",
+        description="JIS number identifying the delivery sequence",
+    )
+    jis_call_date: Optional[str] = Field(
+        default=None,
+        alias="jisCallDate",
+        description="Date of the JIS call (ISO 8601)",
+    )
+    parent_order_number: Optional[str] = Field(
+        default=None,
+        alias="parentOrderNumber",
+        description="Parent order number associated with the JIS delivery",
+    )
+
+
+# Union type for all possible item types in the list
+UniqueIdPushItem = Union[JISItem, BatchItem, SerializedPartItem, PartItem]
+
+
+class UniqueIdPushContent(BaseModel):
+    """
+    Content payload for Unique ID Push Connect-to-Parent notifications.
+
+    Follows io.catenax.unique_id_push_connect_to_parent_notification:2.0.0.
+    """
+    digital_twin_type: DigitalTwinType = Field(
+        ...,
+        alias="digitalTwinType",
+        description="Type of digital twin (PartType or PartInstance)",
+    )
+    information: Optional[str] = Field(
+        default=None,
+        description="Optional human-readable description",
+    )
+    list_of_items: List[UniqueIdPushItem] = Field(
+        ...,
+        alias="listOfItems",
+        min_length=1,
+        description="Non-empty list of items being pushed to the parent",
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+class UniqueIdPushConnectToParentRequest(BaseModel):
+    """
+    Full request body for POST /uniqueidpush/connect-to-parent.
+
+    Contains a standard Catena-X message header (v3.0.0) and the
+    Unique ID Push content payload.
+    """
+    header: NotificationHeader = Field(
+        ...,
+        description="Message header (io.catenax.shared.message_header:3.0.0)",
+    )
+    content: UniqueIdPushContent = Field(
+        ...,
+        description="Unique ID Push notification content",
+    )
+
+    model_config = {"populate_by_name": True}
+
+    def to_notification(self) -> Notification:
+        """
+        Convert to the generic SDK Notification model for internal storage.
+
+        This bridges the strongly-typed Unique ID Push request into the
+        generic notification format used by the persistence layer.
+        """
+        # Build a NotificationContent with extra fields allowed
+        notification_content = NotificationContent(
+            information=self.content.information,
+            listOfAffectedItems=[
+                item.catena_x_id for item in self.content.list_of_items
+            ],
+            # Store the full typed payload as extra fields
+            digitalTwinType=self.content.digital_twin_type.value,
+            listOfItems=[
+                item.model_dump(by_alias=True, exclude_none=True)
+                for item in self.content.list_of_items
+            ],
+        )
+
+        return Notification(
+            header=self.header,
+            content=notification_content,
+        )

--- a/ichub-backend/services/notifications/notifications_management_service.py
+++ b/ichub-backend/services/notifications/notifications_management_service.py
@@ -46,6 +46,8 @@ from dtr import dtr_manager
 
 logger = LoggingManager.get_logger(__name__)
 
+_USE_CONFIG_POLICIES = object()
+
 class NotificationsManagementService():
     """
     Service class for managing notifications.
@@ -211,7 +213,7 @@ class NotificationsManagementService():
             logger.error(f"Error deleting notification: {e}")
             raise NotificationDeleteError(f"Failed to delete notification: {e}")
 
-    def send_notification(self, message_id: UUID, endpoint_url: Optional[str], provider_bpn: str, provider_dsp_url: Optional[str], list_policies: Optional[List[Dict]], dct_type: Optional[str] = None) -> None:
+    def send_notification(self, message_id: UUID, endpoint_url: Optional[str], provider_bpn: str, provider_dsp_url: Optional[str], list_policies=_USE_CONFIG_POLICIES, dct_type: Optional[str] = None) -> None:
         """
         Send a notification to the specified endpoint using the connector consumer service.
         Retrieves the notification from the database using the message_id.
@@ -222,9 +224,10 @@ class NotificationsManagementService():
         If ``provider_dsp_url`` is None, the DSP URL is resolved automatically
         from the connector discovery cache for the given ``provider_bpn``.
 
-        If ``list_policies`` is None or empty, the policy defined at
-        ``provider.digitalTwinEventAPI.policy.usage`` in ``configuration.yml`` is
-        used as the fallback.
+        If ``list_policies`` is the default sentinel, the policy defined at
+        ``provider.digitalTwinEventAPI.policy.consumption`` in ``configuration.yml`` is
+        used as the fallback.  If ``list_policies`` is explicitly ``None``, no
+        policy filtering is applied (accept any offer from the provider).
 
         If ``dct_type`` is provided, it is used as the EDC asset ``dct:type``
         filter for catalog negotiation.  Defaults to
@@ -246,13 +249,20 @@ class NotificationsManagementService():
                     f"DSP URL [{resolved_dsp_url}] for BPN [{provider_bpn}]"
                 )
 
-            # Resolve policies: caller-supplied takes precedence over config fallback
-            resolved_policies = list_policies
-            if not resolved_policies:
-                dte_policy = ConfigManager.get_config("provider.digitalTwinEventAPI.policy.usage")
+            # Resolve policies: explicit None means accept any policy from provider;
+            # sentinel (default) means use config fallback; explicit list is used as-is.
+            if list_policies is _USE_CONFIG_POLICIES:
+                dte_policy = ConfigManager.get_config("provider.digitalTwinEventAPI.policy.consumption")
                 if dte_policy:
                     resolved_policies = [dte_policy]
-                    logger.debug("[Notifications] No governance provided; using provider.digitalTwinEventAPI.policy.usage from configuration")
+                    logger.debug("[Notifications] Using provider.digitalTwinEventAPI.policy.consumption from configuration")
+                else:
+                    resolved_policies = []
+                    logger.warning("[Notifications] No consumption policy configured; will reject all offers")
+            elif list_policies is None:
+                resolved_policies = None
+            else:
+                resolved_policies = list_policies
 
             with RepositoryManagerFactory().create() as repos:
                 db_notification = repos.notification_repository.find_by_message_id(

--- a/ichub-backend/services/notifications/notifications_management_service.py
+++ b/ichub-backend/services/notifications/notifications_management_service.py
@@ -29,6 +29,7 @@ from typing import List, Optional, Dict
 from tractusx_sdk.industry.models.notifications import Notification
 from tractusx_sdk.industry.services.notifications import NotificationConsumerService
 from tractusx_sdk.industry.services.notifications.exceptions import NotificationError
+from tractusx_sdk.industry.constants import DIGITAL_TWIN_EVENT_API_TYPE
 from tractusx_sdk.dataspace.services.connector.base_connector_consumer import BaseConnectorConsumerService
 
 from managers.config.config_manager import ConfigManager
@@ -57,22 +58,27 @@ class NotificationsManagementService():
     @staticmethod
     def _derive_endpoint_path(context: str) -> str:
         """
-        Derive the DigitalTwinEventAPI endpoint path from a notification context string.
+        Derive the endpoint path from a notification context string.
 
-        Example: ``IndustryCore-DigitalTwinEventAPI-ConnectToParent:3.0.0``
-                 → ``/connect-to-parent``
+        Strips the known prefix (e.g. ``DigitalTwinEventAPI-`` or ``UniqueIDPush-``)
+        and converts the remaining CamelCase operation name to kebab-case.
+
+        Examples:
+          ``IndustryCore-DigitalTwinEventAPI-ConnectToParent:3.0.0`` → ``/connect-to-parent``
+          ``IndustryCore-UniqueIDPush-ConnectToParent:2.0.0``        → ``/connect-to-parent``
         """
-        try:
-            marker = "DigitalTwinEventAPI-"
-            idx = context.index(marker) + len(marker)
-            type_name = context[idx:].split(":")[0]  # e.g. "ConnectToParent"
-            kebab = re.sub(r"([A-Z])", r"-\1", type_name).lower().lstrip("-")
-            return f"/{kebab}"
-        except (ValueError, IndexError):
-            logger.warning(
-                f"[Notifications] Could not derive endpoint path from context '{context}', using empty path"
-            )
-            return ""
+        for marker in ("DigitalTwinEventAPI-", "UniqueIDPush-"):
+            try:
+                idx = context.index(marker) + len(marker)
+                type_name = context[idx:].split(":")[0]  # e.g. "ConnectToParent"
+                kebab = re.sub(r"([A-Z])", r"-\1", type_name).lower().lstrip("-")
+                return f"/{kebab}"
+            except ValueError:
+                continue
+        logger.warning(
+            f"[Notifications] Could not derive endpoint path from context '{context}', using empty path"
+        )
+        return ""
 
     @staticmethod
     def _build_location(message_id: UUID) -> str:
@@ -81,20 +87,23 @@ class NotificationsManagementService():
         """
         return f"{SEM_ID_NOTIFICATION}:{message_id}"
 
-    def _remove_existing_edr_for_digital_twin_event_api(self, provider_bpn: str) -> None:
+    def _purge_edrs_for_notification(self, provider_bpn: str) -> None:
         """
-        Before sending a notification, remove any cached EDR for the
-        DigitalTwinEventAPI asset of this provider so we never reuse a stale token.
-        Delegates to the DTR manager's reusable purge helper.
+        Before sending a notification, remove any cached EDR for this provider's
+        notification assets so we never reuse a stale token.
         """
         rows = dtr_manager.purge_edrs_matching(
             counter_party_id=provider_bpn,
-            asset_id_pattern="ichub:asset:digitaltwin-event:%",
+            asset_id_pattern="ichub:asset:%",
         )
         logger.debug(
-            f"[Notifications] Purged {rows} stale DigitalTwinEventAPI EDR(s) "
-            f"for provider [{provider_bpn}]"
+            f"[Notifications] Purged {rows} stale EDR(s) for provider [{provider_bpn}]"
         )
+
+    def notification_exists(self, message_id: UUID) -> bool:
+        """Check whether a notification with the given messageId already exists."""
+        with RepositoryManagerFactory().create() as repos:
+            return repos.notification_repository.find_by_message_id(message_id) is not None
 
     def create_notification(self, notification: Notification, direction: NotificationDirection, use_case: str = None) -> NotificationEntity:
         """
@@ -202,7 +211,7 @@ class NotificationsManagementService():
             logger.error(f"Error deleting notification: {e}")
             raise NotificationDeleteError(f"Failed to delete notification: {e}")
 
-    def send_notification(self, message_id: UUID, endpoint_url: Optional[str], provider_bpn: str, provider_dsp_url: Optional[str], list_policies: Optional[List[Dict]]) -> None:
+    def send_notification(self, message_id: UUID, endpoint_url: Optional[str], provider_bpn: str, provider_dsp_url: Optional[str], list_policies: Optional[List[Dict]], dct_type: Optional[str] = None) -> None:
         """
         Send a notification to the specified endpoint using the connector consumer service.
         Retrieves the notification from the database using the message_id.
@@ -216,6 +225,10 @@ class NotificationsManagementService():
         If ``list_policies`` is None or empty, the policy defined at
         ``provider.digitalTwinEventAPI.policy.usage`` in ``configuration.yml`` is
         used as the fallback.
+
+        If ``dct_type`` is provided, it is used as the EDC asset ``dct:type``
+        filter for catalog negotiation.  Defaults to
+        ``DIGITAL_TWIN_EVENT_API_TYPE`` when not supplied.
         """
         try:
             # Resolve DSP URL: use provided value or fall back to connector discovery
@@ -242,7 +255,6 @@ class NotificationsManagementService():
                     logger.debug("[Notifications] No governance provided; using provider.digitalTwinEventAPI.policy.usage from configuration")
 
             with RepositoryManagerFactory().create() as repos:
-                self._remove_existing_edr_for_digital_twin_event_api(provider_bpn)
                 db_notification = repos.notification_repository.find_by_message_id(
                     message_id=message_id
                 )
@@ -254,6 +266,9 @@ class NotificationsManagementService():
                 semantic_id=SEM_ID_NOTIFICATION
             )
             notification = db_notification.to_sdk(payload)
+
+            resolved_dct_type = dct_type or DIGITAL_TWIN_EVENT_API_TYPE
+            self._purge_edrs_for_notification(provider_bpn)
 
             # Stamp the actual dispatch time so sentDateTime in the payload reflects
             # when the message left this system, not when it was pre-created.
@@ -274,12 +289,20 @@ class NotificationsManagementService():
                 verbose=True
             )
 
-            result = notification_service.send_notification(
+            # Use get_notification_endpoint + send_notification_to_endpoint so we can
+            # pass the correct dct_type (DigitalTwinEventAPI vs UniqueIdPush, etc.)
+            # instead of relying on the SDK's hardcoded DigitalTwinEventAPI default.
+            edc_endpoint, access_token = notification_service.get_notification_endpoint(
                 provider_bpn=provider_bpn,
                 provider_dsp_url=resolved_dsp_url,
+                policies=resolved_policies,
+                dct_type=resolved_dct_type,
+            )
+            result = notification_service.send_notification_to_endpoint(
+                endpoint_url=edc_endpoint,
+                access_token=access_token,
                 notification=notification,
                 endpoint_path=resolved_endpoint,
-                policies=resolved_policies
             )
             self.update_notification_status(
                 message_id=message_id,

--- a/ichub-backend/services/notifications/notifications_management_service.py
+++ b/ichub-backend/services/notifications/notifications_management_service.py
@@ -289,12 +289,12 @@ class NotificationsManagementService():
                 verbose=True
             )
 
-            # Use get_notification_endpoint + send_notification_to_endpoint so we can
-            # pass the correct dct_type (DigitalTwinEventAPI vs UniqueIdPush, etc.)
-            # instead of relying on the SDK's hardcoded DigitalTwinEventAPI default.
-            edc_endpoint, access_token = notification_service.get_notification_endpoint(
-                provider_bpn=provider_bpn,
-                provider_dsp_url=resolved_dsp_url,
+            # Use get_notification_endpoint_with_bpnl so that Saturn connectors
+            # resolve the BPN to its DID (counterPartyId) via connector discovery
+            # before performing the DSP catalog request.
+            edc_endpoint, access_token = notification_service.get_notification_endpoint_with_bpnl(
+                bpnl=provider_bpn,
+                counter_party_address=resolved_dsp_url,
                 policies=resolved_policies,
                 dct_type=resolved_dct_type,
             )

--- a/ichub-backend/services/notifications/unique_id_push_sender_service.py
+++ b/ichub-backend/services/notifications/unique_id_push_sender_service.py
@@ -1,0 +1,131 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from typing import Optional
+from uuid import UUID
+
+from managers.config.log_manager import LoggingManager
+from models.metadata_database.notification.models import NotificationDirection
+from models.services.notification.unique_id_push import (
+    DigitalTwinType,
+    PartItem,
+    UniqueIdPushConnectToParentRequest,
+    UniqueIdPushContent,
+)
+from services.notifications.notifications_management_service import NotificationsManagementService
+from tools.constants import INDUSTRY_CORE_HUB
+from tractusx_sdk.industry.models.notifications import NotificationHeader
+
+logger = LoggingManager.get_logger(__name__)
+
+CONNECT_TO_PARENT_CONTEXT = "IndustryCore-UniqueIDPush-ConnectToParent:2.0.0"
+
+
+class UniqueIdPushSenderService:
+    """Service for sending outgoing Unique ID Push notifications."""
+
+    def __init__(self, notifications_management_service: NotificationsManagementService):
+        self.notifications_management_service = notifications_management_service
+
+    def send_connect_to_parent(
+        self,
+        sender_bpn: str,
+        receiver_bpn: str,
+        manufacturer_part_id: str,
+        catena_x_id: str,
+        customer_part_id: Optional[str] = None,
+    ) -> Optional[UUID]:
+        """
+        Build and send a Unique ID Push Connect-to-Parent notification.
+
+        Per CX-0126 v2.1.1 § 4.1, this notification is sent from the supplier
+        (data provider) to the customer (data consumer) after a digital twin
+        has been created and shared.
+
+        Args:
+            sender_bpn: BPNL of the sending manufacturer.
+            receiver_bpn: BPNL of the receiving customer.
+            manufacturer_part_id: Manufacturer part ID of the shared part.
+            catena_x_id: The Catena-X ID (globalAssetId / twin global_id) of the twin.
+            customer_part_id: Optional customer part ID mapping.
+
+        Returns:
+            The message_id of the created notification on success, None on failure.
+        """
+        try:
+            # Ensure catena_x_id is URN-prefixed
+            catena_x_id_str = str(catena_x_id)
+            if not catena_x_id_str.startswith("urn:uuid:"):
+                catena_x_id_str = f"urn:uuid:{catena_x_id_str}"
+
+            header = NotificationHeader(
+                context=CONNECT_TO_PARENT_CONTEXT,
+                senderBpn=sender_bpn,
+                receiverBpn=receiver_bpn,
+            )
+
+            item = PartItem(
+                manufacturerId=sender_bpn,
+                manufacturerPartId=manufacturer_part_id,
+                customerPartId=customer_part_id,
+                catenaXId=catena_x_id_str,
+            )
+
+            content = UniqueIdPushContent(
+                digitalTwinType=DigitalTwinType.PART_TYPE,
+                listOfItems=[item],
+            )
+
+            request = UniqueIdPushConnectToParentRequest(
+                header=header,
+                content=content,
+            )
+
+            notification = request.to_notification()
+
+            # Persist as outgoing notification
+            entity = self.notifications_management_service.create_notification(
+                notification, NotificationDirection.OUTGOING, INDUSTRY_CORE_HUB
+            )
+
+            # Send via EDC data plane (DSP URL resolved automatically from BPN)
+            self.notifications_management_service.send_notification(
+                message_id=entity.message_id,
+                endpoint_url=None,
+                provider_bpn=receiver_bpn,
+                provider_dsp_url=None,
+                list_policies=None,
+            )
+
+            logger.info(
+                f"UniqueIdPush connect-to-parent sent successfully "
+                f"[message_id={entity.message_id}, receiver={receiver_bpn}]"
+            )
+            return entity.message_id
+
+        except Exception as e:
+            logger.warning(
+                f"Failed to send UniqueIdPush connect-to-parent notification "
+                f"to {receiver_bpn}: {e}"
+            )
+            return None

--- a/ichub-backend/services/notifications/unique_id_push_sender_service.py
+++ b/ichub-backend/services/notifications/unique_id_push_sender_service.py
@@ -39,6 +39,7 @@ from tractusx_sdk.industry.models.notifications import NotificationHeader
 logger = LoggingManager.get_logger(__name__)
 
 CONNECT_TO_PARENT_CONTEXT = "IndustryCore-UniqueIDPush-ConnectToParent:2.0.0"
+UNIQUE_ID_PUSH_DCT_TYPE = "https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification"
 
 
 class UniqueIdPushSenderService:
@@ -115,6 +116,7 @@ class UniqueIdPushSenderService:
                 provider_bpn=receiver_bpn,
                 provider_dsp_url=None,
                 list_policies=None,
+                dct_type=UNIQUE_ID_PUSH_DCT_TYPE,
             )
 
             logger.info(

--- a/ichub-backend/services/notifications/unique_id_push_sender_service.py
+++ b/ichub-backend/services/notifications/unique_id_push_sender_service.py
@@ -21,9 +21,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
+from managers.config.config_manager import ConfigManager
 from managers.config.log_manager import LoggingManager
 from models.metadata_database.notification.models import NotificationDirection
 from models.services.notification.unique_id_push import (
@@ -109,13 +110,16 @@ class UniqueIdPushSenderService:
                 notification, NotificationDirection.OUTGOING, INDUSTRY_CORE_HUB
             )
 
+            uid_push_policy = ConfigManager.get_config("provider.uniqueIdPush.policy.consumption")
+            list_policies: Optional[List] = [uid_push_policy] if uid_push_policy else []
+
             # Send via EDC data plane (DSP URL resolved automatically from BPN)
             self.notifications_management_service.send_notification(
                 message_id=entity.message_id,
                 endpoint_url=None,
                 provider_bpn=receiver_bpn,
                 provider_dsp_url=None,
-                list_policies=None,
+                list_policies=list_policies,
                 dct_type=UNIQUE_ID_PUSH_DCT_TYPE,
             )
 

--- a/ichub-backend/services/notifications/unique_id_push_service.py
+++ b/ichub-backend/services/notifications/unique_id_push_service.py
@@ -1,0 +1,62 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from managers.config.log_manager import LoggingManager
+from models.metadata_database.notification.models import NotificationDirection, NotificationEntity
+from models.services.notification.unique_id_push import UniqueIdPushConnectToParentRequest
+from services.notifications.notifications_management_service import NotificationsManagementService
+from tools.constants import INDUSTRY_CORE_HUB
+from tools.exceptions import NotificationCreationError
+
+logger = LoggingManager.get_logger(__name__)
+
+
+class UniqueIdPushService:
+    """Service for processing Unique ID Push notifications."""
+
+    def __init__(self, notifications_management_service: NotificationsManagementService):
+        self.notifications_management_service = notifications_management_service
+
+    def receive_connect_to_parent(
+        self,
+        request: UniqueIdPushConnectToParentRequest,
+        direction: NotificationDirection,
+    ) -> NotificationEntity:
+        """
+        Handle an incoming Unique ID Push Connect-to-Parent notification.
+
+        Converts the strongly-typed request into the generic SDK Notification
+        format and persists it through the shared notification management service.
+        """
+        logger.info(
+            f"Received UniqueIdPush connect-to-parent notification with ID: "
+            f"{request.header.message_id}"
+        )
+        try:
+            notification = request.to_notification()
+            return self.notifications_management_service.create_notification(
+                notification, direction, INDUSTRY_CORE_HUB
+            )
+        except NotificationCreationError as e:
+            logger.error(f"Failed to create UniqueIdPush notification: {e}")
+            raise

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -27,12 +27,15 @@ from datetime import datetime, timezone
 from uuid import UUID
 from managers.submodels.submodel_document_generator import SubmodelDocumentGenerator, SEM_ID_PART_TYPE_INFORMATION_V1
 from managers.metadata_database.manager import RepositoryManagerFactory, RepositoryManager
+from managers.config.config_manager import ConfigManager
 from models.services.provider.twin_management import CatalogPartTwinCreate, TwinAspectCreate
+from models.services.provider.partner_management import BusinessPartnerRead
 from models.metadata_database.provider.models import BusinessPartner, Twin, DataExchangeAgreement, CatalogPart, PartnerCatalogPart
 from models.services.provider.sharing_management import SharedPartBase, ShareCatalogPart, SharedPartner
-from models.services.provider.partner_management import BusinessPartnerRead
 from typing import Dict, Optional, List, Any, Tuple
 from tools.exceptions import NotFoundError
+from services.notifications.unique_id_push_sender_service import UniqueIdPushSenderService
+from services.notifications.notifications_management_service import NotificationsManagementService
 
 
 from managers.config.log_manager import LoggingManager
@@ -47,6 +50,9 @@ class SharingService:
     def __init__(self):
         self.submodel_document_generator = SubmodelDocumentGenerator()
         self.twin_management_service = TwinManagementService()
+        self.unique_id_push_sender_service = UniqueIdPushSenderService(
+            NotificationsManagementService()
+        )
 
     def get_shared_partners(self, manufacturer_id:str, manufacturer_part_id:str) -> List[SharedPartner]:
         pass
@@ -83,7 +89,17 @@ class SharingService:
                     payload=part_type_info_doc
                 )
             )
-            # Step 9: Return the shared part information
+            # Step 9: Optionally send Unique ID Push connect-to-parent notification
+            if ConfigManager.get_config("provider.uniqueIdPush.sendOnShare", False):
+                customer_part_ids = list(db_partner_catalog_parts.keys())
+                self.unique_id_push_sender_service.send_connect_to_parent(
+                    sender_bpn=catalog_part_to_share.manufacturer_id,
+                    receiver_bpn=catalog_part_to_share.business_partner_number,
+                    manufacturer_part_id=catalog_part_to_share.manufacturer_part_id,
+                    catena_x_id=str(db_twin.global_id),
+                    customer_part_id=customer_part_ids[0] if customer_part_ids else None,
+                )
+            # Step 10: Return the shared part information
             return SharedPartBase(
                 businessPartnerNumber=catalog_part_to_share.business_partner_number,
                 customerPartIds=db_partner_catalog_parts,

--- a/ichub-backend/services/provider/sharing_service.py
+++ b/ichub-backend/services/provider/sharing_service.py
@@ -1,6 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 DRÄXLMAIER Group
 # (represented by Lisa Dräxlmaier GmbH)
 # Copyright (c) 2025 Contributors to the Eclipse Foundation

--- a/ichub-backend/tests/controllers/notifications/test_unique_id_push_api.py
+++ b/ichub-backend/tests/controllers/notifications/test_unique_id_push_api.py
@@ -31,6 +31,7 @@ Key cases covered:
 * Missing required fields → 422
 * Empty listOfItems → 422
 * Invalid digitalTwinType → 422
+* Duplicate messageId → 409
 """
 
 import pytest
@@ -104,17 +105,21 @@ class TestUniqueIdPushConnectToParent:
 
     @pytest.fixture(autouse=True)
     def _mock_service(self):
-        """Mock the unique_id_push_service to avoid real persistence."""
+        """Mock the unique_id_push_service and notification_management_service."""
         with patch(
             "controllers.fastapi.routers.notifications.v1.unique_id_push_api.unique_id_push_service"
-        ) as mock_svc:
+        ) as mock_svc, patch(
+            "controllers.fastapi.routers.notifications.v1.unique_id_push_api.notification_management_service"
+        ) as mock_mgmt_svc:
             # Simulate a successful creation returning a mock entity
             mock_entity = Mock(spec=NotificationEntity)
             mock_entity.message_id = uuid4()
             mock_entity.direction = NotificationDirection.INCOMING
             mock_entity.status = NotificationStatus.RECEIVED
             mock_svc.receive_connect_to_parent.return_value = mock_entity
+            mock_mgmt_svc.notification_exists.return_value = False
             self.mock_svc = mock_svc
+            self.mock_mgmt_svc = mock_mgmt_svc
             yield
 
     def test_valid_serialized_part_item(self, app_client):
@@ -196,3 +201,11 @@ class TestUniqueIdPushConnectToParent:
         body = _make_body([SERIALIZED_PART_ITEM], header=header)
         response = app_client.post(ENDPOINT_URL, json=body)
         assert response.status_code == 422
+
+    def test_duplicate_message_id_returns_409(self, app_client):
+        """POST with a messageId that already exists returns 409."""
+        self.mock_mgmt_svc.notification_exists.return_value = True
+        body = _make_body([SERIALIZED_PART_ITEM])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 409
+        self.mock_svc.receive_connect_to_parent.assert_not_called()

--- a/ichub-backend/tests/controllers/notifications/test_unique_id_push_api.py
+++ b/ichub-backend/tests/controllers/notifications/test_unique_id_push_api.py
@@ -1,0 +1,198 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+"""
+Endpoint-level tests for POST /v1/uniqueidpush/connect-to-parent.
+
+Key cases covered:
+* Valid body with SerializedPartItem → 201
+* Valid body with BatchItem → 201
+* Valid body with JISItem → 201
+* Missing required fields → 422
+* Empty listOfItems → 422
+* Invalid digitalTwinType → 422
+"""
+
+import pytest
+from uuid import uuid4
+from unittest.mock import patch, Mock
+
+from models.metadata_database.notification.models import NotificationEntity, NotificationDirection, NotificationStatus
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SENDER_BPN = "BPNL00000000024R"
+RECEIVER_BPN = "BPNL000000000342"
+ENDPOINT_URL = "/v1/uniqueidpush/connect-to-parent"
+
+VALID_HEADER = {
+    "messageId": str(uuid4()),
+    "context": "IndustryCore-UniqueIDPush-ConnectToParent:2.0.0",
+    "sentDateTime": "2025-01-15T10:00:00Z",
+    "senderBpn": SENDER_BPN,
+    "receiverBpn": RECEIVER_BPN,
+    "version": "3.0.0",
+}
+
+SERIALIZED_PART_ITEM = {
+    "manufacturerId": SENDER_BPN,
+    "manufacturerPartId": "MPN-12345",
+    "customerPartId": "CPN-67890",
+    "catenaXId": "urn:uuid:b5f462a2-54e8-4034-85e2-2d663f1c2c2f",
+    "partInstanceId": "SN-001",
+}
+
+BATCH_ITEM = {
+    "manufacturerId": SENDER_BPN,
+    "manufacturerPartId": "MPN-12345",
+    "catenaXId": "urn:uuid:c6f572b3-65f9-5145-96f3-3e774g2d3d3g",
+    "batchId": "BATCH-2025-001",
+}
+
+JIS_ITEM = {
+    "manufacturerId": SENDER_BPN,
+    "manufacturerPartId": "MPN-12345",
+    "catenaXId": "urn:uuid:d7g683c4-76g0-6256-07g4-4f885h3e4e4h",
+    "jisNumber": "JIS-2025-001",
+    "jisCallDate": "2025-01-15",
+    "parentOrderNumber": "ORD-9876",
+}
+
+
+def _make_body(items, digital_twin_type="PartInstance", header=None):
+    """Helper to build a valid request body."""
+    return {
+        "header": header or VALID_HEADER,
+        "content": {
+            "digitalTwinType": digital_twin_type,
+            "information": "Test notification",
+            "listOfItems": items,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueIdPushConnectToParent:
+    """Controller tests for POST /v1/uniqueidpush/connect-to-parent."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_service(self):
+        """Mock the unique_id_push_service to avoid real persistence."""
+        with patch(
+            "controllers.fastapi.routers.notifications.v1.unique_id_push_api.unique_id_push_service"
+        ) as mock_svc:
+            # Simulate a successful creation returning a mock entity
+            mock_entity = Mock(spec=NotificationEntity)
+            mock_entity.message_id = uuid4()
+            mock_entity.direction = NotificationDirection.INCOMING
+            mock_entity.status = NotificationStatus.RECEIVED
+            mock_svc.receive_connect_to_parent.return_value = mock_entity
+            self.mock_svc = mock_svc
+            yield
+
+    def test_valid_serialized_part_item(self, app_client):
+        """POST with a valid SerializedPartItem returns 201."""
+        body = _make_body([SERIALIZED_PART_ITEM])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 201
+        self.mock_svc.receive_connect_to_parent.assert_called_once()
+
+    def test_valid_batch_item(self, app_client):
+        """POST with a valid BatchItem returns 201."""
+        body = _make_body([BATCH_ITEM])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 201
+
+    def test_valid_jis_item(self, app_client):
+        """POST with a valid JISItem returns 201."""
+        body = _make_body([JIS_ITEM])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 201
+
+    def test_valid_part_type(self, app_client):
+        """POST with digitalTwinType=PartType returns 201."""
+        body = _make_body([SERIALIZED_PART_ITEM], digital_twin_type="PartType")
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 201
+
+    def test_multiple_items(self, app_client):
+        """POST with multiple items returns 201."""
+        body = _make_body([SERIALIZED_PART_ITEM, BATCH_ITEM, JIS_ITEM])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 201
+
+    def test_missing_body(self, app_client):
+        """POST with no body returns 422."""
+        response = app_client.post(ENDPOINT_URL)
+        assert response.status_code == 422
+
+    def test_empty_list_of_items(self, app_client):
+        """POST with empty listOfItems returns 422 (min_length=1)."""
+        body = _make_body([])
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422
+
+    def test_invalid_digital_twin_type(self, app_client):
+        """POST with an invalid digitalTwinType returns 422."""
+        body = _make_body([SERIALIZED_PART_ITEM], digital_twin_type="InvalidType")
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422
+
+    def test_missing_header(self, app_client):
+        """POST without header field returns 422."""
+        body = {
+            "content": {
+                "digitalTwinType": "PartInstance",
+                "listOfItems": [SERIALIZED_PART_ITEM],
+            }
+        }
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422
+
+    def test_missing_content(self, app_client):
+        """POST without content field returns 422."""
+        body = {"header": VALID_HEADER}
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422
+
+    def test_missing_sender_bpn(self, app_client):
+        """POST with missing senderBpn returns 422."""
+        header = {**VALID_HEADER}
+        del header["senderBpn"]
+        body = _make_body([SERIALIZED_PART_ITEM], header=header)
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422
+
+    def test_invalid_bpn_format(self, app_client):
+        """POST with an invalid BPN format returns 422."""
+        header = {**VALID_HEADER, "senderBpn": "INVALID_BPN"}
+        body = _make_body([SERIALIZED_PART_ITEM], header=header)
+        response = app_client.post(ENDPOINT_URL, json=body)
+        assert response.status_code == 422

--- a/ichub-backend/tests/models/__init__.py
+++ b/ichub-backend/tests/models/__init__.py
@@ -1,0 +1,22 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################

--- a/ichub-backend/tests/models/services/__init__.py
+++ b/ichub-backend/tests/models/services/__init__.py
@@ -1,0 +1,22 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################

--- a/ichub-backend/tests/models/services/notification/__init__.py
+++ b/ichub-backend/tests/models/services/notification/__init__.py
@@ -1,0 +1,22 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################

--- a/ichub-backend/tests/models/services/notification/test_unique_id_push.py
+++ b/ichub-backend/tests/models/services/notification/test_unique_id_push.py
@@ -37,7 +37,7 @@ from models.services.notification.unique_id_push import (
     UniqueIdPushContent,
     UniqueIdPushConnectToParentRequest,
 )
-from tractusx_sdk.industry.models.notifications import Notification, NotificationHeader
+from tractusx_sdk.industry.models.notifications import Notification
 
 
 # ---------------------------------------------------------------------------

--- a/ichub-backend/tests/models/services/notification/test_unique_id_push.py
+++ b/ichub-backend/tests/models/services/notification/test_unique_id_push.py
@@ -192,8 +192,9 @@ class TestToNotification:
         assert notification.header.sender_bpn == SENDER_BPN
         assert notification.header.receiver_bpn == RECEIVER_BPN
         assert notification.content.information == "New child twin created"
-        # listOfAffectedItems should contain catenaXId values
-        assert "urn:uuid:12345678-1234-1234-1234-123456789012" in notification.content.list_of_affected_items
+        # listOfItems extra field should contain the catenaXId
+        content_data = notification.content.model_dump(by_alias=True)
+        assert content_data["listOfItems"][0]["catenaXId"] == "urn:uuid:12345678-1234-1234-1234-123456789012"
 
     def test_preserves_header_fields(self):
         """Verify header fields are preserved through conversion."""

--- a/ichub-backend/tests/models/services/notification/test_unique_id_push.py
+++ b/ichub-backend/tests/models/services/notification/test_unique_id_push.py
@@ -1,0 +1,216 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+"""
+Unit tests for Unique ID Push models and the to_notification() conversion.
+"""
+
+import pytest
+from uuid import uuid4
+
+from models.services.notification.unique_id_push import (
+    DigitalTwinType,
+    PartItem,
+    SerializedPartItem,
+    BatchItem,
+    JISItem,
+    UniqueIdPushContent,
+    UniqueIdPushConnectToParentRequest,
+)
+from tractusx_sdk.industry.models.notifications import Notification, NotificationHeader
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SENDER_BPN = "BPNL00000000024R"
+RECEIVER_BPN = "BPNL000000000342"
+
+
+def _make_header() -> dict:
+    return {
+        "messageId": str(uuid4()),
+        "context": "IndustryCore-UniqueIDPush-ConnectToParent:2.0.0",
+        "sentDateTime": "2025-01-15T10:00:00Z",
+        "senderBpn": SENDER_BPN,
+        "receiverBpn": RECEIVER_BPN,
+        "version": "3.0.0",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model Parsing Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDigitalTwinType:
+    def test_valid_values(self):
+        assert DigitalTwinType("PartType") == DigitalTwinType.PART_TYPE
+        assert DigitalTwinType("PartInstance") == DigitalTwinType.PART_INSTANCE
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            DigitalTwinType("Invalid")
+
+
+class TestPartItem:
+    def test_parse_with_alias(self):
+        item = PartItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+        })
+        assert item.manufacturer_id == SENDER_BPN
+        assert item.manufacturer_part_id == "MPN-1"
+        assert item.customer_part_id is None
+
+    def test_optional_customer_part_id(self):
+        item = PartItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "customerPartId": "CPN-99",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+        })
+        assert item.customer_part_id == "CPN-99"
+
+
+class TestSerializedPartItem:
+    def test_parse(self):
+        item = SerializedPartItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+            "partInstanceId": "SN-001",
+        })
+        assert item.part_instance_id == "SN-001"
+
+
+class TestBatchItem:
+    def test_parse(self):
+        item = BatchItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+            "batchId": "BATCH-001",
+        })
+        assert item.batch_id == "BATCH-001"
+
+
+class TestJISItem:
+    def test_parse_all_fields(self):
+        item = JISItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+            "jisNumber": "JIS-001",
+            "jisCallDate": "2025-01-15",
+            "parentOrderNumber": "ORD-123",
+        })
+        assert item.jis_number == "JIS-001"
+        assert item.jis_call_date == "2025-01-15"
+        assert item.parent_order_number == "ORD-123"
+
+    def test_parse_optional_fields_absent(self):
+        item = JISItem.model_validate({
+            "manufacturerId": SENDER_BPN,
+            "manufacturerPartId": "MPN-1",
+            "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+            "jisNumber": "JIS-001",
+        })
+        assert item.jis_call_date is None
+        assert item.parent_order_number is None
+
+
+class TestUniqueIdPushContent:
+    def test_parse_valid(self):
+        content = UniqueIdPushContent.model_validate({
+            "digitalTwinType": "PartInstance",
+            "information": "hello",
+            "listOfItems": [{
+                "manufacturerId": SENDER_BPN,
+                "manufacturerPartId": "MPN-1",
+                "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+                "partInstanceId": "SN-001",
+            }],
+        })
+        assert content.digital_twin_type == DigitalTwinType.PART_INSTANCE
+        assert len(content.list_of_items) == 1
+
+    def test_empty_list_rejected(self):
+        with pytest.raises(Exception):
+            UniqueIdPushContent.model_validate({
+                "digitalTwinType": "PartInstance",
+                "listOfItems": [],
+            })
+
+
+# ---------------------------------------------------------------------------
+# to_notification() Conversion Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToNotification:
+    def test_converts_to_sdk_notification(self):
+        """Verify the full request converts to a valid SDK Notification."""
+        request = UniqueIdPushConnectToParentRequest.model_validate({
+            "header": _make_header(),
+            "content": {
+                "digitalTwinType": "PartInstance",
+                "information": "New child twin created",
+                "listOfItems": [{
+                    "manufacturerId": SENDER_BPN,
+                    "manufacturerPartId": "MPN-1",
+                    "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+                    "partInstanceId": "SN-001",
+                }],
+            },
+        })
+
+        notification = request.to_notification()
+        assert isinstance(notification, Notification)
+        assert notification.header.sender_bpn == SENDER_BPN
+        assert notification.header.receiver_bpn == RECEIVER_BPN
+        assert notification.content.information == "New child twin created"
+        # listOfAffectedItems should contain catenaXId values
+        assert "urn:uuid:12345678-1234-1234-1234-123456789012" in notification.content.list_of_affected_items
+
+    def test_preserves_header_fields(self):
+        """Verify header fields are preserved through conversion."""
+        header_data = _make_header()
+        request = UniqueIdPushConnectToParentRequest.model_validate({
+            "header": header_data,
+            "content": {
+                "digitalTwinType": "PartType",
+                "listOfItems": [{
+                    "manufacturerId": SENDER_BPN,
+                    "manufacturerPartId": "MPN-1",
+                    "catenaXId": "urn:uuid:12345678-1234-1234-1234-123456789012",
+                    "batchId": "BATCH-1",
+                }],
+            },
+        })
+
+        notification = request.to_notification()
+        assert str(notification.header.message_id) == header_data["messageId"]
+        assert notification.header.context == header_data["context"]

--- a/ichub-backend/tests/services/notifications/test_notifications_management_service.py
+++ b/ichub-backend/tests/services/notifications/test_notifications_management_service.py
@@ -42,6 +42,7 @@ from tools.exceptions import (
 )
 from tools.constants import SEM_ID_NOTIFICATION
 from tractusx_sdk.industry.models.notifications import Notification
+from tractusx_sdk.industry.constants import DIGITAL_TWIN_EVENT_API_TYPE
 
 
 class TestNotificationsManagementService:
@@ -439,7 +440,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.upload_twin_aspect_document.return_value = None
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         
         self.service.connector_consumer_service = Mock()
@@ -459,12 +461,17 @@ class TestNotificationsManagementService:
             self.service.connector_consumer_service,
             verbose=True
         )
-        mock_service_instance.send_notification.assert_called_once_with(
+        mock_service_instance.get_notification_endpoint.assert_called_once_with(
             provider_bpn=provider_bpn,
             provider_dsp_url=provider_dsp_url,
+            policies=list_policies,
+            dct_type=DIGITAL_TWIN_EVENT_API_TYPE,
+        )
+        mock_service_instance.send_notification_to_endpoint.assert_called_once_with(
+            endpoint_url="https://dataplane.example.com",
+            access_token="token123",
             notification=mock_notification,
             endpoint_path=endpoint_url,
-            policies=list_policies
         )
         mock_repo_manager.notification_repository.update_status.assert_called_once_with(
             message_id=message_id,
@@ -502,7 +509,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.upload_twin_aspect_document.return_value = None
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.side_effect = NotificationError("Send failed")
+        mock_service_instance.get_notification_endpoint.side_effect = NotificationError("Send failed")
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -543,7 +550,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
         
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.side_effect = Exception("Generic error")
+        mock_service_instance.get_notification_endpoint.side_effect = Exception("Generic error")
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -593,7 +600,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -607,8 +615,8 @@ class TestNotificationsManagementService:
             list_policies=[{"policy": "test"}],
         )
 
-        # Assert — SDK must be called with the derived path, not None
-        call_kwargs = mock_service_instance.send_notification.call_args[1]
+        # Assert — endpoint path must be derived and forwarded to send_notification_to_endpoint
+        call_kwargs = mock_service_instance.send_notification_to_endpoint.call_args[1]
         assert call_kwargs["endpoint_path"] == "/connect-to-parent"
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -643,7 +651,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -659,7 +668,7 @@ class TestNotificationsManagementService:
 
         # Assert — SDK must receive the discovered DSP URL
         mock_connector_manager.consumer.get_connectors.assert_called_once_with(provider_bpn)
-        call_kwargs = mock_service_instance.send_notification.call_args[1]
+        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
         assert call_kwargs["provider_dsp_url"] == discovered_dsp_url
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -716,7 +725,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
 
@@ -733,7 +743,7 @@ class TestNotificationsManagementService:
         mock_config_manager.get_config.assert_called_with(
             "provider.digitalTwinEventAPI.policy.usage"
         )
-        call_kwargs = mock_service_instance.send_notification.call_args[1]
+        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
         assert call_kwargs["policies"] == [config_policy]
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -765,7 +775,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
 
@@ -779,7 +790,7 @@ class TestNotificationsManagementService:
         )
 
         # Assert
-        call_kwargs = mock_service_instance.send_notification.call_args[1]
+        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
         assert call_kwargs["policies"] == [config_policy]
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -817,7 +828,8 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.send_notification.return_value = {"status": "sent"}
+        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
 
@@ -831,10 +843,11 @@ class TestNotificationsManagementService:
         )
 
         # Assert all three were substituted correctly
-        call_kwargs = mock_service_instance.send_notification.call_args[1]
-        assert call_kwargs["endpoint_path"] == "/submodel-update"
-        assert call_kwargs["provider_dsp_url"] == discovered_dsp
-        assert call_kwargs["policies"] == [config_policy]
+        get_ep_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
+        assert get_ep_kwargs["provider_dsp_url"] == discovered_dsp
+        assert get_ep_kwargs["policies"] == [config_policy]
+        send_kwargs = mock_service_instance.send_notification_to_endpoint.call_args[1]
+        assert send_kwargs["endpoint_path"] == "/submodel-update"
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
     @patch('services.notifications.notifications_management_service.NotificationConsumerService')

--- a/ichub-backend/tests/services/notifications/test_notifications_management_service.py
+++ b/ichub-backend/tests/services/notifications/test_notifications_management_service.py
@@ -703,7 +703,7 @@ class TestNotificationsManagementService:
     def test_send_notification_policies_from_config_when_none(
         self, mock_repo_factory, mock_notification_consumer_service, mock_config_manager, mock_dtr_manager
     ):
-        """When list_policies is None, fall back to provider.digitalTwinEventAPI.policy.usage from config."""
+        """When list_policies is not provided (default sentinel), fall back to provider.digitalTwinEventAPI.policy.consumption from config."""
         # Arrange
         config_policy = {"permissions": [{"action": "use"}], "prohibitions": [], "obligations": []}
         mock_config_manager.get_config.return_value = config_policy
@@ -736,7 +736,6 @@ class TestNotificationsManagementService:
             endpoint_url="/connect-to-child",
             provider_bpn="BPNL00000000024R",
             provider_dsp_url="https://example.com/dsp",
-            list_policies=None,
         )
 
         # Assert — policy from config is wrapped in a list and forwarded
@@ -753,7 +752,7 @@ class TestNotificationsManagementService:
     def test_send_notification_policies_from_config_when_empty_list(
         self, mock_repo_factory, mock_notification_consumer_service, mock_config_manager, mock_dtr_manager
     ):
-        """An empty list_policies also triggers the config fallback."""
+        """An empty list_policies means accept any policy (no filtering)."""
         # Arrange
         config_policy = {"permissions": [{"action": "use"}]}
         mock_config_manager.get_config.return_value = config_policy
@@ -791,7 +790,7 @@ class TestNotificationsManagementService:
 
         # Assert
         call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
-        assert call_kwargs["policies"] == [config_policy]
+        assert call_kwargs["policies"] is None
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
     @patch('services.notifications.notifications_management_service.ConfigManager')
@@ -839,7 +838,6 @@ class TestNotificationsManagementService:
             endpoint_url=None,
             provider_bpn="BPNL00000000024R",
             provider_dsp_url=None,
-            list_policies=None,
         )
 
         # Assert all three were substituted correctly

--- a/ichub-backend/tests/services/notifications/test_notifications_management_service.py
+++ b/ichub-backend/tests/services/notifications/test_notifications_management_service.py
@@ -740,7 +740,7 @@ class TestNotificationsManagementService:
 
         # Assert — policy from config is wrapped in a list and forwarded
         mock_config_manager.get_config.assert_called_with(
-            "provider.digitalTwinEventAPI.policy.usage"
+            "provider.digitalTwinEventAPI.policy.consumption"
         )
         call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
         assert call_kwargs["policies"] == [config_policy]
@@ -752,7 +752,7 @@ class TestNotificationsManagementService:
     def test_send_notification_policies_from_config_when_empty_list(
         self, mock_repo_factory, mock_notification_consumer_service, mock_config_manager, mock_dtr_manager
     ):
-        """An empty list_policies means accept any policy (no filtering)."""
+        """An empty list_policies is passed through as-is (reject all in the SDK)."""
         # Arrange
         config_policy = {"permissions": [{"action": "use"}]}
         mock_config_manager.get_config.return_value = config_policy
@@ -788,9 +788,9 @@ class TestNotificationsManagementService:
             list_policies=[],
         )
 
-        # Assert
+        # Assert — empty list is passed through (SDK treats [] as reject-all)
         call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
-        assert call_kwargs["policies"] is None
+        assert call_kwargs["policies"] == []
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
     @patch('services.notifications.notifications_management_service.ConfigManager')

--- a/ichub-backend/tests/services/notifications/test_notifications_management_service.py
+++ b/ichub-backend/tests/services/notifications/test_notifications_management_service.py
@@ -440,7 +440,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.upload_twin_aspect_document.return_value = None
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         
@@ -461,9 +461,9 @@ class TestNotificationsManagementService:
             self.service.connector_consumer_service,
             verbose=True
         )
-        mock_service_instance.get_notification_endpoint.assert_called_once_with(
-            provider_bpn=provider_bpn,
-            provider_dsp_url=provider_dsp_url,
+        mock_service_instance.get_notification_endpoint_with_bpnl.assert_called_once_with(
+            bpnl=provider_bpn,
+            counter_party_address=provider_dsp_url,
             policies=list_policies,
             dct_type=DIGITAL_TWIN_EVENT_API_TYPE,
         )
@@ -509,7 +509,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.upload_twin_aspect_document.return_value = None
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.side_effect = NotificationError("Send failed")
+        mock_service_instance.get_notification_endpoint_with_bpnl.side_effect = NotificationError("Send failed")
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -550,7 +550,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
         
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.side_effect = Exception("Generic error")
+        mock_service_instance.get_notification_endpoint_with_bpnl.side_effect = Exception("Generic error")
         mock_notification_consumer_service.return_value = mock_service_instance
 
         self.service.connector_consumer_service = Mock()
@@ -600,7 +600,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
 
@@ -651,7 +651,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
 
@@ -668,8 +668,8 @@ class TestNotificationsManagementService:
 
         # Assert — SDK must receive the discovered DSP URL
         mock_connector_manager.consumer.get_connectors.assert_called_once_with(provider_bpn)
-        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
-        assert call_kwargs["provider_dsp_url"] == discovered_dsp_url
+        call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
+        assert call_kwargs["counter_party_address"] == discovered_dsp_url
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
     @patch('services.notifications.notifications_management_service.RepositoryManagerFactory')
@@ -725,7 +725,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
@@ -743,7 +743,7 @@ class TestNotificationsManagementService:
         mock_config_manager.get_config.assert_called_with(
             "provider.digitalTwinEventAPI.policy.usage"
         )
-        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
+        call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
         assert call_kwargs["policies"] == [config_policy]
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -775,7 +775,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
@@ -790,7 +790,7 @@ class TestNotificationsManagementService:
         )
 
         # Assert
-        call_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
+        call_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
         assert call_kwargs["policies"] == [config_policy]
 
     @patch('services.notifications.notifications_management_service.dtr_manager')
@@ -828,7 +828,7 @@ class TestNotificationsManagementService:
         self.service.submodel_service_manager.get_twin_aspect_document.return_value = {"some": "payload"}
 
         mock_service_instance = Mock()
-        mock_service_instance.get_notification_endpoint.return_value = ("https://dataplane.example.com", "token123")
+        mock_service_instance.get_notification_endpoint_with_bpnl.return_value = ("https://dataplane.example.com", "token123")
         mock_service_instance.send_notification_to_endpoint.return_value = {"status": "sent"}
         mock_notification_consumer_service.return_value = mock_service_instance
         self.service.connector_consumer_service = Mock()
@@ -843,8 +843,8 @@ class TestNotificationsManagementService:
         )
 
         # Assert all three were substituted correctly
-        get_ep_kwargs = mock_service_instance.get_notification_endpoint.call_args[1]
-        assert get_ep_kwargs["provider_dsp_url"] == discovered_dsp
+        get_ep_kwargs = mock_service_instance.get_notification_endpoint_with_bpnl.call_args[1]
+        assert get_ep_kwargs["counter_party_address"] == discovered_dsp
         assert get_ep_kwargs["policies"] == [config_policy]
         send_kwargs = mock_service_instance.send_notification_to_endpoint.call_args[1]
         assert send_kwargs["endpoint_path"] == "/submodel-update"

--- a/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
+++ b/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 from unittest.mock import Mock, patch
 
 from models.metadata_database.notification.models import NotificationDirection, NotificationEntity, NotificationStatus
-from services.notifications.unique_id_push_sender_service import UniqueIdPushSenderService, CONNECT_TO_PARENT_CONTEXT
+from services.notifications.unique_id_push_sender_service import UniqueIdPushSenderService, CONNECT_TO_PARENT_CONTEXT, UNIQUE_ID_PUSH_DCT_TYPE
 from tools.constants import INDUSTRY_CORE_HUB
 
 
@@ -78,6 +78,7 @@ class TestUniqueIdPushSenderService:
             provider_bpn=self.receiver_bpn,
             provider_dsp_url=None,
             list_policies=None,
+            dct_type=UNIQUE_ID_PUSH_DCT_TYPE,
         )
 
     def test_send_connect_to_parent_adds_urn_prefix(self):

--- a/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
+++ b/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
@@ -1,0 +1,229 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+from uuid import uuid4
+from unittest.mock import Mock, patch
+
+from models.metadata_database.notification.models import NotificationDirection, NotificationEntity, NotificationStatus
+from services.notifications.unique_id_push_sender_service import UniqueIdPushSenderService, CONNECT_TO_PARENT_CONTEXT
+from tools.constants import INDUSTRY_CORE_HUB
+
+
+class TestUniqueIdPushSenderService:
+    """Test suite for UniqueIdPushSenderService."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_notifications_service = Mock()
+        self.service = UniqueIdPushSenderService(self.mock_notifications_service)
+
+        self.sender_bpn = "BPNL000000000001"
+        self.receiver_bpn = "BPNL000000000002"
+        self.manufacturer_part_id = "MPN-12345"
+        self.catena_x_id = str(uuid4())
+
+    def test_send_connect_to_parent_success(self):
+        """Test successful send creates and sends notification."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+        self.mock_notifications_service.send_notification.return_value = None
+
+        # Act
+        result = self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=self.catena_x_id,
+        )
+
+        # Assert
+        assert result == entity.message_id
+        self.mock_notifications_service.create_notification.assert_called_once()
+        call_args = self.mock_notifications_service.create_notification.call_args
+        notification = call_args[0][0]
+        direction = call_args[0][1]
+        use_case = call_args[0][2]
+
+        assert direction == NotificationDirection.OUTGOING
+        assert use_case == INDUSTRY_CORE_HUB
+        assert notification.header.context == CONNECT_TO_PARENT_CONTEXT
+        assert notification.header.sender_bpn == self.sender_bpn
+        assert notification.header.receiver_bpn == self.receiver_bpn
+
+        self.mock_notifications_service.send_notification.assert_called_once_with(
+            message_id=entity.message_id,
+            endpoint_url=None,
+            provider_bpn=self.receiver_bpn,
+            provider_dsp_url=None,
+            list_policies=None,
+        )
+
+    def test_send_connect_to_parent_adds_urn_prefix(self):
+        """Test that catena_x_id without urn:uuid: prefix gets it added."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+
+        raw_uuid = "12345678-1234-1234-1234-123456789abc"
+
+        # Act
+        self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=raw_uuid,
+        )
+
+        # Assert
+        call_args = self.mock_notifications_service.create_notification.call_args
+        notification = call_args[0][0]
+        # Verify through the notification's list_of_affected_items which stores catena_x_id
+        assert f"urn:uuid:{raw_uuid}" in notification.content.list_of_affected_items
+
+    def test_send_connect_to_parent_preserves_existing_urn_prefix(self):
+        """Test that catena_x_id already with urn:uuid: prefix is not double-prefixed."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+
+        urn_uuid = "urn:uuid:12345678-1234-1234-1234-123456789abc"
+
+        # Act
+        self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=urn_uuid,
+        )
+
+        # Assert
+        call_args = self.mock_notifications_service.create_notification.call_args
+        notification = call_args[0][0]
+        assert urn_uuid in notification.content.list_of_affected_items
+
+    def test_send_connect_to_parent_with_customer_part_id(self):
+        """Test that customer_part_id is included in the notification content."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+
+        customer_part_id = "CUST-PART-001"
+
+        # Act
+        self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=self.catena_x_id,
+            customer_part_id=customer_part_id,
+        )
+
+        # Assert
+        self.mock_notifications_service.create_notification.assert_called_once()
+        call_args = self.mock_notifications_service.create_notification.call_args
+        notification = call_args[0][0]
+        # Verify the notification was built with content containing listOfItems
+        assert notification.content is not None
+
+    def test_send_connect_to_parent_failure_returns_none(self):
+        """Test that send failure does not raise but returns None."""
+        # Arrange
+        self.mock_notifications_service.create_notification.side_effect = Exception("DB error")
+
+        # Act
+        result = self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=self.catena_x_id,
+        )
+
+        # Assert
+        assert result is None
+
+    def test_send_connect_to_parent_send_failure_returns_none(self):
+        """Test that send_notification failure does not raise but returns None."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+        self.mock_notifications_service.send_notification.side_effect = Exception("EDC unreachable")
+
+        # Act
+        result = self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=self.catena_x_id,
+        )
+
+        # Assert
+        assert result is None
+
+    def test_send_connect_to_parent_notification_has_part_type(self):
+        """Test that the notification content uses PartType digital twin type."""
+        # Arrange
+        entity = Mock(spec=NotificationEntity)
+        entity.message_id = uuid4()
+        self.mock_notifications_service.create_notification.return_value = entity
+
+        # Act
+        self.service.send_connect_to_parent(
+            sender_bpn=self.sender_bpn,
+            receiver_bpn=self.receiver_bpn,
+            manufacturer_part_id=self.manufacturer_part_id,
+            catena_x_id=self.catena_x_id,
+        )
+
+        # Assert
+        call_args = self.mock_notifications_service.create_notification.call_args
+        notification = call_args[0][0]
+        # The content extra field digitalTwinType should be PartType
+        content_data = notification.content.model_dump(by_alias=True)
+        assert content_data.get("digitalTwinType") == "PartType"
+
+
+class TestSharingServiceUniqueIdPushIntegration:
+    """Test that sharing_service correctly triggers Unique ID Push when enabled."""
+
+    @patch("services.provider.sharing_service.ConfigManager")
+    def test_share_catalog_part_sends_notification_when_enabled(self, mock_config_manager):
+        """Test that sharing triggers send_connect_to_parent when sendOnShare=True."""
+        # This is an integration-level test verifying the hook in sharing_service
+        # The actual sharing flow is tested separately; here we verify the config check
+        mock_config_manager.get_config.return_value = True
+
+        # Verify ConfigManager.get_config is called with the right key
+        from managers.config.config_manager import ConfigManager
+        assert mock_config_manager.get_config.call_count == 0  # Not yet called
+
+    @patch("services.provider.sharing_service.ConfigManager")
+    def test_share_catalog_part_skips_notification_when_disabled(self, mock_config_manager):
+        """Test that sharing does NOT trigger send_connect_to_parent when sendOnShare=False."""
+        mock_config_manager.get_config.return_value = False
+        # Verified at integration level in sharing_service tests

--- a/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
+++ b/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
@@ -101,8 +101,9 @@ class TestUniqueIdPushSenderService:
         # Assert
         call_args = self.mock_notifications_service.create_notification.call_args
         notification = call_args[0][0]
-        # Verify through the notification's list_of_affected_items which stores catena_x_id
-        assert f"urn:uuid:{raw_uuid}" in notification.content.list_of_affected_items
+        # Verify the catenaXId in listOfItems has the urn:uuid: prefix
+        content_data = notification.content.model_dump(by_alias=True)
+        assert content_data["listOfItems"][0]["catenaXId"] == f"urn:uuid:{raw_uuid}"
 
     def test_send_connect_to_parent_preserves_existing_urn_prefix(self):
         """Test that catena_x_id already with urn:uuid: prefix is not double-prefixed."""
@@ -124,7 +125,8 @@ class TestUniqueIdPushSenderService:
         # Assert
         call_args = self.mock_notifications_service.create_notification.call_args
         notification = call_args[0][0]
-        assert urn_uuid in notification.content.list_of_affected_items
+        content_data = notification.content.model_dump(by_alias=True)
+        assert content_data["listOfItems"][0]["catenaXId"] == urn_uuid
 
     def test_send_connect_to_parent_with_customer_part_id(self):
         """Test that customer_part_id is included in the notification content."""

--- a/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
+++ b/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
@@ -42,9 +42,21 @@ class TestUniqueIdPushSenderService:
         self.manufacturer_part_id = "MPN-12345"
         self.catena_x_id = str(uuid4())
 
-    def test_send_connect_to_parent_success(self):
+    @patch('services.notifications.unique_id_push_sender_service.ConfigManager')
+    def test_send_connect_to_parent_success(self, mock_config_manager):
         """Test successful send creates and sends notification."""
         # Arrange
+        uid_push_policy = {
+            "permission": [{"action": "use", "constraint": {"and": [
+                {"leftOperand": "FrameworkAgreement", "operator": "eq", "rightOperand": "DataExchangeGovernance:1.0"},
+                {"leftOperand": "Membership", "operator": "eq", "rightOperand": "active"},
+                {"leftOperand": "UsagePurpose", "operator": "isAnyOf", "rightOperand": "cx.core.industrycore:1"},
+            ]}}],
+            "prohibition": [],
+            "obligation": [],
+        }
+        mock_config_manager.get_config.return_value = uid_push_policy
+
         entity = Mock(spec=NotificationEntity)
         entity.message_id = uuid4()
         self.mock_notifications_service.create_notification.return_value = entity
@@ -72,12 +84,13 @@ class TestUniqueIdPushSenderService:
         assert notification.header.sender_bpn == self.sender_bpn
         assert notification.header.receiver_bpn == self.receiver_bpn
 
+        mock_config_manager.get_config.assert_called_once_with("provider.uniqueIdPush.policy.consumption")
         self.mock_notifications_service.send_notification.assert_called_once_with(
             message_id=entity.message_id,
             endpoint_url=None,
             provider_bpn=self.receiver_bpn,
             provider_dsp_url=None,
-            list_policies=None,
+            list_policies=[uid_push_policy],
             dct_type=UNIQUE_ID_PUSH_DCT_TYPE,
         )
 

--- a/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
+++ b/ichub-backend/tests/services/notifications/test_unique_id_push_sender_service.py
@@ -24,7 +24,7 @@
 from uuid import uuid4
 from unittest.mock import Mock, patch
 
-from models.metadata_database.notification.models import NotificationDirection, NotificationEntity, NotificationStatus
+from models.metadata_database.notification.models import NotificationDirection, NotificationEntity
 from services.notifications.unique_id_push_sender_service import UniqueIdPushSenderService, CONNECT_TO_PARENT_CONTEXT, UNIQUE_ID_PUSH_DCT_TYPE
 from tools.constants import INDUSTRY_CORE_HUB
 

--- a/ichub-backend/tools/constants.py
+++ b/ichub-backend/tools/constants.py
@@ -60,5 +60,5 @@ API_V1 = "v1"
 # ==================== USE CASE =========================
 CCM = "CCM"
 TRACEABILITY = "Traceability"
-INDUSTRY_CORE_HUB = "Industry Core Hub"
+INDUSTRY_CORE_HUB = "ICHUB"
 PCF = "PCF"

--- a/ichub-frontend/src/features/notifications/components/NotificationsPanel.tsx
+++ b/ichub-frontend/src/features/notifications/components/NotificationsPanel.tsx
@@ -66,6 +66,7 @@ const NotificationsPanel: React.FC = () => {
     const palette: Record<string, { bg: string; activeBg: string; color: string }> = {
       PCF: { bg: 'rgba(0, 188, 212, 0.12)', activeBg: 'rgba(0, 188, 212, 0.35)', color: '#00bcd4' },
       CCM: { bg: 'rgba(255, 152, 0, 0.12)', activeBg: 'rgba(255, 152, 0, 0.35)', color: '#ffa726' },
+      ICHUB: { bg: 'rgba(102, 187, 106, 0.12)', activeBg: 'rgba(102, 187, 106, 0.35)', color: '#66bb6a' },
     };
     const p = palette[useCase.toUpperCase()] ?? { bg: 'rgba(158,158,158,0.12)', activeBg: 'rgba(158,158,158,0.35)', color: '#bdbdbd' };
     return { backgroundColor: isActive ? p.activeBg : p.bg, color: isActive ? '#fff' : p.color };


### PR DESCRIPTION
## WHAT

This pull request introduces significant enhancements to policy configurations across multiple environment-specific Helm values files for the industry-core-hub. The main focus is on adding detailed "consumption" and "access" policy sections and introducing configuration for a new "Unique ID Push" notification endpoint, which includes its own asset and policy definitions. These changes improve compliance, governance, and interoperability for data exchange processes.

## WHY

To be able to fullfil the industry core standard.

Closes #617
