### PR TITLE
feat: enhance pcf compatibility with multi version support legacy apis and version negotiation

### DIFF
--- a/charts/industry-core-hub/templates/configmap-backend-postgres-init.yaml
+++ b/charts/industry-core-hub/templates/configmap-backend-postgres-init.yaml
@@ -1,7 +1,7 @@
 {{- /*
 * Eclipse Tractus-X - Industry Core Hub
 *
-* Copyright (c) 2025 LKS Next
+* Copyright (c) 2025,2026 LKS Next
 * Copyright (c) 2025 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional

--- a/charts/industry-core-hub/templates/configmap-backend-postgres-init.yaml
+++ b/charts/industry-core-hub/templates/configmap-backend-postgres-init.yaml
@@ -234,7 +234,8 @@ data:
         customer_part_id character varying,
         message character varying,
         pcf_location character varying,
-        correlation_id character varying
+        correlation_id character varying,
+        version character varying NOT NULL DEFAULT 'v9.0.0'
     );
 
     CREATE TABLE public.pcf_relationships (
@@ -544,6 +545,7 @@ data:
     CREATE INDEX idx_pcf_exchanges_manufacturer_part_id ON public.pcf_exchanges USING btree (manufacturer_part_id);
     CREATE INDEX idx_pcf_exchanges_customer_part_id ON public.pcf_exchanges USING btree (customer_part_id);
     CREATE INDEX idx_pcf_exchanges_correlation_id ON public.pcf_exchanges USING btree (correlation_id);
+    CREATE INDEX idx_pcf_exchanges_version ON public.pcf_exchanges USING btree (version);
     CREATE INDEX idx_pcf_exchanges_type ON public.pcf_exchanges USING btree (type);
 
     CREATE INDEX idx_pcf_relationships_main_manufacturer_part_id ON public.pcf_relationships USING btree (main_manufacturer_part_id);

--- a/charts/industry-core-hub/values-int-manufacturer.yaml
+++ b/charts/industry-core-hub/values-int-manufacturer.yaml
@@ -460,9 +460,15 @@ backend:
         enabled: false
         # -- Hostname of the PCF Exchange API
         hostname: "https://<provider-pcf-exchange-api>"
+        # -- When true, both PCF versions (v7.0.0 and v9.0.0) must be uploaded
+        # -- for a manufacturer part before it can be published or exchanged.
+        requireBothVersions:
+          synchronous: false
+          asynchronous: false
         asset_config:
-          dct_type: "cx-taxo:PcfExchange"
-          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          dct_type: "cx-taxo:PCFExchange"
+          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset (v1.2.0) wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          # existing_legacy_asset_id: <pcf-exchange-legacy-asset> # -- In case an existing PCF Exchange asset (v1.1.1 /productIds) wants to be used specify here the id
         policy:
           usage:
             context:

--- a/charts/industry-core-hub/values-int.yaml
+++ b/charts/industry-core-hub/values-int.yaml
@@ -441,9 +441,15 @@ backend:
         enabled: false
         # -- Hostname of the PCF Exchange API
         hostname: "https://<provider-pcf-exchange-api>"
+        # -- When true, both PCF versions (v7.0.0 and v9.0.0) must be uploaded
+        # -- for a manufacturer part before it can be published or exchanged.
+        requireBothVersions:
+          synchronous: false
+          asynchronous: false
         asset_config:
-          dct_type: "cx-taxo:PcfExchange"
-          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          dct_type: "cx-taxo:PCFExchange"
+          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset (v1.2.0) wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          # existing_legacy_asset_id: <pcf-exchange-legacy-asset> # -- In case an existing PCF Exchange asset (v1.1.1 /productIds) wants to be used specify here the id
         policy:
           usage:
             context:

--- a/charts/industry-core-hub/values-saturn.yaml
+++ b/charts/industry-core-hub/values-saturn.yaml
@@ -373,9 +373,15 @@ backend:
         enabled: false
         # -- Hostname of the PCF Exchange API
         hostname: "https://<provider-pcf-exchange-api>"
+        # -- When true, both PCF versions (v7.0.0 and v9.0.0) must be uploaded
+        # -- for a manufacturer part before it can be published or exchanged.
+        requireBothVersions:
+          synchronous: false
+          asynchronous: false
         asset_config:
-          dct_type: "cx-taxo:PcfExchange"
-          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          dct_type: "cx-taxo:PCFExchange"
+          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset (v1.2.0) wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          # existing_legacy_asset_id: <pcf-exchange-legacy-asset> # -- In case an existing PCF Exchange asset (v1.1.1 /productIds) wants to be used specify here the id
         policy:
           usage:
             context:

--- a/charts/industry-core-hub/values.yaml
+++ b/charts/industry-core-hub/values.yaml
@@ -649,9 +649,16 @@ backend:
         enabled: false
         # -- Hostname of the PCF Exchange API
         hostname: "https://<provider-pcf-exchange-api>"
+        # -- When true, both PCF versions (v7.0.0 and v9.0.0) must be uploaded
+        # -- for a manufacturer part before it can be published or exchanged.
+        # -- Each flow type can be toggled independently.
+        requireBothVersions:
+          synchronous: false
+          asynchronous: false
         asset_config:
-          dct_type: "cx-taxo:PcfExchange"
-          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          dct_type: "cx-taxo:PCFExchange"
+          # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset (v1.2.0) wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+          # existing_legacy_asset_id: <pcf-exchange-legacy-asset> # -- In case an existing PCF Exchange asset (v1.1.1 /productIds) wants to be used specify here the id
         policy:
           usage:
             context:

--- a/docs/database/Metadata-DDL-public.sql
+++ b/docs/database/Metadata-DDL-public.sql
@@ -229,7 +229,8 @@ CREATE TABLE public.pcf_exchanges (
     customer_part_id character varying,
     message character varying,
     pcf_location character varying,
-    correlation_id character varying
+    correlation_id character varying,
+    version character varying NOT NULL DEFAULT 'v9.0.0'
 );
 
 CREATE TABLE public.pcf_relationships (
@@ -568,6 +569,7 @@ CREATE INDEX idx_pcf_exchanges_requesting_bpn ON public.pcf_exchanges USING btre
 CREATE INDEX idx_pcf_exchanges_responding_bpn ON public.pcf_exchanges USING btree (responding_bpn);
 CREATE INDEX idx_pcf_exchanges_manufacturer_part_id ON public.pcf_exchanges USING btree (manufacturer_part_id);
 CREATE INDEX idx_pcf_exchanges_correlation_id ON public.pcf_exchanges USING btree (correlation_id);
+CREATE INDEX idx_pcf_exchanges_version ON public.pcf_exchanges USING btree (version);
 
 CREATE INDEX idx_pcf_relationships_main_manufacturer_part_id ON public.pcf_relationships USING btree (main_manufacturer_part_id);
 

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -612,8 +612,9 @@ provider:
       synchronous: false
       asynchronous: false
     asset_config:
-      dct_type: "cx-taxo:PcfExchange"
-      # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+      dct_type: "cx-taxo:PCFExchange"
+      # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset (v1.2.0) wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created
+      # existing_legacy_asset_id: <pcf-exchange-legacy-asset> # -- In case an existing PCF Exchange asset (v1.1.1 /productIds) wants to be used specify here the id
     policy:
       usage:
         context:

--- a/ichub-backend/config/configuration.yml
+++ b/ichub-backend/config/configuration.yml
@@ -605,6 +605,12 @@ provider:
   pcfExchange:
     enabled: false
     hostname: "https://<provider-pcf-exchange-api>"
+    # -- When true, both PCF versions (v7.0.0 and v9.0.0) must be uploaded
+    # -- for a manufacturer part before it can be published or exchanged.
+    # -- Each flow type can be toggled independently.
+    requireBothVersions:
+      synchronous: false
+      asynchronous: false
     asset_config:
       dct_type: "cx-taxo:PcfExchange"
       # existing_asset_id: <pcf-exchange-asset> # -- In case an existing PCF Exchange asset wants to be used specify here the id, otherwise it will be created based on the url, if it not exists it will be created

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/pcf_kit.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/pcf_kit.py
@@ -23,7 +23,7 @@
 
 from fastapi import APIRouter, Depends
 
-from .v1 import consumption, exchange, provision
+from .v1 import consumption, exchange, product_ids, provision
 
 from controllers.fastapi.routers.authentication.auth_api import get_authentication_dependency
 
@@ -36,3 +36,4 @@ router = APIRouter(
 router.include_router(consumption.router)
 router.include_router(provision.router)
 router.include_router(exchange.router)
+router.include_router(product_ids.router)

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/exchange.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/exchange.py
@@ -32,6 +32,7 @@ from managers.addons_service.pcf_kit.v1 import exchange_manager
 from managers.config.log_manager import LoggingManager
 from tools.exceptions import NotFoundError
 from utils.log_utils import sanitize_log_value as _s
+from utils.pcf_utils import DEFAULT_PCF_VERSION, SUPPORTED_PCF_VERSIONS
 from tools.constants import INTERNAL_SERVER_ERROR
 
 logger = LoggingManager.get_logger(__name__)
@@ -55,7 +56,11 @@ async def put_pcf_with_path_id(
     body: dict = Body(...),
     edc_bpn: Optional[str] = Header(None, alias="edc-bpn", description=EDC_BPN_DESCRIPTION),
     message: Optional[str] = Query(None, max_length=250, description=MESSAGE_DESCRIPTION),
-    update: bool = Query(False, description="Whether this is an update to an existing request")
+    update: bool = Query(False, description="Whether this is an update to an existing request"),
+    version: str = Query(
+        DEFAULT_PCF_VERSION,
+        description="PCF schema version (e.g. v7.0.0, v9.0.0)",
+    ),
 ):
     """
     PCF Response / Update endpoint.
@@ -89,6 +94,11 @@ async def put_pcf_with_path_id(
         )
     
     try:
+        if version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
         logger.debug(f"[PCF Exchange PUT] Delegating to exchange_manager.submit_pcf_response()")
         # Delegate to manager to handle PCF response/update
         result = exchange_manager.submit_pcf_response(
@@ -96,7 +106,8 @@ async def put_pcf_with_path_id(
             pcf_data=body,
             edc_bpn=edc_bpn,
             is_update=update,
-            message=message
+            message=message,
+            version=version,
         )
         
         logger.info(f"[PCF Exchange PUT] Response processed successfully: request_id={_s(request_id)}")
@@ -120,7 +131,11 @@ async def request_pcf(
     edc_bpn: Optional[str] = Header(None, alias="edc-bpn", description=EDC_BPN_DESCRIPTION),
     manufacturer_part_id: Optional[str] = Query(None, alias="manufacturerPartId", description="Manufacturer part ID"),
     customer_part_id: Optional[str] = Query(None, alias="customerPartId", description="Customer part ID"),
-    message: Optional[str] = Query(None, max_length=250, description=MESSAGE_DESCRIPTION)
+    message: Optional[str] = Query(None, max_length=250, description=MESSAGE_DESCRIPTION),
+    version: str = Query(
+        DEFAULT_PCF_VERSION,
+        description="PCF schema version (e.g. v7.0.0, v9.0.0)",
+    ),
 ):
     """
     PCF Request endpoint.
@@ -162,6 +177,11 @@ async def request_pcf(
         )
 
     try:
+        if version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
         logger.debug(f"[PCF Exchange GET] Delegating to exchange_manager.request_pcf()")
         # Delegate to manager to handle PCF request
         result = exchange_manager.request_pcf(
@@ -169,7 +189,8 @@ async def request_pcf(
             edc_bpn=edc_bpn,
             manufacturer_part_id=manufacturer_part_id,
             customer_part_id=customer_part_id,
-            message=message
+            message=message,
+            version=version,
         )
         
         logger.info(f"[PCF Exchange GET] Request processed successfully: request_id={_s(request_id)}")

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/exchange.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/exchange.py
@@ -30,7 +30,7 @@ from fastapi.responses import JSONResponse
 from controllers.fastapi.routers.authentication.auth_api import get_authentication_dependency
 from managers.addons_service.pcf_kit.v1 import exchange_manager
 from managers.config.log_manager import LoggingManager
-from tools.exceptions import NotFoundError
+from tools.exceptions import NotFoundError, PcfVersionGateError
 from utils.log_utils import sanitize_log_value as _s
 from utils.pcf_utils import DEFAULT_PCF_VERSION, SUPPORTED_PCF_VERSIONS
 from tools.constants import INTERNAL_SERVER_ERROR
@@ -115,6 +115,9 @@ async def put_pcf_with_path_id(
             status_code=200,
             content=result
         )
+    except PcfVersionGateError as e:
+        logger.warning(f"[PCF Exchange PUT] Version gate blocked: {_s(e)}")
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         logger.error(f"[PCF Exchange PUT] ValueError: {_s(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/product_ids.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/product_ids.py
@@ -21,11 +21,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #################################################################################
 
-"""PCF Exchange API - EDC-level endpoints for PCF data exchange (v1.2.0).
+"""PCF Exchange API - Legacy v1.1.1 ``/productIds`` endpoints (CX-0136 backward compatibility).
 
-These endpoints are served behind the v1.2.0 EDC asset and always operate
-with PCF schema version v9.0.0.  The version is implicit from the asset
+These endpoints are served behind the v1.1.1 EDC asset and always operate
+with PCF schema version v7.0.0.  The version is implicit from the asset
 negotiated — no version query parameter is exposed.
+
+Key differences from the v1.2.0 ``/footprintExchange`` endpoints:
+
+* Path parameter is ``productId`` (= manufacturerPartId), **not** ``requestId``.
+* ``requestId`` is a **query** parameter, not a path parameter.
 """
 
 from typing import Optional
@@ -42,39 +47,40 @@ from tools.constants import INTERNAL_SERVER_ERROR
 logger = LoggingManager.get_logger(__name__)
 
 router = APIRouter(
-    prefix="/footprintExchange",
+    prefix="/productIds",
     tags=["PCF KIT Microservices"],
     dependencies=[Depends(get_authentication_dependency())]
 )
 
-logger.info("[PCF Exchange] Router initialized")
+logger.info("[PCF ProductIds] Router initialized")
 
 
-# PCF schema version used by the v1.2.0 /footprintExchange endpoints
-_PCF_VERSION = "v9.0.0"
+# PCF schema version used by the v1.1.1 /productIds endpoints
+_PCF_VERSION = "v7.0.0"
 
 EDC_BPN_DESCRIPTION = "The caller's Catena-X BusinessPartnerNumber"
 MESSAGE_DESCRIPTION = "URL encoded, max 250 chars"
 
 
-@router.put("/{requestId}")
-async def put_pcf_with_path_id(
-    request_id: str = Path(..., alias="requestId"),
+@router.put("/{productId}")
+async def put_pcf_legacy(
+    product_id: str = Path(..., alias="productId"),
     body: dict = Body(...),
+    request_id: str = Query(..., alias="requestId", description="ID of the PCF exchange request"),
     edc_bpn: Optional[str] = Header(None, alias="edc-bpn", description=EDC_BPN_DESCRIPTION),
     message: Optional[str] = Query(None, max_length=250, description=MESSAGE_DESCRIPTION),
     update: bool = Query(False, description="Whether this is an update to an existing request"),
 ):
     """
-    PCF Response / Update endpoint.
+    Legacy PCF Response / Update endpoint (v1.1.1 API shape).
 
-    This endpoint accepts PCF data as a response to an open request or as an update
-    to an existing request. The PCF data should match the Catena-X aspect model
-    urn:samm:io.catenax.pcf:9.0.0#Pcf.
+    Accepts PCF data as a response to an open request or as an update. The PCF
+    data should match the Catena-X aspect model ``urn:samm:io.catenax.pcf:7.0.0#Pcf``.
 
     Args:
-        request_id: The ID of the footprint request or response
-        body: PCF data matching the Catena-X PCF aspect model (9.0.0)
+        product_id: The manufacturer part ID (path parameter in v1.1.1 API)
+        body: PCF data matching the Catena-X PCF aspect model (7.0.0)
+        request_id: The ID of the footprint request or response (query parameter)
         edc_bpn: The caller's Catena-X BusinessPartnerNumber (automatically set by EDC)
         message: Optional URL encoded message (max 250 chars)
         update: Whether this is an update to an existing request (default: False)
@@ -85,20 +91,21 @@ async def put_pcf_with_path_id(
     Raises:
         HTTPException: 400 for bad request
     """
-    # Log incoming request
-    logger.info(f"[PCF Exchange PUT] Incoming request: request_id={_s(request_id)}, edc_bpn={_s(edc_bpn)}, update={_s(update)}, message={_s(message)}")
-    
-    # Validate edc_bpn header
+    logger.info(
+        f"[PCF ProductIds PUT] Incoming request: productId={_s(product_id)}, "
+        f"requestId={_s(request_id)}, edc_bpn={_s(edc_bpn)}, "
+        f"update={_s(update)}, message={_s(message)}"
+    )
+
     if not edc_bpn:
-        logger.error("[PCF Exchange PUT] Missing edc-bpn header")
+        logger.error("[PCF ProductIds PUT] Missing edc-bpn header")
         raise HTTPException(
             status_code=400,
             detail="Missing required header: edc-bpn"
         )
-    
+
     try:
-        logger.debug(f"[PCF Exchange PUT] Delegating to exchange_manager.submit_pcf_response()")
-        # Delegate to manager to handle PCF response/update
+        logger.debug("[PCF ProductIds PUT] Delegating to exchange_manager.submit_pcf_response()")
         result = exchange_manager.submit_pcf_response(
             request_id=request_id,
             pcf_data=body,
@@ -107,94 +114,77 @@ async def put_pcf_with_path_id(
             message=message,
             version=_PCF_VERSION,
         )
-        
-        logger.info(f"[PCF Exchange PUT] Response processed successfully: request_id={_s(request_id)}")
-        return JSONResponse(
-            status_code=200,
-            content=result
-        )
+
+        logger.info(f"[PCF ProductIds PUT] Response processed successfully: requestId={_s(request_id)}")
+        return JSONResponse(status_code=200, content=result)
     except PcfVersionGateError as e:
-        logger.warning(f"[PCF Exchange PUT] Version gate blocked: {_s(e)}")
+        logger.warning(f"[PCF ProductIds PUT] Version gate blocked: {_s(e)}")
         raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
-        logger.error(f"[PCF Exchange PUT] ValueError: {_s(e)}", exc_info=True)
+        logger.error(f"[PCF ProductIds PUT] ValueError: {_s(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError:
         raise
     except Exception as e:
-        logger.error(f"[PCF Exchange PUT] Unexpected exception: {_s(e)}", exc_info=True)
+        logger.error(f"[PCF ProductIds PUT] Unexpected exception: {_s(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=INTERNAL_SERVER_ERROR)
 
 
-@router.get("/{requestId}")
-async def request_pcf(
-    request_id: str = Path(..., alias="requestId"),
+@router.get("/{productId}")
+async def request_pcf_legacy(
+    product_id: str = Path(..., alias="productId"),
+    request_id: str = Query(..., alias="requestId", description="ID of the PCF exchange request"),
     edc_bpn: Optional[str] = Header(None, alias="edc-bpn", description=EDC_BPN_DESCRIPTION),
-    manufacturer_part_id: Optional[str] = Query(None, alias="manufacturerPartId", description="Manufacturer part ID"),
-    customer_part_id: Optional[str] = Query(None, alias="customerPartId", description="Customer part ID"),
     message: Optional[str] = Query(None, max_length=250, description=MESSAGE_DESCRIPTION),
 ):
     """
-    PCF Request endpoint.
+    Legacy PCF Request endpoint (v1.1.1 API shape).
 
-    Request a footprint for a product. At least one of manufacturerPartId or 
-    customerPartId must be provided. This initiates an asynchronous PCF data 
-    exchange with the supplier.
+    Request a footprint for a product identified by ``productId``
+    (= manufacturerPartId).
 
     Args:
-        request_id: The ID of the footprint request
+        product_id: The manufacturer part ID (path parameter in v1.1.1 API)
+        request_id: Unique identifier for the PCF request (query parameter)
         edc_bpn: The caller's Catena-X BusinessPartnerNumber (automatically set by EDC)
-        manufacturer_part_id: Manufacturer's part identifier
-        customer_part_id: Customer's part identifier
         message: Optional URL encoded message (max 250 chars)
 
     Returns:
-        JSONResponse with status code 200 for success
+        JSONResponse with status code 202 for accepted
 
     Raises:
-        HTTPException: 400 if both IDs are missing, 404 if request not found
+        HTTPException: 400 for missing edc-bpn, 404 if not found
     """
-    # Log incoming request
-    logger.info(f"[PCF Exchange GET] Incoming request: request_id={_s(request_id)}, edc_bpn={_s(edc_bpn)}, manufacturerPartId={_s(manufacturer_part_id)}, customerPartId={_s(customer_part_id)}, message={_s(message)}")
-    
-    # Validate edc_bpn header
+    logger.info(
+        f"[PCF ProductIds GET] Incoming request: productId={_s(product_id)}, "
+        f"requestId={_s(request_id)}, edc_bpn={_s(edc_bpn)}, message={_s(message)}"
+    )
+
     if not edc_bpn:
-        logger.error("[PCF Exchange GET] Missing edc-bpn header")
+        logger.error("[PCF ProductIds GET] Missing edc-bpn header")
         raise HTTPException(
             status_code=400,
             detail="Missing required header: edc-bpn"
         )
-    
-    # Validate that at least one part ID is provided
-    if not manufacturer_part_id and not customer_part_id:
-        logger.warning(f"[PCF Exchange GET] Missing part IDs: manufacturerPartId={_s(manufacturer_part_id)}, customerPartId={_s(customer_part_id)}")
-        raise HTTPException(
-            status_code=400,
-            detail="At least one of manufacturerPartId or customerPartId must be provided"
-        )
 
     try:
-        logger.debug(f"[PCF Exchange GET] Delegating to exchange_manager.request_pcf()")
-        # Delegate to manager to handle PCF request
+        logger.debug("[PCF ProductIds GET] Delegating to exchange_manager.request_pcf()")
         result = exchange_manager.request_pcf(
             request_id=request_id,
             edc_bpn=edc_bpn,
-            manufacturer_part_id=manufacturer_part_id,
-            customer_part_id=customer_part_id,
+            manufacturer_part_id=product_id,
+            customer_part_id=None,
             message=message,
             version=_PCF_VERSION,
         )
-        
-        logger.info(f"[PCF Exchange GET] Request processed successfully: request_id={_s(request_id)}")
-        return JSONResponse(
-            status_code=202,
-            content=result
-        )
+
+        logger.info(f"[PCF ProductIds GET] Request processed successfully: requestId={_s(request_id)}")
+        return JSONResponse(status_code=202, content=result)
     except ValueError as e:
-        logger.error(f"[PCF Exchange GET] ValueError: {_s(e)}", exc_info=True)
+        logger.error(f"[PCF ProductIds GET] ValueError: {_s(e)}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError:
         raise
     except Exception as e:
-        logger.error(f"[PCF Exchange GET] Unexpected exception: {_s(e)}", exc_info=True)
+        logger.error(f"[PCF ProductIds GET] Unexpected exception: {_s(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=INTERNAL_SERVER_ERROR)

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/provision.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/provision.py
@@ -36,6 +36,7 @@ from models.services.addons.pcf_kit.v1.management import GovernanceBodyModel, No
 from models.services.addons.pcf_kit.v1.models import PcfExchangeModel
 from tools.exceptions import NotFoundError
 from utils.log_utils import sanitize_log_value as _s
+from utils.pcf_utils import DEFAULT_PCF_VERSION, SUPPORTED_PCF_VERSIONS
 from tools.constants import INTERNAL_SERVER_ERROR
 
 logger = LoggingManager.get_logger(__name__)
@@ -51,10 +52,19 @@ router = APIRouter(
 @router.post("/pcfs/{manufacturerPartId}", status_code=201)
 async def upload_new_pcf(
     manufacturer_part_id: str = Path(..., alias="manufacturerPartId"),
-    pcf_data: Dict[str, Any] = Body(...)
+    pcf_data: Dict[str, Any] = Body(...),
+    version: str = Query(
+        DEFAULT_PCF_VERSION,
+        description="PCF schema version (e.g. v7.0.0, v9.0.0)",
+    ),
 ) -> Dict[str, Any]:
     try:
-        result = provision_manager.upload_new_pcf(manufacturer_part_id, pcf_data)
+        if version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
+        result = provision_manager.upload_new_pcf(manufacturer_part_id, pcf_data, version=version)
         return JSONResponse(status_code=201, content=result)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -66,9 +76,20 @@ async def upload_new_pcf(
 
 
 @router.get("/pcfs/{manufacturerPartId}")
-async def view_existing_pcf(manufacturer_part_id: str = Path(..., alias="manufacturerPartId")) -> Dict[str, Any]:
+async def view_existing_pcf(
+    manufacturer_part_id: str = Path(..., alias="manufacturerPartId"),
+    version: str = Query(
+        DEFAULT_PCF_VERSION,
+        description="PCF schema version to retrieve (e.g. v7.0.0, v9.0.0)",
+    ),
+) -> Dict[str, Any]:
     try:
-        result = provision_manager.view_existing_pcf(manufacturer_part_id)
+        if version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
+        result = provision_manager.view_existing_pcf(manufacturer_part_id, version=version)
         return JSONResponse(status_code=200, content=result)
     except ValueError as e: 
         raise HTTPException(status_code=400, detail=str(e))
@@ -82,10 +103,19 @@ async def view_existing_pcf(manufacturer_part_id: str = Path(..., alias="manufac
 @router.put("/pcfs/{manufacturerPartId}")
 async def update_pcf_and_get_participants(
     manufacturer_part_id: str = Path(..., alias="manufacturerPartId"),
-    pcf_data: Dict[str, Any] = Body(...)
+    pcf_data: Dict[str, Any] = Body(...),
+    version: str = Query(
+        DEFAULT_PCF_VERSION,
+        description="PCF schema version (e.g. v7.0.0, v9.0.0)",
+    ),
 ) -> List[str]:
     try:
-        result = provision_manager.update_pcf_and_get_participants(manufacturer_part_id, pcf_data)
+        if version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
+        result = provision_manager.update_pcf_and_get_participants(manufacturer_part_id, pcf_data, version=version)
         return JSONResponse(status_code=200, content=result)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -120,11 +150,17 @@ async def confirm_and_send_update_to_participants(
 @router.get("/requests", response_model=List[PcfExchangeModel], response_model_by_alias=True)
 async def list_provider_notifications(
     status: Optional[PcfExchangeStatus] = Query(None, description="Filter by request status (e.g., pending, delivered)"),
+    version: Optional[str] = Query(None, description="Filter by PCF schema version (e.g. v7.0.0, v9.0.0)"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     limit: int = Query(100, ge=1, le=1000, description="Pagination limit")
 ) -> List[PcfExchangeModel]:
     try:
-        result = provision_manager.list_provider_notifications(status=status, offset=offset, limit=limit)
+        if version is not None and version not in SUPPORTED_PCF_VERSIONS:
+            raise ValueError(
+                f"Unsupported PCF version '{version}'. "
+                f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+            )
+        result = provision_manager.list_provider_notifications(status=status, version=version, offset=offset, limit=limit)
         return result
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/provision.py
+++ b/ichub-backend/controllers/fastapi/routers/addons/pcf_kit/v1/provision.py
@@ -34,7 +34,7 @@ from managers.config.log_manager import LoggingManager
 from models.metadata_database.pcf import PcfExchangeStatus
 from models.services.addons.pcf_kit.v1.management import GovernanceBodyModel, NotifyUpdateModel
 from models.services.addons.pcf_kit.v1.models import PcfExchangeModel
-from tools.exceptions import NotFoundError
+from tools.exceptions import NotFoundError, PcfVersionGateError
 from utils.log_utils import sanitize_log_value as _s
 from utils.pcf_utils import DEFAULT_PCF_VERSION, SUPPORTED_PCF_VERSIONS
 from tools.constants import INTERNAL_SERVER_ERROR
@@ -117,6 +117,8 @@ async def update_pcf_and_get_participants(
             )
         result = provision_manager.update_pcf_and_get_participants(manufacturer_part_id, pcf_data, version=version)
         return JSONResponse(status_code=200, content=result)
+    except PcfVersionGateError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError:
@@ -138,6 +140,8 @@ async def confirm_and_send_update_to_participants(
             list_policies=body.governance if body else None
         )
         return JSONResponse(status_code=200, content=result)
+    except PcfVersionGateError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError:
@@ -179,6 +183,8 @@ async def accept_request_and_send_response(
     try:
         result = provision_manager.accept_request_and_send_response(request_id=request_id, list_policies=body.governance if body else None)
         return JSONResponse(status_code=200, content=result)
+    except PcfVersionGateError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except NotFoundError:

--- a/ichub-backend/jobs/asset_sync_job.py
+++ b/ichub-backend/jobs/asset_sync_job.py
@@ -191,10 +191,16 @@ class AssetSyncJob:
 
     def _sync_pcf_exchange_asset(self) -> None:
         """
-        Synchronize the PCF Exchange asset with the connector.
+        Synchronize both PCF Exchange assets with the connector.
+
+        CX-0136 §6 requires two EDC assets with the same ``dct:type``
+        (``PCFExchange``) but different ``cx-common:version``:
+
+        * **v1.2.0** → ``/footprintExchange`` endpoints (PCF v9.0.0)
+        * **v1.1.1** → ``/productIds`` endpoints      (PCF v7.0.0)
         """
         try:
-            logger.info("[AssetSyncJob] Synchronizing PCF Exchange asset...")
+            logger.info("[AssetSyncJob] Synchronizing PCF Exchange assets...")
             
             # Get PCF Exchange configuration
             pcf_config = ConfigManager.get_config("provider.pcfExchange")
@@ -204,20 +210,36 @@ class AssetSyncJob:
             
             asset_config = pcf_config.get("asset_config", {})
             
-            # Register PCF Exchange asset
+            # --- v1.2.0 asset (/footprintExchange → PCF v9.0.0) ---
             pcf_asset_id, _, _, _ = self.connector_provider_manager.register_pcf_exchange_offer(
                 base_url=pcf_config.get("hostname"),
+                api_path="/v1/addons/pcf-kit/footprintExchange",
                 pcf_exchange_policy_config=pcf_config.get("policy"),
-                existing_asset_id=asset_config.get("existing_asset_id", None)
+                existing_asset_id=asset_config.get("existing_asset_id", None),
+                version="1.2.0",
             )
             
             if pcf_asset_id:
-                logger.info(f"[AssetSyncJob] PCF Exchange asset synchronized: {pcf_asset_id}")
+                logger.info(f"[AssetSyncJob] PCF Exchange v1.2.0 asset synchronized: {pcf_asset_id}")
             else:
-                logger.error("[AssetSyncJob] Failed to synchronize PCF Exchange asset.")
+                logger.error("[AssetSyncJob] Failed to synchronize PCF Exchange v1.2.0 asset.")
+
+            # --- v1.1.1 asset (/productIds → PCF v7.0.0) ---
+            legacy_asset_id, _, _, _ = self.connector_provider_manager.register_pcf_exchange_offer(
+                base_url=pcf_config.get("hostname"),
+                api_path="/v1/addons/pcf-kit/productIds",
+                pcf_exchange_policy_config=pcf_config.get("policy"),
+                existing_asset_id=asset_config.get("existing_legacy_asset_id", None),
+                version="1.1.1",
+            )
+
+            if legacy_asset_id:
+                logger.info(f"[AssetSyncJob] PCF Exchange v1.1.1 (legacy) asset synchronized: {legacy_asset_id}")
+            else:
+                logger.error("[AssetSyncJob] Failed to synchronize PCF Exchange v1.1.1 (legacy) asset.")
                 
         except Exception as e:
-            logger.error(f"[AssetSyncJob] Error synchronizing PCF Exchange asset: {e}", exc_info=True)
+            logger.error(f"[AssetSyncJob] Error synchronizing PCF Exchange assets: {e}", exc_info=True)
 
     def _pcf_kit_enablement_check(self) -> bool:
         """

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/consumption.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/consumption.py
@@ -40,11 +40,9 @@ from managers.addons_service.pcf_kit.v1.management import management_manager
 from models.metadata_database.pcf import PcfExchangeDirection, PcfExchangeStatus, PcfExchangeType
 from models.services.addons.pcf_kit.v1.models import PcfExchangeModel, PcfRelationshipModel, PcfSpecificStateModel
 from utils.log_utils import sanitize_log_value as _s
+from utils.pcf_utils import PCF_EXCHANGE_ASSET_TYPE
 
 logger = LoggingManager.get_logger(__name__)
-
-# Asset type used to identify PCF exchange assets in EDC catalogs (CX-0136)
-PCF_EXCHANGE_ASSET_TYPE = "https://w3id.org/catenax/taxonomy#PcfExchange"
 
 
 class PcfConsumptionManager:
@@ -85,9 +83,12 @@ class PcfConsumptionManager:
         list_policies: Optional[List[Dict]] = None,
     ) -> None:
         """
-        Send a PCF request to the data provider via EDC.
+        Send a PCF request to the data provider via EDC with version negotiation.
 
-        Delegates to the management manager's generic send_via_edc method.
+        Tries the v1.2.0 asset (``/footprintExchange``) first. If no v1.2.0
+        asset is available in the provider's catalog, falls back to the
+        v1.1.1 legacy asset (``/productIds``). CX-0136 §6 requires the
+        consumer to pick the highest compatible ``cx-common:version``.
 
         Args:
             request_id: The PCF request ID.
@@ -98,29 +99,58 @@ class PcfConsumptionManager:
             list_policies: Optional list of policies.
 
         Raises:
-            ValueError: If the data transfer fails.
+            ValueError: If the data transfer fails on all versions.
         """
-        # Build query parameters per CX-0136 footprintExchange GET spec
-        params: Dict[str, str] = {}
-        if manufacturer_part_id:
-            params["manufacturerPartId"] = manufacturer_part_id
-        if customer_part_id:
-            params["customerPartId"] = customer_part_id
+        # --- Try v1.2.0 first (highest version) ---
+        try:
+            params_v120: Dict[str, str] = {}
+            if manufacturer_part_id:
+                params_v120["manufacturerPartId"] = manufacturer_part_id
+            if customer_part_id:
+                params_v120["customerPartId"] = customer_part_id
+            if message:
+                params_v120["message"] = quote(message, safe="")
+
+            management_manager.send_via_edc(
+                request_id=request_id,
+                target_bpn=target_bpn,
+                http_method="GET",
+                path=f"/{request_id}",
+                params=params_v120 if params_v120 else None,
+                list_policies=list_policies,
+                asset_type=PCF_EXCHANGE_ASSET_TYPE,
+                asset_version="1.2.0",
+            )
+            logger.info(f"[PCF Consumption] Request {_s(request_id)} sent via v1.2.0 asset")
+            return
+        except Exception as e:
+            logger.info(
+                f"[PCF Consumption] v1.2.0 asset not available for BPN {_s(target_bpn)}, "
+                f"falling back to v1.1.1: {_s(e)}"
+            )
+
+        # --- Fall back to v1.1.1 (legacy /productIds) ---
+        if not manufacturer_part_id:
+            raise ValueError(
+                "Cannot fall back to v1.1.1 /productIds API: "
+                "manufacturerPartId is required but not provided."
+            )
+
+        params_v111: Dict[str, str] = {"requestId": request_id}
         if message:
-            params["message"] = quote(message, safe="")
+            params_v111["message"] = quote(message, safe="")
 
-        get_path = f"/{request_id}"
-
-        # Use the shared EDC method from management manager
         management_manager.send_via_edc(
             request_id=request_id,
             target_bpn=target_bpn,
             http_method="GET",
-            path=get_path,
-            params=params if params else None,
+            path=f"/{manufacturer_part_id}",
+            params=params_v111,
             list_policies=list_policies,
             asset_type=PCF_EXCHANGE_ASSET_TYPE,
+            asset_version="1.1.1",
         )
+        logger.info(f"[PCF Consumption] Request {_s(request_id)} sent via v1.1.1 (legacy) asset")
 
     def search_own_parts_by_manufacturer_part_id(
         self,

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
@@ -42,6 +42,7 @@ from managers.metadata_database.manager import RepositoryManagerFactory
 from models.metadata_database.pcf import PcfExchangeDirection, PcfExchangeStatus, PcfExchangeType
 from tools.json_validator import json_validator_draft_aware
 from utils.log_utils import sanitize_log_value as _s
+from utils.pcf_utils import DEFAULT_PCF_VERSION, get_pcf_semantic_id
 
 logger = LoggingManager.get_logger(__name__)
 
@@ -70,7 +71,8 @@ class PcfExchangeManager:
         edc_bpn: str,
         manufacturer_part_id: Optional[str] = None,
         customer_part_id: Optional[str] = None,
-        message: Optional[str] = None
+        message: Optional[str] = None,
+        version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         """
         Receive a PCF data request from a data consumer via EDC data plane.
@@ -91,6 +93,7 @@ class PcfExchangeManager:
             manufacturer_part_id: Manufacturer's part identifier
             customer_part_id: Customer's part identifier  
             message: Optional message accompanying the request
+            version: PCF schema version (default: ``"v9.0.0"``).
             
         Returns:
             Dict containing request confirmation details
@@ -124,7 +127,8 @@ class PcfExchangeManager:
                         responding_bpn=self._own_bpn,
                         manufacturer_part_id=manufacturer_part_id,
                         customer_part_id=customer_part_id,
-                        message=message
+                        message=message,
+                        version=version,
                     )
                     logger.info(f"Created PCF exchange record for request {_s(request_id)} with status DELIVERED")
                 else:
@@ -157,7 +161,8 @@ class PcfExchangeManager:
                         manufacturer_part_id=manufacturer_part_id,
                         customer_part_id=customer_part_id,
                         message=message,
-                        pcf_location=pcf_location
+                        pcf_location=pcf_location,
+                        version=version,
                     )
                     logger.info(f"Created PCF exchange record for response to request {_s(request_id)} with status PENDING")
                 else:
@@ -200,7 +205,8 @@ class PcfExchangeManager:
         pcf_data: Dict[str, Any],
         edc_bpn: str,
         is_update: bool = False,
-        message: Optional[str] = None
+        message: Optional[str] = None,
+        version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         """
         Receive PCF response or update via EDC data plane.
@@ -242,10 +248,11 @@ class PcfExchangeManager:
         
         try:
             # submodel_schema_finder returns {'status': ..., 'schema': <actual_schema>}
-            pcf_schema_result = submodel_schema_finder("urn:samm:io.catenax.pcf:9.0.0#Pcf")
+            semantic_id = get_pcf_semantic_id(version)
+            pcf_schema_result = submodel_schema_finder(semantic_id)
             # Use draft-aware validator (PCF schema uses Draft-04, not Draft-07)
             json_validator_draft_aware(pcf_schema_result['schema'], pcf_data)
-            logger.info(f"PCF data for request {_s(request_id)} validated successfully against schema")
+            logger.info(f"PCF data for request {_s(request_id)} validated successfully against {_s(version)} schema")
         except Exception as e:
             logger.error(f"PCF data validation failed for request {_s(request_id)}: {_s(e)}")
             raise ValueError(f"PCF data validation failed: {str(e)}")
@@ -257,7 +264,8 @@ class PcfExchangeManager:
                 pcf_data, 
                 is_update, 
                 type=PcfExchangeType.RESPONSE,
-                responding_bpn=edc_bpn
+                responding_bpn=edc_bpn,
+                version=version,
             )
         except Exception as e:
             logger.error(f"Failed to store PCF data for request {_s(request_id)}: {_s(e)}")
@@ -298,7 +306,8 @@ class PcfExchangeManager:
         pcf_data: Dict[str, Any],
         is_update: bool,
         type: PcfExchangeType,
-        responding_bpn: Optional[str] = None
+        responding_bpn: Optional[str] = None,
+        version: str = DEFAULT_PCF_VERSION,
     ) -> None:
         """
         Store the PCF payload in the submodel service and update the exchange
@@ -327,15 +336,15 @@ class PcfExchangeManager:
         
         # Try to upload new PCF data; if it already exists, check if we should update or if it's identical
         try:
-            management_manager.upload_pcf_data(manufacturer_part_id, pcf_data)
+            management_manager.upload_pcf_data(manufacturer_part_id, pcf_data, version=version)
         except ValueError as e:
             if "already exists" in str(e):
                 if is_update:
                     # Update is allowed when is_update=True
-                    management_manager.update_pcf_data(manufacturer_part_id, pcf_data)
+                    management_manager.update_pcf_data(manufacturer_part_id, pcf_data, version=version)
                 else:
                     # If is_update=False but data exists, check if it's the same data (idempotent)
-                    existing_pcf = management_manager.get_pcf_data_by_manufacturer_part_id(manufacturer_part_id)
+                    existing_pcf = management_manager.get_pcf_data_by_manufacturer_part_id(manufacturer_part_id, version=version)
                     if existing_pcf == pcf_data:
                         logger.info(f"PCF data for {_s(manufacturer_part_id)} already exists and is identical - treating as idempotent operation")
                         # Continue with normal flow (create/update response record)
@@ -349,7 +358,7 @@ class PcfExchangeManager:
                 raise
 
         with RepositoryManagerFactory.create() as repo_manager:
-            pcf_location = management_manager.get_pcf_location(manufacturer_part_id)
+            pcf_location = management_manager.get_pcf_location(manufacturer_part_id, version=version)
             
             if type == PcfExchangeType.RESPONSE:
                 # When receiving a response, create or update an INCOMING RESPONSE record
@@ -379,7 +388,8 @@ class PcfExchangeManager:
                         manufacturer_part_id=manufacturer_part_id,
                         status=PcfExchangeStatus.DELIVERED if not is_update else PcfExchangeStatus.UPDATED,
                         pcf_location=pcf_location,
-                        request_id=UUID(request_id)
+                        request_id=UUID(request_id),
+                        version=version,
                     )
                     repo_manager.commit()
                     logger.info(f"Created PCF INCOMING RESPONSE for request {_s(request_id)} with status DELIVERED")

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
@@ -334,9 +334,6 @@ class PcfExchangeManager:
             manufacturer_part_id = outgoing_request.manufacturer_part_id
             requesting_bpn = outgoing_request.requesting_bpn
 
-        # Gate: require both PCF versions before allowing publish/exchange
-        management_manager.check_both_versions_exist(manufacturer_part_id, flow="asynchronous")
-        
         # Try to upload new PCF data; if it already exists, check if we should update or if it's identical
         try:
             management_manager.upload_pcf_data(manufacturer_part_id, pcf_data, version=version)

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
@@ -138,7 +138,7 @@ class PcfExchangeManager:
                 pcf_location = None
                 if manufacturer_part_id:
                     try:
-                        pcf_location = management_manager.get_pcf_location(manufacturer_part_id)
+                        pcf_location = management_manager.get_pcf_location(manufacturer_part_id, version=version)
                     except Exception as e:
                         logger.info(f"No existing PCF data found for manufacturer_part_id {_s(manufacturer_part_id)}: {_s(e)}")
                         pcf_location = None

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/exchange.py
@@ -333,6 +333,9 @@ class PcfExchangeManager:
                 )
             manufacturer_part_id = outgoing_request.manufacturer_part_id
             requesting_bpn = outgoing_request.requesting_bpn
+
+        # Gate: require both PCF versions before allowing publish/exchange
+        management_manager.check_both_versions_exist(manufacturer_part_id, flow="asynchronous")
         
         # Try to upload new PCF data; if it already exists, check if we should update or if it's identical
         try:

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
@@ -38,7 +38,12 @@ from tractusx_sdk.dataspace.tools.validate_submodels import submodel_schema_find
 from tools.json_validator import json_validator_draft_aware
 from tools.exceptions import NotFoundError
 from utils.log_utils import sanitize_log_value as _s
-from utils.pcf_utils import PCF_SEMANTIC_ID, pcf_submodel_id
+from utils.pcf_utils import (
+    DEFAULT_PCF_VERSION,
+    get_pcf_exchange_semantic_id,
+    get_pcf_semantic_id,
+    pcf_submodel_id,
+)
 
 logger = LoggingManager.get_logger(__name__)
 
@@ -76,6 +81,7 @@ class PcfManagementManager:
             "message": entity.message,
             "pcfLocation": entity.pcf_location,
             "correlationId": entity.correlation_id,
+            "version": entity.version,
             "createdAt": entity.created_at.isoformat() if entity.created_at else None,
             "updatedAt": entity.updated_at.isoformat() if entity.updated_at else None,
         }
@@ -85,7 +91,8 @@ class PcfManagementManager:
         Retrieve the PCF data payload for a request.
 
         The payload is looked up by ``manufacturer_part_id`` (product-scoped
-        storage).
+        storage).  The PCF schema version is read from the stored entity so
+        the correct submodel document is returned.
 
         Args:
             request_id: The unique request identifier (UUID string).
@@ -106,52 +113,47 @@ class PcfManagementManager:
                     )
                     return None
 
-                # Store the manufacturer_part_id while session is open
+                # Store fields while session is open
                 stored_manufacturer_part_id = entity.manufacturer_part_id
+                stored_version = entity.version or DEFAULT_PCF_VERSION
 
-            submodel_id = pcf_submodel_id(stored_manufacturer_part_id)
+            semantic_id = get_pcf_exchange_semantic_id(stored_version)
+            submodel_id = pcf_submodel_id(stored_manufacturer_part_id, stored_version)
             pcf_data = self._submodel_service.get_twin_aspect_document(
                 submodel_id=submodel_id,
-                semantic_id=PCF_SEMANTIC_ID
+                semantic_id=semantic_id
             )
             return pcf_data
         except Exception as e:
             logger.warning(f"PCF data not found for request {_s(request_id)}: {_s(e)}")
             return None
         
-    def get_pcf_data_by_manufacturer_part_id(self, manufacturer_part_id: str) -> Optional[Dict[str, Any]]:
+    def get_pcf_data_by_manufacturer_part_id(
+        self,
+        manufacturer_part_id: str,
+        version: str = DEFAULT_PCF_VERSION,
+    ) -> Optional[Dict[str, Any]]:
         """
-        Retrieve the PCF data payload for a request.
-
-        The payload is looked up by ``manufacturer_part_id`` (product-scoped
-        storage).
+        Retrieve the PCF data payload by manufacturer part ID and version.
 
         Args:
             manufacturer_part_id: The manufacturer part ID.
+            version: PCF schema version (default: ``"v9.0.0"``).
             
         Returns:
             The PCF data payload, or None if not found.
         """
-        logger.info(f"Retrieving PCF data for manufacturer part ID {_s(manufacturer_part_id)}")
+        logger.info(
+            f"Retrieving PCF data for manufacturer part ID {_s(manufacturer_part_id)} "
+            f"version={_s(version)}"
+        )
         
         try:
-            with RepositoryManagerFactory.create() as repo_manager:
-                entity = repo_manager.pcf_repository.find_by_part_id(manufacturer_part_id)
-
-                if not entity or not entity[0].manufacturer_part_id:
-                    logger.warning(
-                        f"No manufacturerPartId for manufacturer part ID {_s(manufacturer_part_id)}. "
-                        "Cannot retrieve PCF data."
-                    )
-                    return None
-
-                # Store the manufacturer_part_id while session is open
-                stored_manufacturer_part_id = entity[0].manufacturer_part_id
-
-            submodel_id = pcf_submodel_id(stored_manufacturer_part_id)
+            semantic_id = get_pcf_exchange_semantic_id(version)
+            submodel_id = pcf_submodel_id(manufacturer_part_id, version)
             pcf_data = self._submodel_service.get_twin_aspect_document(
                 submodel_id=submodel_id,
-                semantic_id=PCF_SEMANTIC_ID
+                semantic_id=semantic_id
             )
             return pcf_data
         except Exception as e:
@@ -212,16 +214,19 @@ class PcfManagementManager:
         self,
         manufacturer_part_id: str,
         pcf_data: Dict[str, Any],
+        version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         """
         Upload a PCF payload for a product.
 
-        Validates the payload against the Catena-X PCF 9.0.0 schema and stores
-        it in the submodel service keyed by ``manufacturerPartId``.
+        Validates the payload against the Catena-X PCF schema for the
+        specified version and stores it in the submodel service keyed by
+        ``manufacturerPartId`` and ``version``.
 
         Args:
             manufacturer_part_id: The manufacturer part ID for the product.
             pcf_data: The PCF payload to store.
+            version: PCF schema version (default: ``"v9.0.0"``).
 
         Returns:
             Dictionary with upload confirmation details.
@@ -229,34 +234,38 @@ class PcfManagementManager:
         Raises:
             ValueError: If the PCF data fails schema validation.
         """
-        logger.info(f"Uploading PCF data for manufacturerPartId={_s(manufacturer_part_id)}")
+        logger.info(
+            f"Uploading PCF data for manufacturerPartId={_s(manufacturer_part_id)} "
+            f"version={_s(version)}"
+        )
 
-        submodel_id = pcf_submodel_id(manufacturer_part_id)
+        semantic_id = get_pcf_exchange_semantic_id(version)
+        submodel_id = pcf_submodel_id(manufacturer_part_id, version)
 
         # Verify that existing data is not present
         try:
             existing = self._submodel_service.get_twin_aspect_document(
                 submodel_id=submodel_id,
-                semantic_id=PCF_SEMANTIC_ID,
+                semantic_id=semantic_id,
             )
             if existing:
                 raise ValueError(
-                    f"PCF data already exists for manufacturerPartId={manufacturer_part_id}. "
-                    "Use update to modify existing data."
+                    f"PCF data already exists for manufacturerPartId={manufacturer_part_id} "
+                    f"version={version}. Use update to modify existing data."
                 )
         except NotFoundError:
             # File doesn't exist yet - this is expected for a new upload
             pass
 
 
-        self._validate_pcf_schema(pcf_data)
+        self._validate_pcf_schema(pcf_data, version)
 
 
-        pcf_location = f"submodel://{PCF_SEMANTIC_ID}/{manufacturer_part_id}"
+        pcf_location = f"submodel://{semantic_id}/{manufacturer_part_id}"
 
         self._submodel_service.upload_twin_aspect_document(
             submodel_id=submodel_id,
-            semantic_id=PCF_SEMANTIC_ID,
+            semantic_id=semantic_id,
             payload=pcf_data,
         )
 
@@ -265,12 +274,13 @@ class PcfManagementManager:
 
         logger.info(
             f"PCF data uploaded for manufacturerPartId={_s(manufacturer_part_id)} "
-            f"(submodel_id={_s(submodel_id)})"
+            f"version={_s(version)} (submodel_id={_s(submodel_id)})"
         )
 
         return {
             "manufacturerPartId": manufacturer_part_id,
             "pcfLocation": pcf_location,
+            "version": version,
             "status": "uploaded",
         }
 
@@ -278,16 +288,19 @@ class PcfManagementManager:
         self,
         manufacturer_part_id: str,
         pcf_data: Dict[str, Any],
+        version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         """
         Update an existing PCF payload for a product.
 
-        Validates the payload against the Catena-X PCF 9.0.0 schema and
-        overwrites the existing data in the submodel service.
+        Validates the payload against the Catena-X PCF schema for the
+        specified version and overwrites the existing data in the submodel
+        service.
 
         Args:
             manufacturer_part_id: The manufacturer part ID for the product.
             pcf_data: The updated PCF payload.
+            version: PCF schema version (default: ``"v9.0.0"``).
 
         Returns:
             Dictionary with update confirmation details.
@@ -296,28 +309,32 @@ class PcfManagementManager:
             ValueError: If the PCF data fails schema validation or no
                         existing data is found.
         """
-        logger.info(f"Updating PCF data for manufacturerPartId={_s(manufacturer_part_id)}")
+        logger.info(
+            f"Updating PCF data for manufacturerPartId={_s(manufacturer_part_id)} "
+            f"version={_s(version)}"
+        )
 
-        submodel_id = pcf_submodel_id(manufacturer_part_id)
+        semantic_id = get_pcf_exchange_semantic_id(version)
+        submodel_id = pcf_submodel_id(manufacturer_part_id, version)
 
         # Verify that existing data is present
         existing = self._submodel_service.get_twin_aspect_document(
             submodel_id=submodel_id,
-            semantic_id=PCF_SEMANTIC_ID,
+            semantic_id=semantic_id,
         )
         if not existing:
             raise ValueError(
-                f"No existing PCF data found for manufacturerPartId={manufacturer_part_id}. "
-                "Use upload to create new data."
+                f"No existing PCF data found for manufacturerPartId={manufacturer_part_id} "
+                f"version={version}. Use upload to create new data."
             )
 
-        self._validate_pcf_schema(pcf_data)
+        self._validate_pcf_schema(pcf_data, version)
 
-        pcf_location = f"submodel://{PCF_SEMANTIC_ID}/{manufacturer_part_id}"
+        pcf_location = f"submodel://{semantic_id}/{manufacturer_part_id}"
 
         self._submodel_service.upload_twin_aspect_document(
             submodel_id=submodel_id,
-            semantic_id=PCF_SEMANTIC_ID,
+            semantic_id=semantic_id,
             payload=pcf_data,
         )
 
@@ -325,38 +342,47 @@ class PcfManagementManager:
 
         logger.info(
             f"PCF data updated for manufacturerPartId={_s(manufacturer_part_id)} "
-            f"(submodel_id={_s(submodel_id)})"
+            f"version={_s(version)} (submodel_id={_s(submodel_id)})"
         )
 
         return {
             "manufacturerPartId": manufacturer_part_id,
             "pcfLocation": pcf_location,
+            "version": version,
             "status": "updated",
             "sharedWithBpns": shared_bpns
         }
     
-    def get_pcf_location(self, manufacturer_part_id: str) -> str:
+    def get_pcf_location(
+        self,
+        manufacturer_part_id: str,
+        version: str = DEFAULT_PCF_VERSION,
+    ) -> str:
         """
         Get the storage location of the PCF data for a given manufacturer part ID.
 
         Args:
             manufacturer_part_id: The manufacturer part ID to look up.
+            version: PCF schema version (default: ``"v9.0.0"``).
+
         Returns:
             The PCF location string (e.g., submodel URL).
         """
-        submodel_id = pcf_submodel_id(manufacturer_part_id)
+        semantic_id = get_pcf_exchange_semantic_id(version)
+        submodel_id = pcf_submodel_id(manufacturer_part_id, version)
 
         # Verify that existing data is present
         existing = self._submodel_service.get_twin_aspect_document(
             submodel_id=submodel_id,
-            semantic_id=PCF_SEMANTIC_ID,
+            semantic_id=semantic_id,
         )
 
         if not existing:
             raise ValueError(
-                f"No existing PCF data found for manufacturerPartId={manufacturer_part_id}."
+                f"No existing PCF data found for manufacturerPartId={manufacturer_part_id} "
+                f"version={version}."
             )
-        return f"submodel://{PCF_SEMANTIC_ID}/{manufacturer_part_id}"
+        return f"submodel://{semantic_id}/{manufacturer_part_id}"
 
 
     def _update_pending_responses_with_pcf_location(self, manufacturer_part_id: str, pcf_location: str) -> None:
@@ -409,13 +435,22 @@ class PcfManagementManager:
 
         return sorted(bpns)
 
-    def _validate_pcf_schema(self, pcf_data: Dict[str, Any]) -> None:
-        """Validate PCF data against the Catena-X PCF 9.0.0 JSON schema.
+    def _validate_pcf_schema(
+        self,
+        pcf_data: Dict[str, Any],
+        version: str = DEFAULT_PCF_VERSION,
+    ) -> None:
+        """Validate PCF data against the Catena-X PCF JSON schema.
+
+        Args:
+            pcf_data: The PCF payload to validate.
+            version: PCF schema version to validate against (default: ``"v9.0.0"``).
 
         Raises:
             ValueError: If the data does not conform to the schema.
         """
-        pcf_schema_result = submodel_schema_finder("urn:samm:io.catenax.pcf:9.0.0#Pcf")
+        semantic_id = get_pcf_semantic_id(version)
+        pcf_schema_result = submodel_schema_finder(semantic_id)
         json_validator_draft_aware(pcf_schema_result["schema"], pcf_data)
 
     def send_via_edc(

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
@@ -105,7 +105,11 @@ class PcfManagementManager:
         
         try:
             with RepositoryManagerFactory.create() as repo_manager:
-                entity = repo_manager.pcf_repository.find_by_request_id(UUID(request_id))
+                entity = repo_manager.pcf_repository.find_by_request_id(
+                    UUID(request_id), type=PcfExchangeType.RESPONSE
+                )
+                if not entity:
+                    entity = repo_manager.pcf_repository.find_by_request_id(UUID(request_id))
 
                 if not entity or not entity.manufacturer_part_id:
                     logger.warning(

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
@@ -40,6 +40,7 @@ from tools.exceptions import NotFoundError
 from utils.log_utils import sanitize_log_value as _s
 from utils.pcf_utils import (
     DEFAULT_PCF_VERSION,
+    SUPPORTED_PCF_VERSIONS,
     get_pcf_exchange_semantic_id,
     get_pcf_semantic_id,
     pcf_submodel_id,
@@ -159,6 +160,53 @@ class PcfManagementManager:
         except Exception as e:
             logger.warning(f"PCF data not found for manufacturer part ID {_s(manufacturer_part_id)}: {_s(e)}")
             return None
+
+    def check_both_versions_exist(
+        self,
+        manufacturer_part_id: str,
+        flow: str = "synchronous",
+    ) -> None:
+        """Ensure all supported PCF versions have been uploaded for a part.
+
+        When the configuration flag
+        ``provider.pcfExchange.requireBothVersions.<flow>`` is enabled, this
+        method verifies that every version listed in
+        :data:`~utils.pcf_utils.SUPPORTED_PCF_VERSIONS` has a stored submodel
+        document.  If any version is missing, a
+        :class:`~tools.exceptions.PcfVersionGateError` is raised so the
+        caller (provision / exchange managers) can block the operation.
+
+        When the flag is disabled (the default), the method returns
+        immediately without performing any check.
+
+        Args:
+            manufacturer_part_id: The manufacturer part identifier to check.
+            flow: ``"synchronous"`` or ``"asynchronous"`` — selects the
+                corresponding configuration toggle.
+
+        Raises:
+            PcfVersionGateError: If the gate is enabled and at least one
+                version has not been uploaded yet.
+        """
+        from tools.exceptions import PcfVersionGateError
+
+        require_both = ConfigManager.get_config(
+            f"provider.pcfExchange.requireBothVersions.{flow}", default=False
+        )
+        if not require_both:
+            return
+
+        missing = [
+            v for v in sorted(SUPPORTED_PCF_VERSIONS)
+            if self.get_pcf_data_by_manufacturer_part_id(manufacturer_part_id, version=v) is None
+        ]
+
+        if missing:
+            raise PcfVersionGateError(
+                f"Both PCF versions must be uploaded for manufacturerPartId "
+                f"'{manufacturer_part_id}' before it can be published or exchanged. "
+                f"Missing version(s): {', '.join(missing)}"
+            )
 
     def update_pcf_exchange_status(
         self,

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/management.py
@@ -510,7 +510,8 @@ class PcfManagementManager:
         params: Optional[Dict[str, str]] = None,
         json_data: Optional[Dict[str, Any]] = None,
         list_policies: Optional[List[Dict]] = None,
-        asset_type: str = "https://w3id.org/catenax/taxonomy#PcfExchange",
+        asset_type: str = "https://w3id.org/catenax/taxonomy#PCFExchange",
+        asset_version: Optional[str] = None,
     ) -> None:
         """
         Send PCF data via EDC using either GET or PUT method with single retry on failure.
@@ -526,7 +527,10 @@ class PcfManagementManager:
             params: Query parameters for GET requests
             json_data: JSON payload for PUT requests
             list_policies: Optional list of policies for contract negotiation
-            asset_type: The EDC asset type to filter by (default: PcfExchange)
+            asset_type: The EDC asset type to filter by (default: PCFExchange)
+            asset_version: Optional ``cx-common:version`` value to add as a
+                catalog filter (e.g. ``"1.2.0"``). When ``None``, only
+                ``dct:type`` is used for filtering.
 
         Returns:
             The response object from the EDC data plane
@@ -577,6 +581,7 @@ class PcfManagementManager:
                 response = self._dispatch_edc_request(
                     consumer_connector_service, http_method, target_bpn,
                     connector_url, asset_type, list_policies, path, params, json_data,
+                    asset_version=asset_version,
                 )
 
                 if response.status_code in (200, 201, 202, 204):
@@ -610,6 +615,7 @@ class PcfManagementManager:
                     response = self._dispatch_edc_request(
                         consumer_connector_service, http_method, target_bpn,
                         connector_url, asset_type, list_policies, path, params, json_data,
+                        asset_version=asset_version,
                     )
                     
                     if response.status_code in (200, 201, 202, 204):
@@ -647,26 +653,46 @@ class PcfManagementManager:
         path: str,
         params: Optional[Dict[str, str]],
         json_data: Optional[Dict[str, Any]],
+        asset_version: Optional[str] = None,
     ):
-        """Execute a single EDC GET or PUT request and return the response."""
+        """Execute a single EDC GET or PUT request and return the response.
+
+        When *asset_version* is provided, a ``cx-common:version`` filter is
+        appended alongside the ``dct:type`` filter so the catalog request
+        targets a specific asset version (e.g. ``1.2.0`` vs ``1.1.1``).
+        """
         logger.info(
             f"[PCF EDC] Attempting {_s(http_method)} on [{_s(connector_url)}] path=[{_s(path)}]"
         )
 
+        # Build filter expressions
+        dct_type_filter = consumer_connector_service.get_filter_expression(
+            key="'http://purl.org/dc/terms/type'.'@id'",
+            value=asset_type,
+        )
+        filter_expression = [dct_type_filter]
+
+        if asset_version:
+            version_filter = consumer_connector_service.get_filter_expression(
+                key="'https://w3id.org/catenax/ontology/common#version'",
+                value=asset_version,
+            )
+            filter_expression.append(version_filter)
+
         if http_method.upper() == "GET":
-            return consumer_connector_service.do_get_by_dct_type_with_bpnl(
+            return consumer_connector_service.do_get_with_bpnl(
                 bpnl=target_bpn,
                 counter_party_address=connector_url,
-                dct_type=asset_type,
+                filter_expression=filter_expression,
                 policies=list_policies,
                 path=path,
                 params=params if params else None,
             )
         elif http_method.upper() == "PUT":
-            return consumer_connector_service.do_put_by_dct_type_with_bpnl(
+            return consumer_connector_service.do_put_with_bpnl(
                 bpnl=target_bpn,
                 counter_party_address=connector_url,
-                dct_type=asset_type,
+                filter_expression=filter_expression,
                 json=json_data if json_data is not None else {},
                 policies=list_policies,
                 path=path,

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
@@ -293,8 +293,6 @@ class PcfProvisionManager:
             if pcf_data is None:
                 raise ValueError("PCF data payload is required for update.")
 
-            # Gate: require both PCF versions before allowing publish/exchange
-            management_manager.check_both_versions_exist(manufacturer_part_id, flow="synchronous")
 
             result = management_manager.update_pcf_data(
                 manufacturer_part_id=manufacturer_part_id,

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
@@ -40,7 +40,7 @@ from managers.metadata_database.manager import RepositoryManagerFactory
 from models.metadata_database.pcf import PcfExchangeDirection, PcfExchangeStatus, PcfExchangeType
 from models.services.addons.pcf_kit.v1.models import PcfExchangeModel
 from utils.log_utils import sanitize_log_value as _s
-from utils.pcf_utils import PCF_EXCHANGE_ASSET_TYPE
+from utils.pcf_utils import DEFAULT_PCF_VERSION, PCF_EXCHANGE_ASSET_TYPE
 
 logger = LoggingManager.get_logger(__name__)
 
@@ -137,6 +137,7 @@ class PcfProvisionManager:
         is_update: bool,
         message: Optional[str] = None,
         manufacturer_part_id: Optional[str] = None,
+        version: str = DEFAULT_PCF_VERSION,
     ) -> None:
         """
         Update the PCF exchange record in the metadata database.
@@ -152,12 +153,13 @@ class PcfProvisionManager:
             is_update: Whether this is an update to a previously delivered response.
             message: Optional message for the exchange record.
             manufacturer_part_id: The manufacturer part ID (used in pcf_location).
+            version: PCF schema version (default: ``"v9.0.0"``).
 
         Raises:
             ValueError: If the exchange record is not found or the update fails.
         """
         try:
-            pcf_location = management_manager.get_pcf_location(manufacturer_part_id)
+            pcf_location = management_manager.get_pcf_location(manufacturer_part_id, version=version)
             logger.info(f"Stored PCF data location for request {_s(request_id)}: {_s(pcf_location)}")
             
             if is_update:
@@ -182,7 +184,8 @@ class PcfProvisionManager:
     def upload_new_pcf(
             self,
             manufacturer_part_id: str,
-            pcf_data: Dict[str, Any]
+            pcf_data: Dict[str, Any],
+            version: str = DEFAULT_PCF_VERSION,
     ) -> None:
         """
         Upload a new PCF document to the submodel service for a given manufacturer part ID.
@@ -194,6 +197,8 @@ class PcfProvisionManager:
         Args:
             manufacturer_part_id: The manufacturer part ID to associate with the PCF data.
             pcf_data: The PCF payload to store.
+            version: PCF schema version (default: ``"v9.0.0"``).
+
         Raises:
             ValueError: If there is an error during upload to the submodel service.
         """
@@ -203,7 +208,8 @@ class PcfProvisionManager:
 
             management_manager.upload_pcf_data(
                 manufacturer_part_id=manufacturer_part_id,
-                pcf_data=pcf_data
+                pcf_data=pcf_data,
+                version=version,
             )
         except Exception as e:
             logger.error(f"Failed to upload PCF data for manufacturerPartId [{_s(manufacturer_part_id)}]: {_s(e)}")
@@ -212,22 +218,29 @@ class PcfProvisionManager:
 
     def view_existing_pcf(
             self,
-            manufacturer_part_id: str
+            manufacturer_part_id: str,
+            version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         """
         View an existing PCF document from the submodel service for a given manufacturer part ID.
 
         Args:
             manufacturer_part_id: The manufacturer part ID to retrieve the PCF data for.
+            version: PCF schema version (default: ``"v9.0.0"``).
+
         Raises:
             ValueError: If there is an error during retrieval from the submodel service.
         """
         try:
             result = management_manager.get_pcf_data_by_manufacturer_part_id(
-                manufacturer_part_id=manufacturer_part_id
+                manufacturer_part_id=manufacturer_part_id,
+                version=version,
             )
             if result is None:
-                raise ValueError(f"No PCF data found for manufacturerPartId [{manufacturer_part_id}].")
+                raise ValueError(
+                    f"No PCF data found for manufacturerPartId [{manufacturer_part_id}] "
+                    f"version [{version}]."
+                )
             return result
         except Exception as e:
             logger.error(f"Failed to retrieve PCF data for manufacturerPartId [{_s(manufacturer_part_id)}]: {_s(e)}")
@@ -236,7 +249,8 @@ class PcfProvisionManager:
     def update_pcf_and_get_participants(            
             self,
             manufacturer_part_id: str,
-            pcf_data: Dict[str, Any]
+            pcf_data: Dict[str, Any],
+            version: str = DEFAULT_PCF_VERSION,
     ) -> Dict[str, Any]:
         try:
             if pcf_data is None:
@@ -244,7 +258,8 @@ class PcfProvisionManager:
             
             result = management_manager.update_pcf_data(
                 manufacturer_part_id=manufacturer_part_id,
-                pcf_data=pcf_data
+                pcf_data=pcf_data,
+                version=version,
             )
             return result
         except Exception as e:
@@ -293,7 +308,13 @@ class PcfProvisionManager:
             logger.error(f"Failed to confirm and send PCF update for manufacturerPartId [{_s(manufacturer_part_id)}]: {_s(e)}")
             raise ValueError(f"Failed to confirm and send PCF update: {str(e)}")
 
-    def list_provider_notifications(self, status: Optional[str] = None, offset: int = 0, limit: int = 100) -> List[Dict[str, Any]]:
+    def list_provider_notifications(
+        self,
+        status: Optional[str] = None,
+        version: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
         """
         List all notifications related to a specific manufacturer part ID.
 
@@ -313,6 +334,7 @@ class PcfProvisionManager:
                         type=PcfExchangeType.RESPONSE,
                         direction=PcfExchangeDirection.OUTGOING,
                         status=status,
+                        version=version,
                         offset=offset,
                         limit=limit)
                 return [PcfExchangeModel.from_entity(n) for n in notifications]
@@ -400,7 +422,8 @@ class PcfProvisionManager:
                 if not manufacturer_part_id:
                     raise ValueError(f"No manufacturerPartId associated with request {request_id}. Cannot retrieve PCF data for refresh.")
                 
-                pcf_location = management_manager.get_pcf_location(manufacturer_part_id)
+                entity_version = exchange_entity.version or DEFAULT_PCF_VERSION
+                pcf_location = management_manager.get_pcf_location(manufacturer_part_id, version=entity_version)
                 if not pcf_location:
                     raise ValueError(f"No PCF location found for request {request_id}. Cannot refresh PCF data.")
                 final_exchange = repo_manager.pcf_repository.update_pcf_location(

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
@@ -95,38 +95,75 @@ class PcfProvisionManager:
         list_policies: Optional[List[Dict]] = None,
     ) -> None:
         """
-        Send PCF data to the requesting party through the EDC dataspace connector.
+        Send PCF data to the requesting party via EDC with version negotiation.
 
-        Delegates to the management manager's generic send_via_edc method which 
-        handles connector discovery, EDR cleanup, contract negotiation, and PUT request.
+        Tries the v1.2.0 asset (``/footprintExchange``) first. If no v1.2.0
+        asset is available in the consumer's catalog, falls back to the
+        v1.1.1 legacy asset (``/productIds``). CX-0136 §6 requires the
+        highest compatible ``cx-common:version`` to be used.
 
         Args:
             request_id: The PCF request ID (used as the PUT path).
             requesting_bpn: BPN of the party that requested the PCF data.
             pcf_data: The validated PCF payload to send.
             is_update: Whether this is an update to a previously delivered response.
-            manufacturer_part_id: The manufacturer part ID (used for pcf_location).
+            manufacturer_part_id: The manufacturer part ID (used for pcf_location and v1.1.1 path).
             list_policies: Optional list of policies for contract negotiation.
 
         Raises:
             ValueError: If no connectors are found or the data transfer fails.
         """
-        put_path = f"/{request_id}"
-        if is_update:
-            put_path += "?update=true"
+        # --- Try v1.2.0 first ---
+        try:
+            put_path = f"/{request_id}"
+            if is_update:
+                put_path += "?update=true"
 
-        # Use the shared EDC method from management manager
+            management_manager.send_via_edc(
+                request_id=request_id,
+                target_bpn=requesting_bpn,
+                http_method="PUT",
+                path=put_path,
+                json_data=pcf_data,
+                list_policies=list_policies,
+                asset_type=PCF_EXCHANGE_ASSET_TYPE,
+                asset_version="1.2.0",
+            )
+            logger.info(f"[PCF Provision] Response {_s(request_id)} sent via v1.2.0 asset")
+
+            self._update_exchange_record(
+                request_id, is_update, manufacturer_part_id=manufacturer_part_id
+            )
+            return
+        except Exception as e:
+            logger.info(
+                f"[PCF Provision] v1.2.0 asset not available for BPN {_s(requesting_bpn)}, "
+                f"falling back to v1.1.1: {_s(e)}"
+            )
+
+        # --- Fall back to v1.1.1 (legacy /productIds) ---
+        if not manufacturer_part_id:
+            raise ValueError(
+                "Cannot fall back to v1.1.1 /productIds API: "
+                "manufacturerPartId is required but not provided."
+            )
+
+        put_path_legacy = f"/{manufacturer_part_id}?requestId={request_id}"
+        if is_update:
+            put_path_legacy += "&update=true"
+
         management_manager.send_via_edc(
             request_id=request_id,
             target_bpn=requesting_bpn,
             http_method="PUT",
-            path=put_path,
+            path=put_path_legacy,
             json_data=pcf_data,
             list_policies=list_policies,
             asset_type=PCF_EXCHANGE_ASSET_TYPE,
+            asset_version="1.1.1",
         )
+        logger.info(f"[PCF Provision] Response {_s(request_id)} sent via v1.1.1 (legacy) asset")
 
-        # Update exchange record after successful EDC transfer
         self._update_exchange_record(
             request_id, is_update, manufacturer_part_id=manufacturer_part_id
         )

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
@@ -323,18 +323,26 @@ class PcfProvisionManager:
             ValueError: If there is an error during the update or sending process.
         """
         try:
-            pcf_data = self.view_existing_pcf(manufacturer_part_id=manufacturer_part_id)
             # Gate: require both PCF versions before allowing publish/exchange
             management_manager.check_both_versions_exist(manufacturer_part_id, flow="synchronous")
-            # Collect required data from DB first, then close session before EDC calls
+            # Collect required data from DB first, then close session before EDC calls.
             send_targets: List[Dict[str, str]] = []
             with RepositoryManagerFactory.create() as repo_manager:
                 for bpn in list_bpns:
                     result = repo_manager.pcf_repository.find_by_bpn(bpn, manufacturer_part_id=manufacturer_part_id, direction=PcfExchangeDirection.OUTGOING, status=PcfExchangeStatus.DELIVERED)
                     if result:
-                        send_targets.append({"request_id": str(result[0].request_id), "bpn": bpn})
-            # Send EDC calls outside DB session to avoid holding connections
+                        send_targets.append({
+                            "request_id": str(result[0].request_id),
+                            "bpn": bpn,
+                            "version": result[0].version or DEFAULT_PCF_VERSION,
+                        })
+            # Send EDC calls outside DB session to avoid holding connections.
+            # Retrieve the PCF data matching each exchange's version.
             for target in send_targets:
+                pcf_data = self.view_existing_pcf(
+                    manufacturer_part_id=manufacturer_part_id,
+                    version=target["version"],
+                )
                 self._send_pcf_via_edc(
                     request_id=target["request_id"],
                     requesting_bpn=target["bpn"],
@@ -409,12 +417,17 @@ class PcfProvisionManager:
                 entity_requesting_bpn = exchange_entity.requesting_bpn
                 entity_manufacturer_part_id = exchange_entity.manufacturer_part_id
                 entity_status = exchange_entity.status
+                entity_version = exchange_entity.version or DEFAULT_PCF_VERSION
 
             # Gate: require both PCF versions before allowing publish/exchange
             management_manager.check_both_versions_exist(entity_manufacturer_part_id, flow="asynchronous")
 
-            # Perform EDC calls outside DB session
-            pcf_data = management_manager.get_pcf_data_by_manufacturer_part_id(entity_manufacturer_part_id)
+            # Perform EDC calls outside DB session — use the version
+            # stored on the exchange record so that a v7 request retrieves
+            # the v7 PCF document (not the default v9).
+            pcf_data = management_manager.get_pcf_data_by_manufacturer_part_id(
+                entity_manufacturer_part_id, version=entity_version
+            )
             self._send_pcf_via_edc(
                 request_id=request_id,
                 requesting_bpn=entity_requesting_bpn,

--- a/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
+++ b/ichub-backend/managers/addons_service/pcf_kit/v1/provision.py
@@ -255,7 +255,10 @@ class PcfProvisionManager:
         try:
             if pcf_data is None:
                 raise ValueError("PCF data payload is required for update.")
-            
+
+            # Gate: require both PCF versions before allowing publish/exchange
+            management_manager.check_both_versions_exist(manufacturer_part_id, flow="synchronous")
+
             result = management_manager.update_pcf_data(
                 manufacturer_part_id=manufacturer_part_id,
                 pcf_data=pcf_data,
@@ -286,6 +289,8 @@ class PcfProvisionManager:
         """
         try:
             pcf_data = self.view_existing_pcf(manufacturer_part_id=manufacturer_part_id)
+            # Gate: require both PCF versions before allowing publish/exchange
+            management_manager.check_both_versions_exist(manufacturer_part_id, flow="synchronous")
             # Collect required data from DB first, then close session before EDC calls
             send_targets: List[Dict[str, str]] = []
             with RepositoryManagerFactory.create() as repo_manager:
@@ -369,6 +374,9 @@ class PcfProvisionManager:
                 entity_requesting_bpn = exchange_entity.requesting_bpn
                 entity_manufacturer_part_id = exchange_entity.manufacturer_part_id
                 entity_status = exchange_entity.status
+
+            # Gate: require both PCF versions before allowing publish/exchange
+            management_manager.check_both_versions_exist(entity_manufacturer_part_id, flow="asynchronous")
 
             # Perform EDC calls outside DB session
             pcf_data = management_manager.get_pcf_data_by_manufacturer_part_id(entity_manufacturer_part_id)

--- a/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/connector_provider_manager.py
@@ -495,7 +495,7 @@ class ConnectorProviderManager:
                            base_url:str=None,
                            api_path:str = "/v1/addons/pcf-kit/footprintExchange", 
                            pcf_exchange_policy_config=dict, 
-                           dct_type:str="cx-taxo:PcfExchange", 
+                           dct_type:str="cx-taxo:PCFExchange", 
                            existing_asset_id:str=None,
                            version="1.2.0",
                            headers:dict=None) -> tuple[str, str, str, str]:

--- a/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
@@ -1,6 +1,7 @@
 #################################################################################
 # Eclipse Tractus-X - Industry Core Hub Backend
 #
+# Copyright (c) 2026 LKS Next
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
+++ b/ichub-backend/managers/enablement_services/provider/dtr_provider_manager.py
@@ -385,11 +385,24 @@ class DtrProviderManager:
         submodel_id: UUID|str,
         semantic_id: str,
         connector_asset_id: str,
+        id_short_override: str | None = None,
+        interface: str = "SUBMODEL-3.0",
     ) -> SubModelDescriptor:
         """
         Creates a submodel descriptor in the DTR.
+
+        Args:
+            aas_id: AAS identifier.
+            submodel_id: Submodel identifier.
+            semantic_id: Semantic ID URN for the submodel.
+            connector_asset_id: Connector asset ID for the subprotocolBody.
+            id_short_override: If provided, use this as ``idShort`` instead of
+                deriving it from the semantic ID. Required for PCF submodels
+                where CX-0136 mandates specific idShort values.
+            interface: Endpoint interface value (default ``"SUBMODEL-3.0"``).
+                PCF async endpoints use ``"PCF-1.1"``.
         """
-        aspect_id_name = extract_aspect_id_name_from_urn_camelcase(semantic_id)
+        aspect_id_name = id_short_override or extract_aspect_id_name_from_urn_camelcase(semantic_id)
 
         # semantic_id must be added to the submodel descriptor (CX-00002)
         semantic_id_reference = Reference(
@@ -424,7 +437,7 @@ class DtrProviderManager:
         subprotocol_body_str = f"id={connector_asset_id};dspEndpoint={dsp_endpoint_url}"
 
         endpoint = Endpoint(
-            interface="SUBMODEL-3.0",
+            interface=interface,
             protocolInformation=ProtocolInformation(
                 href=href_url,
                 endpointProtocol="HTTP",

--- a/ichub-backend/managers/metadata_database/repositories.py
+++ b/ichub-backend/managers/metadata_database/repositories.py
@@ -797,6 +797,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
         pcf_location: Optional[str] = None,
         correlation_id: Optional[str] = None,
         request_id: Optional[UUID] = None,
+        version: str = "v9.0.0",
     ) -> PcfExchangeEntity:
         """
         Creates a new PCF exchange record.
@@ -812,6 +813,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
             pcf_location: URI/path where PCF payload is stored.
             correlation_id: Optional external correlation ID.
             request_id: Optional UUID for the request (auto-generated if not provided).
+            version: PCF schema version (e.g. "v7.0.0", "v9.0.0").
 
         Returns:
             The created PcfExchangeEntity.
@@ -829,6 +831,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
             message=message,
             pcf_location=pcf_location,
             correlation_id=correlation_id,
+            version=version,
             created_at=now,
             updated_at=now,
         )
@@ -852,6 +855,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
         manufacturer_part_id: Optional[str] = None,
         customer_part_id: Optional[str] = None,
         type: Optional[PcfExchangeType] = None,
+        version: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
     ) -> List[PcfExchangeEntity]:
@@ -865,6 +869,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
             manufacturer_part_id: Filter by manufacturer part ID (optional).
             customer_part_id: Filter by customer part ID (optional).
             type: Filter by exchange type (optional).
+            version: Filter by PCF schema version (optional).
             limit: Maximum number of results.
             offset: Number of results to skip.
 
@@ -910,6 +915,9 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
         if type:
             stmt = stmt.where(PcfExchangeEntity.type == type)
 
+        if version:
+            stmt = stmt.where(PcfExchangeEntity.version == version)
+
         # Order by newest first
         stmt = stmt.order_by(desc(PcfExchangeEntity.created_at)).offset(offset).limit(limit)
 
@@ -920,6 +928,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
         manufacturer_part_id: Optional[str] = None,
         customer_part_id: Optional[str] = None,
         status: Optional[PcfExchangeStatus] = None,
+        version: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
     ) -> List[PcfExchangeEntity]:
@@ -930,6 +939,7 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
             manufacturer_part_id: Filter by manufacturer part ID (optional).
             customer_part_id: Filter by customer part ID (optional).
             status: Filter by exchange status (optional).
+            version: Filter by PCF schema version (optional).
             limit: Maximum number of results.
             offset: Number of results to skip.
 
@@ -946,6 +956,9 @@ class PCFRepository(BaseRepository[PcfExchangeEntity]):
 
         if status:
             stmt = stmt.where(PcfExchangeEntity.status == status)
+
+        if version:
+            stmt = stmt.where(PcfExchangeEntity.version == version)
 
         stmt = stmt.order_by(desc(PcfExchangeEntity.created_at)).offset(offset).limit(limit)
 

--- a/ichub-backend/models/metadata_database/pcf/models.py
+++ b/ichub-backend/models/metadata_database/pcf/models.py
@@ -80,6 +80,7 @@ class PcfExchangeEntity(SQLModel, table=True):
         message: Optional message associated with the exchange.
         pcf_location: URI/path where the PCF data payload is stored.
         correlation_id: Optional ID to correlate with external systems.
+        version: PCF schema version (e.g. "v7.0.0", "v9.0.0").
     """
     __tablename__ = "pcf_exchanges"
     __table_args__ = {"schema": "public"}
@@ -152,7 +153,14 @@ class PcfExchangeEntity(SQLModel, table=True):
         default=None,
         index=True,
         description="Optional ID to correlate with external systems"
-    ) 
+    )
+
+    # PCF schema version
+    version: str = Field(
+        default="v9.0.0",
+        index=True,
+        description="PCF schema version used for this exchange (e.g. v7.0.0, v9.0.0)"
+    )
 
 class PcfRelationshipEntity(SQLModel, table=True):
 

--- a/ichub-backend/models/services/addons/pcf_kit/v1/models.py
+++ b/ichub-backend/models/services/addons/pcf_kit/v1/models.py
@@ -81,6 +81,10 @@ class PcfExchangeModel(BaseModel):
         default=None,
         description="Timestamp when the PCF exchange was initiated (ISO 8601 UTC)."
     )
+    version: str = Field(
+        default="v9.0.0",
+        description="PCF schema version used for this exchange (e.g. v7.0.0, v9.0.0)."
+    )
 
     @staticmethod
     def from_entity(entity: PcfExchangeEntity) -> "PcfExchangeModel":
@@ -95,7 +99,8 @@ class PcfExchangeModel(BaseModel):
             type=entity.type.value,
             message=entity.message,
             pcfLocation=entity.pcf_location,
-            createdAt=entity.created_at.isoformat() if entity.created_at else None
+            createdAt=entity.created_at.isoformat() if entity.created_at else None,
+            version=entity.version,
         )
 
 class PcfRelationshipModel(BaseModel):

--- a/ichub-backend/services/provider/twin_management_service.py
+++ b/ichub-backend/services/provider/twin_management_service.py
@@ -55,6 +55,7 @@ from models.services.provider.twin_management import (
 )
 from models.metadata_database.provider.models import CatalogPart, EnablementServiceStack, Twin, BusinessPartner, TwinAspect, TwinAspectRegistration
 from tools.exceptions import NotFoundError, NotAvailableError
+from utils.pcf_utils import get_pcf_submodel_overrides
 
 from managers.config.log_manager import LoggingManager
 
@@ -723,11 +724,15 @@ class TwinManagementService:
         if db_twin_aspect_registration.status < TwinAspectRegistrationStatus.DTR_REGISTERED.value:               
             # Register the submodel in the DTR (if necessary)
             try:
+                # PCF submodels require CX-0136 mandated idShort + interface
+                pcf_overrides = get_pcf_submodel_overrides(db_twin_aspect.semantic_id) or {}
+
                 dtr_provider_manager.create_submodel_descriptor(
                     aas_id=db_twin.aas_id,
                     submodel_id=db_twin_aspect.submodel_id,
                     semantic_id=db_twin_aspect.semantic_id,
-                    connector_asset_id=asset_id
+                    connector_asset_id=asset_id,
+                    **pcf_overrides,
                 )
                 # Update the registration status to DTR_REGISTERED only on success
                 db_twin_aspect_registration.status = TwinAspectRegistrationStatus.DTR_REGISTERED.value

--- a/ichub-backend/tests/controllers/pcf_kit/conftest.py
+++ b/ichub-backend/tests/controllers/pcf_kit/conftest.py
@@ -95,6 +95,10 @@ def app_client():
             "controllers.fastapi.routers.addons.pcf_kit.v1.exchange.exchange_manager",
             MagicMock(),
         ),
+        patch(
+            "controllers.fastapi.routers.addons.pcf_kit.v1.product_ids.exchange_manager",
+            MagicMock(),
+        ),
     ):
         from controllers.fastapi.app import app
 
@@ -122,5 +126,13 @@ def mock_provision_mgr():
 def mock_exchange_mgr():
     with patch(
         "controllers.fastapi.routers.addons.pcf_kit.v1.exchange.exchange_manager"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_product_ids_mgr():
+    with patch(
+        "controllers.fastapi.routers.addons.pcf_kit.v1.product_ids.exchange_manager"
     ) as mock:
         yield mock

--- a/ichub-backend/tests/controllers/pcf_kit/conftest.py
+++ b/ichub-backend/tests/controllers/pcf_kit/conftest.py
@@ -46,6 +46,13 @@ _MODULES_NEEDING_REAL_IMPL = [
     "managers.config.log_manager",
     "tools.exceptions",
     "tools.constants",
+    # test_twin_management_service.py replaces these with MagicMock at
+    # collection time; they must be restored so that the tractusx_sdk
+    # import chain works when the FastAPI app is loaded.
+    "tractusx_sdk",
+    "tractusx_sdk.dataspace",
+    "tractusx_sdk.dataspace.tools",
+    "tractusx_sdk.dataspace.tools.validate_submodels",
 ]
 
 

--- a/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
@@ -82,6 +82,7 @@ class TestPutPcfWithPathId:
             edc_bpn=VALID_BPN,
             is_update=False,
             message=None,
+            version="v9.0.0",
         )
 
     def test_update_flag_is_passed_to_manager(self, app_client, mock_exchange_mgr):
@@ -143,6 +144,30 @@ class TestPutPcfWithPathId:
 
         assert resp.status_code == 500
 
+    def test_put_with_v7_version(self, app_client, mock_exchange_mgr):
+        mock_exchange_mgr.submit_pcf_response.return_value = {"status": "accepted"}
+
+        resp = app_client.put(
+            f"{BASE}/{REQUEST_ID}?version=v7.0.0",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_exchange_mgr.submit_pcf_response.call_args
+        assert kwargs["version"] == "v7.0.0"
+
+    def test_put_with_invalid_version_returns_400(self, app_client, mock_exchange_mgr):
+        resp = app_client.put(
+            f"{BASE}/{REQUEST_ID}?version=v99.0.0",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 400
+        assert "Unsupported PCF version" in resp.json().get("detail", "")
+        mock_exchange_mgr.submit_pcf_response.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GET /{requestId}  — request_pcf
@@ -167,6 +192,7 @@ class TestRequestPcf:
             manufacturer_part_id=PART_ID,
             customer_part_id=None,
             message=None,
+            version="v9.0.0",
         )
 
     def test_valid_request_with_customer_part_id_returns_202(self, app_client, mock_exchange_mgr):
@@ -251,3 +277,27 @@ class TestRequestPcf:
         )
 
         assert resp.status_code == 500
+
+    def test_get_with_v7_version(self, app_client, mock_exchange_mgr):
+        mock_exchange_mgr.request_pcf.return_value = {"status": "accepted"}
+
+        resp = app_client.get(
+            f"{BASE}/{REQUEST_ID}",
+            params={"manufacturerPartId": PART_ID, "version": "v7.0.0"},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 202
+        _, kwargs = mock_exchange_mgr.request_pcf.call_args
+        assert kwargs["version"] == "v7.0.0"
+
+    def test_get_with_invalid_version_returns_400(self, app_client, mock_exchange_mgr):
+        resp = app_client.get(
+            f"{BASE}/{REQUEST_ID}",
+            params={"manufacturerPartId": PART_ID, "version": "v99.0.0"},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 400
+        assert "Unsupported PCF version" in resp.json().get("detail", "")
+        mock_exchange_mgr.request_pcf.assert_not_called()

--- a/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
@@ -39,6 +39,8 @@ GET also requires at least one of ``manufacturerPartId`` or ``customerPartId``
 query parameters; omitting both must return 400.
 """
 
+from tools.exceptions import PcfVersionGateError
+
 # ---------------------------------------------------------------------------
 # URL constants
 # ---------------------------------------------------------------------------
@@ -167,6 +169,20 @@ class TestPutPcfWithPathId:
         assert resp.status_code == 400
         assert "Unsupported PCF version" in resp.json().get("detail", "")
         mock_exchange_mgr.submit_pcf_response.assert_not_called()
+
+    def test_version_gate_error_returns_409(self, app_client, mock_exchange_mgr):
+        mock_exchange_mgr.submit_pcf_response.side_effect = PcfVersionGateError(
+            "Both PCF versions must be uploaded"
+        )
+
+        resp = app_client.put(
+            f"{BASE}/{REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 409
+        assert "Both PCF versions" in resp.json().get("detail", "")
 
 
 # ---------------------------------------------------------------------------

--- a/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_exchange.py
@@ -147,6 +147,7 @@ class TestPutPcfWithPathId:
         assert resp.status_code == 500
 
     def test_put_with_v7_version(self, app_client, mock_exchange_mgr):
+        """version query param is ignored — endpoint always uses v9.0.0."""
         mock_exchange_mgr.submit_pcf_response.return_value = {"status": "accepted"}
 
         resp = app_client.put(
@@ -157,18 +158,21 @@ class TestPutPcfWithPathId:
 
         assert resp.status_code == 200
         _, kwargs = mock_exchange_mgr.submit_pcf_response.call_args
-        assert kwargs["version"] == "v7.0.0"
+        assert kwargs["version"] == "v9.0.0"
 
-    def test_put_with_invalid_version_returns_400(self, app_client, mock_exchange_mgr):
+    def test_put_with_invalid_version_is_ignored(self, app_client, mock_exchange_mgr):
+        """Invalid version query param is silently ignored; endpoint hardcodes v9.0.0."""
+        mock_exchange_mgr.submit_pcf_response.return_value = {"status": "accepted"}
+
         resp = app_client.put(
             f"{BASE}/{REQUEST_ID}?version=v99.0.0",
             json=PCF_BODY,
             headers={"edc-bpn": VALID_BPN},
         )
 
-        assert resp.status_code == 400
-        assert "Unsupported PCF version" in resp.json().get("detail", "")
-        mock_exchange_mgr.submit_pcf_response.assert_not_called()
+        assert resp.status_code == 200
+        _, kwargs = mock_exchange_mgr.submit_pcf_response.call_args
+        assert kwargs["version"] == "v9.0.0"
 
     def test_version_gate_error_returns_409(self, app_client, mock_exchange_mgr):
         mock_exchange_mgr.submit_pcf_response.side_effect = PcfVersionGateError(
@@ -295,6 +299,7 @@ class TestRequestPcf:
         assert resp.status_code == 500
 
     def test_get_with_v7_version(self, app_client, mock_exchange_mgr):
+        """version query param is ignored — endpoint always uses v9.0.0."""
         mock_exchange_mgr.request_pcf.return_value = {"status": "accepted"}
 
         resp = app_client.get(
@@ -305,15 +310,18 @@ class TestRequestPcf:
 
         assert resp.status_code == 202
         _, kwargs = mock_exchange_mgr.request_pcf.call_args
-        assert kwargs["version"] == "v7.0.0"
+        assert kwargs["version"] == "v9.0.0"
 
-    def test_get_with_invalid_version_returns_400(self, app_client, mock_exchange_mgr):
+    def test_get_with_invalid_version_is_ignored(self, app_client, mock_exchange_mgr):
+        """Invalid version query param is silently ignored; endpoint hardcodes v9.0.0."""
+        mock_exchange_mgr.request_pcf.return_value = {"status": "accepted"}
+
         resp = app_client.get(
             f"{BASE}/{REQUEST_ID}",
             params={"manufacturerPartId": PART_ID, "version": "v99.0.0"},
             headers={"edc-bpn": VALID_BPN},
         )
 
-        assert resp.status_code == 400
-        assert "Unsupported PCF version" in resp.json().get("detail", "")
-        mock_exchange_mgr.request_pcf.assert_not_called()
+        assert resp.status_code == 202
+        _, kwargs = mock_exchange_mgr.request_pcf.call_args
+        assert kwargs["version"] == "v9.0.0"

--- a/ichub-backend/tests/controllers/pcf_kit/test_product_ids.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_product_ids.py
@@ -1,0 +1,293 @@
+#################################################################################
+# Eclipse Tractus-X - Industry Core Hub Backend
+#
+# Copyright (c) 2026 LKS Next
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the
+# License for the specific language govern in permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+## Code created partially using a LLM and reviewed by a human committer
+
+"""
+Endpoint-level tests for the PCF Kit ProductIds controller (legacy v1.1.1 API).
+
+Base URL: /v1/addons/pcf-kit/productIds
+
+Endpoints under test
+--------------------
+PUT /{productId}?requestId=xxx  → submit_pcf_response  (PCF response, v7.0.0)
+GET /{productId}?requestId=xxx  → request_pcf           (PCF request, v7.0.0)
+
+The ``edc-bpn`` header is mandatory on both endpoints; its absence must be
+rejected with HTTP 400 before the manager is ever called.
+
+Both endpoints always call the exchange manager with ``version="v7.0.0"``.
+"""
+
+from tools.exceptions import PcfVersionGateError
+
+# ---------------------------------------------------------------------------
+# URL constants
+# ---------------------------------------------------------------------------
+
+BASE = "/v1/addons/pcf-kit/productIds"
+PRODUCT_ID = "part-abc-123"
+REQUEST_ID = "req-xyz-456"
+VALID_BPN = "BPNL000000000342"
+
+# ---------------------------------------------------------------------------
+# PCF data payload (minimal valid structure for the PUT body)
+# ---------------------------------------------------------------------------
+
+PCF_BODY = {
+    "specVersion": "2.0.1-20230314T161325Z-027-88749B3",
+    "pcf": {"pCfExcludingBiogenic": 2.0},
+}
+
+
+# ---------------------------------------------------------------------------
+# PUT /{productId}  — put_pcf_legacy
+# ---------------------------------------------------------------------------
+
+class TestPutPcfLegacy:
+    """PUT /{productId}?requestId=xxx — EDC calls this to deliver a PCF v7 response."""
+
+    def test_valid_request_returns_200(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.return_value = {"status": "accepted"}
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 200
+        mock_product_ids_mgr.submit_pcf_response.assert_called_once_with(
+            request_id=REQUEST_ID,
+            pcf_data=PCF_BODY,
+            edc_bpn=VALID_BPN,
+            is_update=False,
+            message=None,
+            version="v7.0.0",
+        )
+
+    def test_always_uses_v7_version(self, app_client, mock_product_ids_mgr):
+        """productIds endpoint always hardcodes v7.0.0 regardless of any query params."""
+        mock_product_ids_mgr.submit_pcf_response.return_value = {}
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_product_ids_mgr.submit_pcf_response.call_args
+        assert kwargs["version"] == "v7.0.0"
+
+    def test_update_flag_is_passed_to_manager(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.return_value = {}
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}&update=true",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_product_ids_mgr.submit_pcf_response.call_args
+        assert kwargs["is_update"] is True
+
+    def test_optional_message_param_forwarded(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.return_value = {}
+        raw_param = "Hello+world"
+        decoded_msg = "Hello world"
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}&message={raw_param}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_product_ids_mgr.submit_pcf_response.call_args
+        assert kwargs["message"] == decoded_msg
+
+    def test_missing_edc_bpn_header_returns_400(self, app_client, mock_product_ids_mgr):
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+        )
+
+        assert resp.status_code == 400
+        mock_product_ids_mgr.submit_pcf_response.assert_not_called()
+
+    def test_missing_request_id_returns_422(self, app_client, mock_product_ids_mgr):
+        """requestId is a required query param."""
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 422
+        mock_product_ids_mgr.submit_pcf_response.assert_not_called()
+
+    def test_manager_value_error_returns_400(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.side_effect = ValueError("Malformed PCF")
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 400
+
+    def test_manager_unexpected_error_returns_500(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.side_effect = RuntimeError("DB crash")
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 500
+
+    def test_version_gate_error_returns_409(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.submit_pcf_response.side_effect = PcfVersionGateError(
+            "Both PCF versions must be uploaded"
+        )
+
+        resp = app_client.put(
+            f"{BASE}/{PRODUCT_ID}?requestId={REQUEST_ID}",
+            json=PCF_BODY,
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 409
+        assert "Both PCF versions" in resp.json().get("detail", "")
+
+
+# ---------------------------------------------------------------------------
+# GET /{productId}  — request_pcf_legacy
+# ---------------------------------------------------------------------------
+
+class TestRequestPcfLegacy:
+    """GET /{productId}?requestId=xxx — EDC calls this to request a PCF v7 footprint."""
+
+    def test_valid_request_returns_202(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.return_value = {"status": "accepted"}
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 202
+        mock_product_ids_mgr.request_pcf.assert_called_once_with(
+            request_id=REQUEST_ID,
+            edc_bpn=VALID_BPN,
+            manufacturer_part_id=PRODUCT_ID,
+            customer_part_id=None,
+            message=None,
+            version="v7.0.0",
+        )
+
+    def test_always_uses_v7_version(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.return_value = {}
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 202
+        _, kwargs = mock_product_ids_mgr.request_pcf.call_args
+        assert kwargs["version"] == "v7.0.0"
+
+    def test_product_id_maps_to_manufacturer_part_id(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.return_value = {}
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 202
+        _, kwargs = mock_product_ids_mgr.request_pcf.call_args
+        assert kwargs["manufacturer_part_id"] == PRODUCT_ID
+        assert kwargs["customer_part_id"] is None
+
+    def test_optional_message_forwarded(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.return_value = {}
+        msg = "PCF request for battery"
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID, "message": msg},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 202
+        _, kwargs = mock_product_ids_mgr.request_pcf.call_args
+        assert kwargs["message"] == msg
+
+    def test_missing_edc_bpn_header_returns_400(self, app_client, mock_product_ids_mgr):
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+        )
+
+        assert resp.status_code == 400
+        mock_product_ids_mgr.request_pcf.assert_not_called()
+
+    def test_missing_request_id_returns_422(self, app_client, mock_product_ids_mgr):
+        """requestId is a required query param."""
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 422
+        mock_product_ids_mgr.request_pcf.assert_not_called()
+
+    def test_manager_value_error_returns_400(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.side_effect = ValueError("Part not found")
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 400
+
+    def test_manager_unexpected_error_returns_500(self, app_client, mock_product_ids_mgr):
+        mock_product_ids_mgr.request_pcf.side_effect = RuntimeError("Timeout")
+
+        resp = app_client.get(
+            f"{BASE}/{PRODUCT_ID}",
+            params={"requestId": REQUEST_ID},
+            headers={"edc-bpn": VALID_BPN},
+        )
+
+        assert resp.status_code == 500

--- a/ichub-backend/tests/controllers/pcf_kit/test_provision.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_provision.py
@@ -112,7 +112,7 @@ class TestUploadNewPcf:
         resp = app_client.post(f"{BASE}/pcfs/{PART_ID}", json=PCF_DATA_BODY)
 
         assert resp.status_code == 201
-        mock_provision_mgr.upload_new_pcf.assert_called_once_with(PART_ID, PCF_DATA_BODY)
+        mock_provision_mgr.upload_new_pcf.assert_called_once_with(PART_ID, PCF_DATA_BODY, version="v9.0.0")
 
     def test_manager_value_error_returns_400(self, app_client, mock_provision_mgr):
         mock_provision_mgr.upload_new_pcf.side_effect = ValueError("Schema validation failed")
@@ -129,6 +129,25 @@ class TestUploadNewPcf:
 
         assert resp.status_code == 500
 
+    def test_upload_with_v7_version(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.upload_new_pcf.return_value = {
+            "manufacturerPartId": PART_ID,
+            "pcfLocation": "submodel://some-location",
+            "version": "v7.0.0",
+        }
+
+        resp = app_client.post(f"{BASE}/pcfs/{PART_ID}?version=v7.0.0", json=PCF_DATA_BODY)
+
+        assert resp.status_code == 201
+        mock_provision_mgr.upload_new_pcf.assert_called_once_with(PART_ID, PCF_DATA_BODY, version="v7.0.0")
+
+    def test_upload_with_invalid_version_returns_400(self, app_client, mock_provision_mgr):
+        resp = app_client.post(f"{BASE}/pcfs/{PART_ID}?version=v99.0.0", json=PCF_DATA_BODY)
+
+        assert resp.status_code == 400
+        assert "Unsupported PCF version" in resp.json().get("detail", "")
+        mock_provision_mgr.upload_new_pcf.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GET /pcfs/{manufacturerPartId}
@@ -143,7 +162,7 @@ class TestViewExistingPcf:
         resp = app_client.get(f"{BASE}/pcfs/{PART_ID}")
 
         assert resp.status_code == 200
-        mock_provision_mgr.view_existing_pcf.assert_called_once_with(PART_ID)
+        mock_provision_mgr.view_existing_pcf.assert_called_once_with(PART_ID, version="v9.0.0")
 
     def test_manager_value_error_returns_400(self, app_client, mock_provision_mgr):
         mock_provision_mgr.view_existing_pcf.side_effect = ValueError("Not found")
@@ -158,6 +177,21 @@ class TestViewExistingPcf:
         resp = app_client.get(f"{BASE}/pcfs/{PART_ID}")
 
         assert resp.status_code == 500
+
+    def test_view_with_v7_version(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.view_existing_pcf.return_value = {"pcfData": PCF_DATA_BODY}
+
+        resp = app_client.get(f"{BASE}/pcfs/{PART_ID}?version=v7.0.0")
+
+        assert resp.status_code == 200
+        mock_provision_mgr.view_existing_pcf.assert_called_once_with(PART_ID, version="v7.0.0")
+
+    def test_view_with_invalid_version_returns_400(self, app_client, mock_provision_mgr):
+        resp = app_client.get(f"{BASE}/pcfs/{PART_ID}?version=v99.0.0")
+
+        assert resp.status_code == 400
+        assert "Unsupported PCF version" in resp.json().get("detail", "")
+        mock_provision_mgr.view_existing_pcf.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +210,7 @@ class TestUpdatePcfAndGetParticipants:
         resp = app_client.put(f"{BASE}/pcfs/{PART_ID}", json=PCF_DATA_BODY)
 
         assert resp.status_code == 200
-        mock_provision_mgr.update_pcf_and_get_participants.assert_called_once_with(PART_ID, PCF_DATA_BODY)
+        mock_provision_mgr.update_pcf_and_get_participants.assert_called_once_with(PART_ID, PCF_DATA_BODY, version="v9.0.0")
 
     def test_manager_value_error_returns_400(self, app_client, mock_provision_mgr):
         mock_provision_mgr.update_pcf_and_get_participants.side_effect = ValueError("No existing PCF")
@@ -258,7 +292,7 @@ class TestListProviderNotifications:
 
         assert resp.status_code == 200
         mock_provision_mgr.list_provider_notifications.assert_called_once_with(
-            status=None, offset=0, limit=100
+            status=None, version=None, offset=0, limit=100
         )
 
     def test_filters_by_status_query_param(self, app_client, mock_provision_mgr):
@@ -268,8 +302,25 @@ class TestListProviderNotifications:
 
         assert resp.status_code == 200
         mock_provision_mgr.list_provider_notifications.assert_called_once_with(
-            status=PcfExchangeStatus.PENDING, offset=5, limit=10
+            status=PcfExchangeStatus.PENDING, version=None, offset=5, limit=10
         )
+
+    def test_filters_by_version_query_param(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.list_provider_notifications.return_value = []
+
+        resp = app_client.get(f"{BASE}/requests?version=v7.0.0")
+
+        assert resp.status_code == 200
+        mock_provision_mgr.list_provider_notifications.assert_called_once_with(
+            status=None, version="v7.0.0", offset=0, limit=100
+        )
+
+    def test_list_with_invalid_version_returns_400(self, app_client, mock_provision_mgr):
+        resp = app_client.get(f"{BASE}/requests?version=v99.0.0")
+
+        assert resp.status_code == 400
+        assert "Unsupported PCF version" in resp.json().get("detail", "")
+        mock_provision_mgr.list_provider_notifications.assert_not_called()
 
     def test_manager_value_error_returns_400(self, app_client, mock_provision_mgr):
         mock_provision_mgr.list_provider_notifications.side_effect = ValueError("Bad status value")

--- a/ichub-backend/tests/controllers/pcf_kit/test_provision.py
+++ b/ichub-backend/tests/controllers/pcf_kit/test_provision.py
@@ -45,6 +45,7 @@ from unittest.mock import MagicMock
 
 from models.metadata_database.pcf.models import PcfExchangeStatus
 from models.services.addons.pcf_kit.v1.models import PcfExchangeModel
+from tools.exceptions import PcfVersionGateError
 
 # ---------------------------------------------------------------------------
 # URL constants
@@ -226,6 +227,16 @@ class TestUpdatePcfAndGetParticipants:
 
         assert resp.status_code == 500
 
+    def test_version_gate_error_returns_409(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.update_pcf_and_get_participants.side_effect = PcfVersionGateError(
+            "Both PCF versions must be uploaded"
+        )
+
+        resp = app_client.put(f"{BASE}/pcfs/{PART_ID}", json=PCF_DATA_BODY)
+
+        assert resp.status_code == 409
+        assert "Both PCF versions" in resp.json().get("detail", "")
+
 
 # ---------------------------------------------------------------------------
 # POST /pcfs/{manufacturerPartId}/notify-update
@@ -274,6 +285,16 @@ class TestConfirmAndSendUpdateToParticipants:
         resp = app_client.post(f"{BASE}/pcfs/{PART_ID}/notify-update", json=NOTIFY_UPDATE_BODY)
 
         assert resp.status_code == 500
+
+    def test_version_gate_error_returns_409(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.confirm_and_send_update_to_participants.side_effect = PcfVersionGateError(
+            "Both PCF versions must be uploaded"
+        )
+
+        resp = app_client.post(f"{BASE}/pcfs/{PART_ID}/notify-update", json=NOTIFY_UPDATE_BODY)
+
+        assert resp.status_code == 409
+        assert "Both PCF versions" in resp.json().get("detail", "")
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +405,16 @@ class TestAcceptRequestAndSendResponse:
         resp = app_client.post(f"{BASE}/requests/{REQUEST_ID}/accept")
 
         assert resp.status_code == 500
+
+    def test_version_gate_error_returns_409(self, app_client, mock_provision_mgr):
+        mock_provision_mgr.accept_request_and_send_response.side_effect = PcfVersionGateError(
+            "Both PCF versions must be uploaded"
+        )
+
+        resp = app_client.post(f"{BASE}/requests/{REQUEST_ID}/accept")
+
+        assert resp.status_code == 409
+        assert "Both PCF versions" in resp.json().get("detail", "")
 
 
 # ---------------------------------------------------------------------------

--- a/ichub-backend/tests/services/provider/test_twin_management_service.py
+++ b/ichub-backend/tests/services/provider/test_twin_management_service.py
@@ -52,7 +52,6 @@ mock_modules = [
     'managers.config.config_manager',
     'managers.config.log_manager',
     'managers.metadata_database.manager',
-    'tools.exceptions',
     'database',
     'connector',
 ]

--- a/ichub-backend/tools/exceptions.py
+++ b/ichub-backend/tools/exceptions.py
@@ -88,6 +88,17 @@ class AlreadyExistsError(BaseError):
     def __init__(self, message: str):
         super().__init__(status_code=409, message=message)
 
+class PcfVersionGateError(BaseError):
+    """
+    Exception raised when a PCF operation is blocked because not all required
+    schema versions have been uploaded for the manufacturer part.
+
+    Returns HTTP 409 Conflict: the request conflicts with the current state
+    of the resource (missing PCF version uploads).
+    """
+    def __init__(self, message: str):
+        super().__init__(status_code=409, message=message)
+
 class ValidationError(BaseError):
     """
     Exception raised when validation fails.

--- a/ichub-backend/utils/pcf_utils.py
+++ b/ichub-backend/utils/pcf_utils.py
@@ -23,19 +23,95 @@
 
 """Shared utilities for PCF Kit operations."""
 
+from typing import Set
 from uuid import UUID, NAMESPACE_URL, uuid5
 
-# PCF semantic ID constant (Catena-X PCF aspect model v9.0.0 - async exchange use case)
-PCF_SEMANTIC_ID = "urn:samm:io.catenax.pcf:9.0.0#PcfExchangeAsync"
+# Supported PCF schema versions
+SUPPORTED_PCF_VERSIONS: Set[str] = {"v7.0.0", "v9.0.0"}
+
+# Default PCF version used when no version is specified (backward compatible)
+DEFAULT_PCF_VERSION: str = "v9.0.0"
+
+# Mapping from version string to the PCF aspect model semantic ID
+PCF_SEMANTIC_IDS: dict[str, str] = {
+    "v7.0.0": "urn:samm:io.catenax.pcf:7.0.0#Pcf",
+    "v9.0.0": "urn:samm:io.catenax.pcf:9.0.0#Pcf",
+}
+
+# Mapping from version string to the PCF async exchange semantic ID
+PCF_EXCHANGE_SEMANTIC_IDS: dict[str, str] = {
+    "v7.0.0": "urn:samm:io.catenax.pcf:7.0.0#PcfExchangeAsync",
+    "v9.0.0": "urn:samm:io.catenax.pcf:9.0.0#PcfExchangeAsync",
+}
+
+# Legacy constant kept for backward compatibility — prefer get_pcf_semantic_id()
+PCF_SEMANTIC_ID = PCF_EXCHANGE_SEMANTIC_IDS[DEFAULT_PCF_VERSION]
 
 # Asset type used to identify PCF exchange assets in EDC catalogs (CX-0136)
 PCF_EXCHANGE_ASSET_TYPE = "https://w3id.org/catenax/taxonomy#PcfExchange"
 
 
-def pcf_submodel_id(manufacturer_part_id: str) -> UUID:
-    """Derive a deterministic UUID for a manufacturer part ID.
+def validate_pcf_version(version: str) -> None:
+    """Raise ``ValueError`` if *version* is not a supported PCF version.
 
-    Uses UUID5 with NAMESPACE_URL so the same part always maps to the
-    same submodel document in the submodel service.
+    Args:
+        version: Version string to validate (e.g. ``"v7.0.0"``).
+
+    Raises:
+        ValueError: When *version* is not in :data:`SUPPORTED_PCF_VERSIONS`.
     """
-    return uuid5(NAMESPACE_URL, manufacturer_part_id)
+    if version not in SUPPORTED_PCF_VERSIONS:
+        raise ValueError(
+            f"Unsupported PCF version '{version}'. "
+            f"Supported versions: {sorted(SUPPORTED_PCF_VERSIONS)}"
+        )
+
+
+def get_pcf_semantic_id(version: str) -> str:
+    """Return the PCF aspect model semantic ID for the given version.
+
+    Args:
+        version: PCF version string (e.g. ``"v7.0.0"`` or ``"v9.0.0"``).
+
+    Returns:
+        The SAMM semantic ID for the PCF aspect model.
+
+    Raises:
+        ValueError: When *version* is not supported.
+    """
+    validate_pcf_version(version)
+    return PCF_SEMANTIC_IDS[version]
+
+
+def get_pcf_exchange_semantic_id(version: str) -> str:
+    """Return the PCF async-exchange semantic ID for the given version.
+
+    Args:
+        version: PCF version string (e.g. ``"v7.0.0"`` or ``"v9.0.0"``).
+
+    Returns:
+        The SAMM semantic ID for the async exchange use case.
+
+    Raises:
+        ValueError: When *version* is not supported.
+    """
+    validate_pcf_version(version)
+    return PCF_EXCHANGE_SEMANTIC_IDS[version]
+
+
+def pcf_submodel_id(manufacturer_part_id: str, version: str = DEFAULT_PCF_VERSION) -> UUID:
+    """Derive a deterministic UUID for a manufacturer part ID and version.
+
+    Uses UUID5 with NAMESPACE_URL so the same (part, version) pair always
+    maps to the same submodel document in the submodel service.
+    Including the version in the seed prevents v7 and v9 data for the
+    same part from colliding.
+
+    Args:
+        manufacturer_part_id: The manufacturer part identifier.
+        version: PCF schema version (default: ``"v9.0.0"``).
+
+    Returns:
+        Deterministic UUID5 for the (part, version) combination.
+    """
+    return uuid5(NAMESPACE_URL, f"{manufacturer_part_id}:{version}")

--- a/ichub-backend/utils/pcf_utils.py
+++ b/ichub-backend/utils/pcf_utils.py
@@ -48,7 +48,14 @@ PCF_EXCHANGE_SEMANTIC_IDS: dict[str, str] = {
 PCF_SEMANTIC_ID = PCF_EXCHANGE_SEMANTIC_IDS[DEFAULT_PCF_VERSION]
 
 # Asset type used to identify PCF exchange assets in EDC catalogs (CX-0136)
-PCF_EXCHANGE_ASSET_TYPE = "https://w3id.org/catenax/taxonomy#PcfExchange"
+PCF_EXCHANGE_ASSET_TYPE = "https://w3id.org/catenax/taxonomy#PCFExchange"
+
+# CX-0136 §2.1.2.5 / §4.2.2.1 mandated idShort values for PCF submodel descriptors
+PCF_ID_SHORT_SYNC = "SynchronousPCFExchangeEndpoint"
+PCF_ID_SHORT_ASYNC = "PCFExchangeEndpoint"
+
+# All semantic IDs that belong to PCF aspect models (sync + async, all versions)
+_PCF_SEMANTIC_ID_VALUES: set[str] = set(PCF_SEMANTIC_IDS.values()) | set(PCF_EXCHANGE_SEMANTIC_IDS.values())
 
 
 def validate_pcf_version(version: str) -> None:
@@ -115,3 +122,28 @@ def pcf_submodel_id(manufacturer_part_id: str, version: str = DEFAULT_PCF_VERSIO
         Deterministic UUID5 for the (part, version) combination.
     """
     return uuid5(NAMESPACE_URL, f"{manufacturer_part_id}:{version}")
+
+
+def get_pcf_submodel_overrides(semantic_id: str) -> dict[str, str] | None:
+    """Return ``id_short_override`` and ``interface`` for PCF submodel descriptors.
+
+    If *semantic_id* belongs to a PCF aspect model the function returns the
+    CX-0136 mandated values; otherwise ``None`` (= use defaults).
+
+    * Synchronous PCF models (``#Pcf``) → ``SynchronousPCFExchangeEndpoint``, ``SUBMODEL-3.0``
+    * Asynchronous PCF models (``#PcfExchangeAsync``) → ``PCFExchangeEndpoint``, ``PCF-1.1``
+
+    Args:
+        semantic_id: Full SAMM URN of the aspect model.
+
+    Returns:
+        ``dict`` with keys ``id_short_override`` and ``interface``, or ``None``.
+    """
+    if semantic_id not in _PCF_SEMANTIC_ID_VALUES:
+        return None
+
+    is_async = semantic_id in PCF_EXCHANGE_SEMANTIC_IDS.values()
+    return {
+        "id_short_override": PCF_ID_SHORT_ASYNC if is_async else PCF_ID_SHORT_SYNC,
+        "interface": "PCF-1.1" if is_async else "SUBMODEL-3.0",
+    }


### PR DESCRIPTION
## WHAT

This pull request introduces support for handling multiple PCF (Product Carbon Footprint) schema versions and backward compatibility for the PCF Exchange API. It adds new configuration options to enforce the presence of both PCF v7.0.0 and v9.0.0 for manufacturer parts, introduces legacy endpoints for v1.1.1 shape (`/productIds`), and ensures that API endpoints and configuration files are version-aware. The changes improve flexibility and compatibility for PCF data exchange and provisioning.

## WHY

To be able to fullfil the PCF use case standard.

Closes #618
