### PR TITLE
[Frontend] Allow user to see the CONSUMER STATUS of the shared certificates

### DIFF
--- a/ichub-frontend/src/features/ccm-kit/provision-management/pages/ProvisionManagement.tsx
+++ b/ichub-frontend/src/features/ccm-kit/provision-management/pages/ProvisionManagement.tsx
@@ -139,6 +139,19 @@ const inboundStatusSx = (status: InboundRequestStatus) => {
   }
 };
 
+const consumerStatusSx = (status?: string | null) => {
+  switch (status) {
+    case 'ACCEPTED':
+      return { backgroundColor: 'rgba(76,175,80,0.15)', color: '#81c784', border: '1px solid rgba(76,175,80,0.3)' };
+    case 'RECEIVED':
+      return { backgroundColor: 'rgba(157,111,212,0.15)', color: '#B399D3', border: '1px solid rgba(157,111,212,0.3)' };
+    case 'REJECTED':
+      return { backgroundColor: 'rgba(244,67,54,0.15)', color: '#e57373', border: '1px solid rgba(244,67,54,0.3)' };
+    default:
+      return { backgroundColor: 'rgba(255,255,255,0.08)', color: 'rgba(255,255,255,0.6)', border: '1px solid rgba(255,255,255,0.15)' };
+  }
+};
+
 const shareStatusSx = (status: ShareStatus) => {
   switch (status) {
     case 'Active':
@@ -511,9 +524,15 @@ const ProvisionManagement = () => {
                             <Chip label={req.status} size="small" sx={{ fontWeight: 600, fontSize: '0.7rem', ...inboundStatusSx(req.status) }} />
                           </CcmBodyCell>
                           <CcmBodyCell>
-                            <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.6)' }}>
-                              {req.consumerStatus ?? '—'}
-                            </Typography>
+                            {req.consumerStatus ? (
+                              <Chip
+                                label={req.consumerStatus}
+                                size="small"
+                                sx={{ fontWeight: 600, fontSize: '0.7rem', ...consumerStatusSx(req.consumerStatus) }}
+                              />
+                            ) : (
+                              <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.4)' }}>—</Typography>
+                            )}
                           </CcmBodyCell>
                           <CcmBodyCell>
                             <RelativeDate value={req.updatedAt} />
@@ -570,6 +589,7 @@ const ProvisionManagement = () => {
                         t('provisionPage.sharesColumns.type'),
                         t('provisionPage.sharesColumns.consumer'),
                         t('provisionPage.sharesColumns.status'),
+                        t('provisionPage.sharesColumns.consumerStatus'),
                         t('provisionPage.sharesColumns.lastShared'),
                       ]).map((h) => (
                         <CcmHeaderCell key={h}>{h}</CcmHeaderCell>
@@ -600,6 +620,17 @@ const ProvisionManagement = () => {
                               </Tooltip>
                             )}
                           </Box>
+                        </CcmBodyCell>
+                        <CcmBodyCell>
+                          {share.consumerStatus ? (
+                            <Chip
+                              label={share.consumerStatus}
+                              size="small"
+                              sx={{ fontWeight: 600, fontSize: '0.7rem', ...consumerStatusSx(share.consumerStatus) }}
+                            />
+                          ) : (
+                            <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.4)' }}>—</Typography>
+                          )}
                         </CcmBodyCell>
                         <CcmBodyCell>
                           <RelativeDate value={share.lastSharedDate} />

--- a/ichub-frontend/src/i18n/locales/de/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/de/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "Typ",
       "consumer": "Verbraucher",
       "status": "Status",
+      "consumerStatus": "Verbraucherstatus",
       "lastShared": "Zuletzt geteilt"
     },
     "locations": "{{count}} Standort(e)",

--- a/ichub-frontend/src/i18n/locales/en/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/en/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "Type",
       "consumer": "Consumer",
       "status": "Status",
+      "consumerStatus": "Consumer Status",
       "lastShared": "Last Shared"
     },
     "locations": "{{count}} site(s)",

--- a/ichub-frontend/src/i18n/locales/es/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/es/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "Tipo",
       "consumer": "Consumidor",
       "status": "Estado",
+      "consumerStatus": "Estado del Consumidor",
       "lastShared": "Última Compartición"
     },
     "locations": "{{count}} sitio(s)",

--- a/ichub-frontend/src/i18n/locales/fr/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/fr/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "Type",
       "consumer": "Consommateur",
       "status": "Statut",
+      "consumerStatus": "Statut consommateur",
       "lastShared": "Dernier partage"
     },
     "locations": "{{count}} site(s)",

--- a/ichub-frontend/src/i18n/locales/ja/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/ja/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "種別",
       "consumer": "コンシューマー",
       "status": "ステータス",
+      "consumerStatus": "コンシューマーステータス",
       "lastShared": "最終共有日"
     },
     "locations": "{{count}}サイト",

--- a/ichub-frontend/src/i18n/locales/pt/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/pt/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "Tipo",
       "consumer": "Consumidor",
       "status": "Estado",
+      "consumerStatus": "Estado do Consumidor",
       "lastShared": "Última Partilha"
     },
     "locations": "{{count}} instalação(ões)",

--- a/ichub-frontend/src/i18n/locales/zh/certificateManagement.json
+++ b/ichub-frontend/src/i18n/locales/zh/certificateManagement.json
@@ -524,6 +524,7 @@
       "type": "类型",
       "consumer": "消费者",
       "status": "状态",
+      "consumerStatus": "消费者状态",
       "lastShared": "最后共享时间"
     },
     "locations": "{{count}} 个站点",


### PR DESCRIPTION
## WHAT

Added a new Consumer Status column to both the Inbound Requests and Shares dashboard tables. This column displays the real-time lifecycle status of a certificate based on the explicit validation feedback sent back by the data consumer, mapping the standard states: RECEIVED, ACCEPTED, and REJECTED.

## WHY

This change is necessary to provide full end-to-end traceability and visibility of the certificate exchange process directly within the user interface. It ensures compliance with the ecosystem's audit requirements, allowing data providers to immediately verify if a consumer has successfully acknowledged, validated, or rejected a shared certificate without relying on backend log inspections.

## FURTHER NOTES

Wait until #586 was merged.